### PR TITLE
chore: remove local-only entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,10 +65,6 @@ homeassistant/
 # Scripts (local tools, not for remote)
 scripts/
 
-# MCP / RAG (local only, not for remote)
-.mcp.json
-.venv-qdrant-mcp/
-
 # Secrets (never)
 *.env
 .secrets


### PR DESCRIPTION
## Summary
- Removes 4 lines from .gitignore covering local-only tooling artefacts
- The same paths are already tracked in .git/info/exclude (local-only, never pushed)
- Keeps the public .gitignore focused on build output and secrets

## Test plan
- [x] .git/info/exclude already covers these paths
- [ ] CI green
- [ ] main still ignores these paths locally