### PR TITLE
fix: prevent EMS raw field from overwriting derived battery state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - Added diagnostic logging for battery state derivation to help debug device-specific sign convention differences. Logs raw power values on each state transition at DEBUG level. (beta.10)
 - Battery state flipping rapidly between charging/discharging/standby when solar production is close to house load. Raised power threshold from 50W to 200W to filter inverter balancing currents, and added hysteresis requiring two consecutive identical derivations before changing state. (beta.11)
 - Battery state still flickering at sunrise/sunset when power oscillates around the 200W threshold. Added two-layer debounce: 3 consecutive confirmations (~9s) plus 60-second minimum hold time before state transitions. (beta.13)
+- Battery state still flipping ~250 times/day despite debounce. Root cause: the EMS raw field bp_chg_dsg_sta (which reports controller mode, not physical state) overwrote the power-derived state on every EMS report and HTTP poll, bypassing the debounce entirely. The raw EMS value is now stripped before it reaches device data. (beta.15)
 
 ### Changed
 - Entity display names follow a consistent naming convention: suffix qualifiers (max./min./real), no internal abbreviations (EMS/PCS/MPPT), app-aligned names where possible. Entity IDs unchanged - automations and dashboards are not affected. (beta.12)

--- a/custom_components/ecoflow_energy/coordinator.py
+++ b/custom_components/ecoflow_energy/coordinator.py
@@ -1010,6 +1010,12 @@ class EcoFlowDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._last_mqtt_event_ts = now
             self._log_event("mqtt_data", f"keys={len(parsed)}")
         self._enforce_monotonic(parsed)
+        # Remove EMS raw battery state before update: bp_chg_dsg_sta reports the
+        # controller MODE ("discharging" even at 0W/100% SoC), not the physical
+        # state. The derivation below sets the correct value from actual power.
+        # Without this, the parser overwrites the derived state on every EMS
+        # report, causing ~250 false transitions/day (#50).
+        parsed.pop("batt_charge_discharge_state", None)
         self._device_data.update(parsed)
 
         # Re-aggregate bp_remain_watth from accumulated device_data (#10).
@@ -1024,58 +1030,7 @@ class EcoFlowDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
 
         # Derive battery charge/discharge state from actual power (#50).
-        # The EMS field bp_chg_dsg_sta reports the controller MODE, not the
-        # physical state: at 100% SOC with 0W flow, it still sends "discharge
-        # mode". Override with the measured power when available.
-        # Threshold 200W filters inverter balancing currents that cause rapid
-        # state flipping when solar production ~ house load.
-        # Two-layer debounce:
-        #   1. New state must be derived 3 consecutive times (~9s at 3s heartbeat)
-        #   2. Current state must have been held for >= 60s
-        # This prevents flicker when power oscillates around the threshold.
-        charge_w = self._device_data.get("batt_charge_power_w")
-        discharge_w = self._device_data.get("batt_discharge_power_w")
-        if charge_w is not None and discharge_w is not None:
-            threshold = 200
-            if charge_w > threshold:
-                derived = "charging"
-            elif discharge_w > threshold:
-                derived = "discharging"
-            else:
-                derived = "standby"
-            prev = self._device_data.get("batt_charge_discharge_state")
-            if derived != prev:
-                if derived == self._batt_state_candidate:
-                    self._batt_state_confirm_count += 1
-                else:
-                    self._batt_state_candidate = derived
-                    self._batt_state_confirm_count = 1
-                now_mono = time.monotonic()
-                hold_elapsed = now_mono - self._batt_state_changed_at
-                min_hold_s = 60
-                if self._batt_state_confirm_count >= 3 and (
-                    prev is None or hold_elapsed >= min_hold_s
-                ):
-                    self._device_data["batt_charge_discharge_state"] = derived
-                    self._batt_state_candidate = None
-                    self._batt_state_confirm_count = 0
-                    self._batt_state_changed_at = now_mono
-                    batt_w_raw = self._device_data.get("batt_w")
-                    _LOGGER.debug(
-                        "Battery state for %s: batt_w=%.1f charge_w=%.1f "
-                        "discharge_w=%.1f -> %s (was %s, held %.0fs)",
-                        self.device_sn,
-                        batt_w_raw if batt_w_raw is not None else 0.0,
-                        charge_w,
-                        discharge_w,
-                        derived,
-                        prev,
-                        hold_elapsed,
-                    )
-            else:
-                # State confirmed - reset candidate
-                self._batt_state_candidate = None
-                self._batt_state_confirm_count = 0
+        self._derive_battery_state()
 
         # Integrate power → energy via Riemann sum
         self._integrate_energy(parsed)
@@ -1095,6 +1050,59 @@ class EcoFlowDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _async_flush_energy_state(self) -> None:
         """Flush energy integrator state to disk (non-blocking)."""
         await self.hass.async_add_executor_job(self._energy_integrator.flush)
+
+    def _derive_battery_state(self) -> None:
+        """Derive battery charge/discharge state from actual power (#50).
+
+        The EMS field bp_chg_dsg_sta reports the controller MODE, not the
+        physical state: at 100% SoC with 0W flow, it still sends "discharging".
+        We override it using measured power values with a two-layer debounce:
+          1. New state must be derived 3 consecutive times (~9s at 3s heartbeat)
+          2. Current state must have been held for >= 60s
+        """
+        charge_w = self._device_data.get("batt_charge_power_w")
+        discharge_w = self._device_data.get("batt_discharge_power_w")
+        if charge_w is None or discharge_w is None:
+            return
+        threshold = 200
+        if charge_w > threshold:
+            derived = "charging"
+        elif discharge_w > threshold:
+            derived = "discharging"
+        else:
+            derived = "standby"
+        prev = self._device_data.get("batt_charge_discharge_state")
+        if derived != prev:
+            if derived == self._batt_state_candidate:
+                self._batt_state_confirm_count += 1
+            else:
+                self._batt_state_candidate = derived
+                self._batt_state_confirm_count = 1
+            now_mono = time.monotonic()
+            hold_elapsed = now_mono - self._batt_state_changed_at
+            min_hold_s = 60
+            if self._batt_state_confirm_count >= 3 and (
+                prev is None or hold_elapsed >= min_hold_s
+            ):
+                self._device_data["batt_charge_discharge_state"] = derived
+                self._batt_state_candidate = None
+                self._batt_state_confirm_count = 0
+                self._batt_state_changed_at = now_mono
+                batt_w_raw = self._device_data.get("batt_w")
+                _LOGGER.debug(
+                    "Battery state for %s: batt_w=%.1f charge_w=%.1f "
+                    "discharge_w=%.1f -> %s (was %s, held %.0fs)",
+                    self.device_sn,
+                    batt_w_raw if batt_w_raw is not None else 0.0,
+                    charge_w,
+                    discharge_w,
+                    derived,
+                    prev,
+                    hold_elapsed,
+                )
+        else:
+            self._batt_state_candidate = None
+            self._batt_state_confirm_count = 0
 
     # ------------------------------------------------------------------
     # SET commands (switches, numbers)
@@ -1245,7 +1253,13 @@ class EcoFlowDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         else:
             parsed = raw
         self._enforce_monotonic(parsed)
+        # Same pop as in _apply_data: prevent EMS raw battery state from
+        # overwriting the power-derived value (#50).
+        parsed.pop("batt_charge_discharge_state", None)
         self._device_data.update(parsed)
+
+        # Derive battery state from power (same logic as MQTT path, #50)
+        self._derive_battery_state()
 
         # Riemann sum: integrate power → energy
         self._integrate_energy(parsed)

--- a/tests/ha/test_coordinator.py
+++ b/tests/ha/test_coordinator.py
@@ -1439,6 +1439,54 @@ class TestApplyData:
         coordinator._apply_data({"batt_charge_power_w": 150, "batt_discharge_power_w": 0})
         assert coordinator.device_data["batt_charge_discharge_state"] == "standby"
 
+    async def test_apply_data_ems_raw_state_does_not_overwrite_derived(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """EMS bp_chg_dsg_sta must not overwrite the power-derived state (#50).
+
+        The EMS reports controller MODE ("discharging" at 0W/100% SoC).
+        Without the pop fix, each EMS report overwrites the derived "standby",
+        causing ~250 false transitions/day.
+        """
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        # Establish standby (prev=None, no hold time needed)
+        for _ in range(3):
+            coordinator._apply_data({"batt_charge_power_w": 0, "batt_discharge_power_w": 0})
+        assert coordinator.device_data["batt_charge_discharge_state"] == "standby"
+
+        # Simulate EMS change report with "discharging" mode at 0W
+        # (the exact scenario causing 15-minute night flips)
+        coordinator._batt_state_changed_at = time.monotonic() - 900
+        for _ in range(5):
+            coordinator._apply_data({
+                "batt_charge_power_w": 0,
+                "batt_discharge_power_w": 0,
+                "batt_charge_discharge_state": "discharging",
+            })
+        # Must remain standby - EMS raw value must not leak through
+        assert coordinator.device_data["batt_charge_discharge_state"] == "standby"
+
+    async def test_apply_data_ems_raw_state_stripped_from_device_data(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """The EMS raw field must not appear in device_data before power data arrives."""
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        # Send only EMS state, no power data
+        coordinator._apply_data({"batt_charge_discharge_state": "discharging"})
+        # Without power data, derivation doesn't run, and the raw EMS value
+        # should have been popped - so no state is set
+        assert coordinator.device_data.get("batt_charge_discharge_state") is None
+
 
 # ===========================================================================
 # Protobuf Key Remapping (_remap_proto_keys) — F-001


### PR DESCRIPTION
## Summary
- Strip EMS raw `batt_charge_discharge_state` from parsed data before `_device_data.update()` in both MQTT and HTTP paths
- Extract battery state derivation into `_derive_battery_state()` method, called from both data paths
- 2 new tests verifying the EMS raw value cannot overwrite the derived state

## Root cause
The EMS field `bp_chg_dsg_sta` reports the controller MODE ("discharging" even at 0W/100% SoC), not the physical state. The parser mapped this to `batt_charge_discharge_state`, which `_device_data.update(parsed)` wrote before the power-based derivation ran. The derivation saw a "changed" prev value on every EMS report and flipped it back, bypassing the debounce entirely. Result: ~250 false transitions/day instead of stable standby.

## Test plan
- [x] 820 tests pass (818 existing + 2 new)
- [ ] Deploy to Docker Desktop HA, verify battery state stability over 24h
- [ ] Verify on prod Pi after beta release

Ref #50