### PR TITLE
fix: disambiguate Backup Reserve sensor name with EMS suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Entity display names follow a consistent naming convention: suffix qualifiers (max./min./real), no internal abbreviations (EMS/PCS/MPPT), app-aligned names where possible. Entity IDs unchanged - automations and dashboards are not affected. (beta.12)
+- Renamed "Backup Reserve" sensor to "Backup Reserve (EMS)" to distinguish it from the controllable backup reserve settings. (beta.14)
 
 ### Changed
 - Enum sensors use HA `device_class: enum` with `options` for proper state handling and translation support.

--- a/custom_components/ecoflow_energy/strings.json
+++ b/custom_components/ecoflow_energy/strings.json
@@ -1063,7 +1063,7 @@
         "name": "Discharge Lower Limit"
       },
       "ems_keep_soc_pct": {
-        "name": "Backup Reserve"
+        "name": "Backup Reserve (EMS)"
       },
       "ems_backup_ratio_pct": {
         "name": "Backup Ratio"

--- a/custom_components/ecoflow_energy/translations/de.json
+++ b/custom_components/ecoflow_energy/translations/de.json
@@ -1063,7 +1063,7 @@
         "name": "Entladeuntergrenze"
       },
       "ems_keep_soc_pct": {
-        "name": "Batterie-Backup-Reserve"
+        "name": "Backup-Reserve (EMS)"
       },
       "ems_backup_ratio_pct": {
         "name": "Backup-Anteil"

--- a/custom_components/ecoflow_energy/translations/en.json
+++ b/custom_components/ecoflow_energy/translations/en.json
@@ -1063,7 +1063,7 @@
         "name": "Discharge Lower Limit"
       },
       "ems_keep_soc_pct": {
-        "name": "Backup Reserve"
+        "name": "Backup Reserve (EMS)"
       },
       "ems_backup_ratio_pct": {
         "name": "Backup Ratio"


### PR DESCRIPTION
## Summary
- Renamed `ems_keep_soc_pct` display name from "Backup Reserve" to "Backup Reserve (EMS)" to distinguish it from the controllable backup reserve settings
- DE translation: "Backup-Reserve (EMS)"
- Entity IDs unchanged

## Test plan
- [x] 818 tests pass
- [ ] Verify name in HA UI after HACS update + hard reload

Ref #24