### PR TITLE
fix: battery state debounce with hold time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Battery charge/discharge state showing inverted values: "discharging" while charging and vice versa. The EMS field reports the controller mode, not the physical state. State is now derived from actual battery power: charging when charge power > 50W, discharging when discharge power > 50W, standby otherwise. (beta.9)
 - Added diagnostic logging for battery state derivation to help debug device-specific sign convention differences. Logs raw power values on each state transition at DEBUG level. (beta.10)
 - Battery state flipping rapidly between charging/discharging/standby when solar production is close to house load. Raised power threshold from 50W to 200W to filter inverter balancing currents, and added hysteresis requiring two consecutive identical derivations before changing state. (beta.11)
+- Battery state still flickering at sunrise/sunset when power oscillates around the 200W threshold. Added two-layer debounce: 3 consecutive confirmations (~9s) plus 60-second minimum hold time before state transitions. (beta.13)
 
 ### Changed
 - Entity display names follow a consistent naming convention: suffix qualifiers (max./min./real), no internal abbreviations (EMS/PCS/MPPT), app-aligned names where possible. Entity IDs unchanged - automations and dashboards are not affected. (beta.12)

--- a/custom_components/ecoflow_energy/coordinator.py
+++ b/custom_components/ecoflow_energy/coordinator.py
@@ -176,9 +176,13 @@ class EcoFlowDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # physical pack always maps to the same pack{n}_* sensor keys.
         self._bp_sn_to_index: dict[str, int] = {}
         # Hysteresis for battery charge/discharge state (#50).
-        # Require 2 consecutive identical derivations before changing state.
+        # Two-layer debounce to prevent flicker:
+        #   1. Confirmation: new state must be derived 3 consecutive times (~9s)
+        #   2. Hold time: current state must have been active for >= 60s
+        # Both conditions must be met before a state transition occurs.
         self._batt_state_candidate: str | None = None
         self._batt_state_confirm_count: int = 0
+        self._batt_state_changed_at: float = 0.0  # monotonic timestamp
 
         # Energy integrator for power → kWh Riemann sum (all device types)
         state_path = hass.config.path(f".storage/ecoflow_energy_{self.device_sn}.json")
@@ -1025,8 +1029,10 @@ class EcoFlowDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # mode". Override with the measured power when available.
         # Threshold 200W filters inverter balancing currents that cause rapid
         # state flipping when solar production ~ house load.
-        # Hysteresis: new state must be derived twice consecutively (~6-10s)
-        # before it replaces the current state.
+        # Two-layer debounce:
+        #   1. New state must be derived 3 consecutive times (~9s at 3s heartbeat)
+        #   2. Current state must have been held for >= 60s
+        # This prevents flicker when power oscillates around the threshold.
         charge_w = self._device_data.get("batt_charge_power_w")
         discharge_w = self._device_data.get("batt_discharge_power_w")
         if charge_w is not None and discharge_w is not None:
@@ -1044,19 +1050,27 @@ class EcoFlowDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 else:
                     self._batt_state_candidate = derived
                     self._batt_state_confirm_count = 1
-                if self._batt_state_confirm_count >= 2:
+                now_mono = time.monotonic()
+                hold_elapsed = now_mono - self._batt_state_changed_at
+                min_hold_s = 60
+                if self._batt_state_confirm_count >= 3 and (
+                    prev is None or hold_elapsed >= min_hold_s
+                ):
                     self._device_data["batt_charge_discharge_state"] = derived
                     self._batt_state_candidate = None
                     self._batt_state_confirm_count = 0
+                    self._batt_state_changed_at = now_mono
                     batt_w_raw = self._device_data.get("batt_w")
                     _LOGGER.debug(
-                        "Battery state for %s: batt_w=%.1f charge_w=%.1f discharge_w=%.1f -> %s (was %s)",
+                        "Battery state for %s: batt_w=%.1f charge_w=%.1f "
+                        "discharge_w=%.1f -> %s (was %s, held %.0fs)",
                         self.device_sn,
                         batt_w_raw if batt_w_raw is not None else 0.0,
                         charge_w,
                         discharge_w,
                         derived,
                         prev,
+                        hold_elapsed,
                     )
             else:
                 # State confirmed - reset candidate

--- a/tests/ha/test_coordinator.py
+++ b/tests/ha/test_coordinator.py
@@ -1312,8 +1312,11 @@ class TestApplyData:
         coordinator = EcoFlowDeviceCoordinator(
             hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
         )
-        # Hysteresis: need 2 consecutive derivations to change state
+        # Hysteresis: need 3 consecutive derivations to change state
+        # (no hold time required when prev is None)
         coordinator._apply_data({"batt_charge_power_w": 910, "batt_discharge_power_w": 0})
+        coordinator._apply_data({"batt_charge_power_w": 910, "batt_discharge_power_w": 0})
+        assert coordinator.device_data.get("batt_charge_discharge_state") is None
         coordinator._apply_data({"batt_charge_power_w": 910, "batt_discharge_power_w": 0})
         assert coordinator.device_data["batt_charge_discharge_state"] == "charging"
 
@@ -1329,6 +1332,7 @@ class TestApplyData:
         )
         coordinator._apply_data({"batt_charge_power_w": 0, "batt_discharge_power_w": 1500})
         coordinator._apply_data({"batt_charge_power_w": 0, "batt_discharge_power_w": 1500})
+        coordinator._apply_data({"batt_charge_power_w": 0, "batt_discharge_power_w": 1500})
         assert coordinator.device_data["batt_charge_discharge_state"] == "discharging"
 
     async def test_apply_data_derives_battery_state_standby(
@@ -1342,11 +1346,15 @@ class TestApplyData:
             hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
         )
         # EMS sends "discharge mode" but battery is idle at 100% SOC
-        # Hysteresis: need 2 consecutive derivations to change state
+        # Hysteresis: need 3 consecutive derivations to change state
         coordinator._apply_data({
             "batt_charge_power_w": 0,
             "batt_discharge_power_w": 0,
             "batt_charge_discharge_state": "discharging",
+        })
+        coordinator._apply_data({
+            "batt_charge_power_w": 0,
+            "batt_discharge_power_w": 0,
         })
         coordinator._apply_data({
             "batt_charge_power_w": 0,
@@ -1359,21 +1367,61 @@ class TestApplyData:
         hass: HomeAssistant,
         enhanced_config_entry: MockConfigEntry,
     ) -> None:
-        """Single transient spike should not change state (hysteresis)."""
+        """Transient spikes should not change state (hysteresis + hold time)."""
         enhanced_config_entry.add_to_hass(hass)
         coordinator = EcoFlowDeviceCoordinator(
             hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
         )
-        # Establish discharging state
-        coordinator._apply_data({"batt_charge_power_w": 0, "batt_discharge_power_w": 1000})
-        coordinator._apply_data({"batt_charge_power_w": 0, "batt_discharge_power_w": 1000})
+        # Establish discharging state (prev=None, no hold time needed)
+        for _ in range(3):
+            coordinator._apply_data({"batt_charge_power_w": 0, "batt_discharge_power_w": 1000})
         assert coordinator.device_data["batt_charge_discharge_state"] == "discharging"
-        # Single spike to charging - should NOT change state
-        coordinator._apply_data({"batt_charge_power_w": 300, "batt_discharge_power_w": 0})
+
+        # 3 consecutive charging spikes within hold time - should NOT change state
+        for _ in range(3):
+            coordinator._apply_data({"batt_charge_power_w": 300, "batt_discharge_power_w": 0})
         assert coordinator.device_data["batt_charge_discharge_state"] == "discharging"
-        # Back to discharging - resets candidate
-        coordinator._apply_data({"batt_charge_power_w": 0, "batt_discharge_power_w": 800})
+
+        # Even more spikes - still blocked by hold time
+        for _ in range(5):
+            coordinator._apply_data({"batt_charge_power_w": 500, "batt_discharge_power_w": 0})
         assert coordinator.device_data["batt_charge_discharge_state"] == "discharging"
+
+        # After hold time expires, 3 consecutive derivations should change state
+        coordinator._batt_state_changed_at = time.monotonic() - 61
+        coordinator._batt_state_candidate = None
+        coordinator._batt_state_confirm_count = 0
+        for _ in range(3):
+            coordinator._apply_data({"batt_charge_power_w": 500, "batt_discharge_power_w": 0})
+        assert coordinator.device_data["batt_charge_discharge_state"] == "charging"
+
+    async def test_apply_data_battery_state_hold_time_prevents_oscillation(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """Oscillating power around threshold should not cause state flicker."""
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        # Establish standby
+        for _ in range(3):
+            coordinator._apply_data({"batt_charge_power_w": 50, "batt_discharge_power_w": 0})
+        assert coordinator.device_data["batt_charge_discharge_state"] == "standby"
+
+        # Simulate oscillation: 250W, 150W, 250W, 150W (around 200W threshold)
+        # Even with 3 consecutive 250W readings, hold time blocks the change
+        oscillating = [
+            {"batt_charge_power_w": 250, "batt_discharge_power_w": 0},
+            {"batt_charge_power_w": 150, "batt_discharge_power_w": 0},
+            {"batt_charge_power_w": 250, "batt_discharge_power_w": 0},
+            {"batt_charge_power_w": 250, "batt_discharge_power_w": 0},
+            {"batt_charge_power_w": 250, "batt_discharge_power_w": 0},
+        ]
+        for data in oscillating:
+            coordinator._apply_data(data)
+        assert coordinator.device_data["batt_charge_discharge_state"] == "standby"
 
     async def test_apply_data_battery_state_below_threshold_is_standby(
         self,
@@ -1386,6 +1434,7 @@ class TestApplyData:
             hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
         )
         # 150W charge power is below 200W threshold - should be standby
+        coordinator._apply_data({"batt_charge_power_w": 150, "batt_discharge_power_w": 0})
         coordinator._apply_data({"batt_charge_power_w": 150, "batt_discharge_power_w": 0})
         coordinator._apply_data({"batt_charge_power_w": 150, "batt_discharge_power_w": 0})
         assert coordinator.device_data["batt_charge_discharge_state"] == "standby"


### PR DESCRIPTION
## Summary
- Two-layer debounce for battery charge/discharge state to prevent flicker
- New state must be derived 3 consecutive times (~9s) AND current state must have been held for >= 60s
- Prevents rapid state flipping when battery power oscillates around the 200W threshold at sunrise/sunset

## Test plan
- [x] 818 unit tests passing (6 battery state tests, including 2 new)
- [ ] Docker Desktop HA verification (skipped, deploying as beta)
- [ ] Beta validation on prod

Ref #50