### PR TITLE
fix: enum sensors unavailable in Enhanced Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
 - German translations for all new state values.
 - Delta 2 Max enum sensors: charge/discharge state, EMS charge state, MPPT charge state, and charger type now show translated labels.
 
+### Fixed
+- Enum sensors showing "unavailable" in Enhanced Mode due to proto3 zero-value omission. Fields like grid_status=0 were silently dropped by MessageToDict; EMS change reports now default missing enum fields to their zero-value label. (beta.2)
+
 ### Changed
 - Enum sensors use HA `device_class: enum` with `options` for proper state handling and translation support.
 - **Breaking:** Automations using raw numeric state values (e.g. `state == "1"`) for these sensors must update to the new string values (e.g. `state == "charging"`). All affected sensors are diagnostic and disabled by default.

--- a/custom_components/ecoflow_energy/coordinator.py
+++ b/custom_components/ecoflow_energy/coordinator.py
@@ -908,15 +908,16 @@ class EcoFlowDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     }
                     return flatten_heartbeat(raw)
                 # Enhanced Mode: change reports and battery heartbeat
-                if result.mapped.get("_is_ems_change") or result.mapped.get("_is_bp_heartbeat"):
+                is_ems_change = bool(result.mapped.get("_is_ems_change"))
+                if is_ems_change or result.mapped.get("_is_bp_heartbeat"):
                     raw = {
                         k: v
                         for k, v in result.mapped.items()
                         if not k.startswith("_")
                     }
-                    if not raw:
+                    if not raw and not is_ems_change:
                         return None
-                    return remap_bp_keys(raw, self._bp_sn_to_index, self.device_sn)
+                    return remap_bp_keys(raw, self._bp_sn_to_index, self.device_sn, is_ems_change=is_ems_change)
                 # Non-PowerOcean protobuf: SmartPlug heartbeats
                 return self._parse_proto_device_data(payload)
             except Exception:

--- a/custom_components/ecoflow_energy/ecoflow/parsers/powerocean_proto.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/powerocean_proto.py
@@ -233,6 +233,7 @@ def remap_bp_keys(
     raw: dict[str, Any],
     bp_sn_to_index: dict[str, int],
     device_sn: str,
+    is_ems_change: bool = False,
 ) -> dict[str, Any]:
     """Remap battery heartbeat (cmd_id=7) and EMS change (cmd_id=8) keys to sensor keys.
 
@@ -240,6 +241,8 @@ def remap_bp_keys(
         raw: Raw protobuf-decoded dict (mutated: all_packs is popped).
         bp_sn_to_index: Mutable SN-to-pack-index mapping (updated in place).
         device_sn: Device serial number for debug logging.
+        is_ems_change: True for EMS change reports (cmd_id=8), enables
+            proto3 zero-value defaults for enum fields.
     """
     result: dict[str, Any] = {}
 
@@ -303,16 +306,23 @@ def remap_bp_keys(
             else:
                 result[sensor_key] = float(value) if isinstance(value, (int, float)) else value
 
-    # Apply enum mappings to remapped sensor keys
+    # Apply enum mappings to remapped sensor keys.
+    # Proto3 zero-value omission: MessageToDict omits fields with value 0,
+    # so enum fields like grid_status=0 are missing from result.
+    # For EMS change reports, default to 0 (proto3 default) when absent.
     for sensor_key, mapping in _PROTO_ENUM_INT.items():
         if sensor_key in result:
             iv = int(result[sensor_key]) if isinstance(result[sensor_key], (int, float)) else None
             if iv is not None and iv in mapping:
                 result[sensor_key] = mapping[iv]
+        elif is_ems_change and 0 in mapping:
+            result[sensor_key] = mapping[0]
     for sensor_key in _CONNECTIVITY_KEYS:
         if sensor_key in result:
             iv = int(result[sensor_key]) if isinstance(result[sensor_key], (int, float)) else 0
             result[sensor_key] = "disconnected" if iv == 0 else "connected"
+        elif is_ems_change:
+            result[sensor_key] = "disconnected"
     for sensor_key, mapping in _PROTO_ENUM_STR.items():
         if sensor_key in result:
             raw_val = str(result[sensor_key])


### PR DESCRIPTION
## Summary
- Proto3 `MessageToDict` silently omits fields with value 0
- Enum fields like `grid_status=0` (disconnected) were missing from parsed data
- Sensors showed "Nicht verfuegbar" (unavailable) instead of "Disconnected"
- EMS change reports now default missing enum fields to their zero-value label

## Test plan
- [ ] Enum sensors show labels (not "unavailable") after restart in Enhanced Mode
- [ ] Grid status shows "Disconnected" or "Connected" (not blank)
- [ ] 778 tests pass

Ref #24