### PR TITLE
chore: add minimum HA version to hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
   "name": "EcoFlow Energy",
-  "render_readme": true
+  "render_readme": true,
+  "homeassistant": "2025.1.0"
 }


### PR DESCRIPTION
Adds `homeassistant` minimum version field (2025.1.0) to hacs.json. Required by HACS reviewers - all recently accepted integrations include this field.