### PR TITLE
chore: cap pytest-homeassistant-custom-component below Python 3.14 floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
       minor-and-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    ignore:
+      # pytest-homeassistant-custom-component >=0.13.317 requires Python 3.14.
+      # Our CI runs Python 3.13. Re-evaluate when CI is upgraded to 3.14.
+      - dependency-name: "pytest-homeassistant-custom-component"
+        versions: [">=0.13.317"]
 
   # GitHub Actions versions
   - package-ecosystem: "github-actions"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,4 @@
 # Test framework
-pytest-homeassistant-custom-component>=0.13.0
+# Floor pinned to 0.13.316 because >=0.13.317 requires Python 3.14 (CI uses 3.13).
+# See .github/dependabot.yml ignore rule.
+pytest-homeassistant-custom-component>=0.13.316


### PR DESCRIPTION
## Summary
- pytest-HA versions >=0.13.317 require Python 3.14; our CI runs 3.13
- Dependabot was opening PRs that always failed CI (e.g. #72) with "No matching distribution found"
- Pin floor to 0.13.316 in requirements_test.txt and add a Dependabot ignore rule

## Changes
- `.github/dependabot.yml` — ignore `pytest-homeassistant-custom-component` versions `>=0.13.317`
- `requirements_test.txt` — bump floor from `>=0.13.0` to `>=0.13.316` with explanatory comment

## Test plan
- [x] CI passes on this branch (tests + HACS validation + Hassfest)
- [x] Dependabot will no longer file PRs that target Python 3.14-only versions

Closes the loop on #72 (separate close after this merges).

Ref #72