### PR TITLE
feat: PowerOcean energy management controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.13.0] - 2026-05-06
+
+### Added
+- PowerOcean controls verified against live app traffic. The 3-field `SysBatChgDsgSet` payload (cmd_id=112) replicates the official EcoFlow app byte-for-byte, ensuring writes are accepted reliably. (beta.1)
+  - `number.backup_reserve` - emergency reserve SoC (0-100%, step 5). Maps to the "Backup-Reserve" slider in the EcoFlow app.
+  - `number.solar_surplus_threshold` - SoC threshold above which surplus solar is routed to controllable devices (0-100%, step 5). Maps to "Überschüssige Solarenergie" in the app.
+  - `select.work_mode` - operational strategy. Phase 1 supports Self-use ("Eigenstromversorgung") and AI Schedule ("Intelligenter Modus"). TOU and Backup require additional sub-parameters and are deferred.
+
+### Fixed
+- Enum sensors no longer crash with `ValueError: state value not in options` when the device emits a previously-unseen enum value. Unknown values are now dropped (sensor stays unavailable until a known value arrives) rather than being passed through as raw integers. Affects `ems_work_mode`, `ems_work_state`, `pcs_run_state`, and other enum fields. (beta.1)
+
+### Removed
+- `number.min_discharge_soc` (legacy) - sent only 2 of the 3 fields the device requires, causing writes to be silently ignored. Use the new `number.backup_reserve` instead. The wire field and read sensor are unchanged; only the entity name and range (was 0-30%, now 0-100%) differ. (beta.1)
+
+### Migration
+- After upgrade, the old `number.ecoflow_powerocean_min_entladezustand` (DE) / `min_discharge_soc` (EN) entity will appear as "unavailable" in HA. It is safe to delete via Settings → Devices & Services → EcoFlow Energy → ⋮ → Delete on the entity. Any automation referencing it should be updated to use `number.ecoflow_powerocean_backup_reserve` instead.
+
 ## [1.12.0] - 2026-04-22
 
 ### Added

--- a/custom_components/ecoflow_energy/const.py
+++ b/custom_components/ecoflow_energy/const.py
@@ -21,6 +21,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.SWITCH,
     Platform.NUMBER,
+    Platform.SELECT,
 ]
 
 # Config entry keys
@@ -147,6 +148,17 @@ class EcoFlowNumberDef:
     min_value: float = 0
     max_value: float = 100
     step: float = 1
+    enhanced_only: bool = False
+
+
+@dataclass(frozen=True)
+class EcoFlowSelectDef:
+    """Select entity definition - maps a state value to user-facing options."""
+    key: str
+    name: str
+    state_key: str
+    options: tuple[str, ...]
+    icon: str | None = None
     enhanced_only: bool = False
 
 
@@ -302,7 +314,26 @@ POWEROCEAN_BINARY_SENSORS: list[EcoFlowBinarySensorDef] = [
 ]
 
 POWEROCEAN_NUMBERS: list[EcoFlowNumberDef] = [
-    EcoFlowNumberDef("min_discharge_soc", "Min Discharge SoC", "ems_discharge_lower_limit_pct", "%", "mdi:battery-alert-variant-outline", 0, 30, 5, enhanced_only=True),
+    # Backup-Reserve (App-slider): minimum SoC kept in reserve. Wire field 2
+    # in cmd_id=112 SysBatChgDsgSet, sent as a 3-field app-replay payload.
+    EcoFlowNumberDef("backup_reserve", "Backup Reserve", "ems_discharge_lower_limit_pct", "%", "mdi:battery-lock", 0, 100, 5, enhanced_only=True),
+    # Überschüssige-Solarenergie threshold (App-slider): SoC above which
+    # surplus solar is routed to controllable devices. Wire field 4.
+    EcoFlowNumberDef("solar_surplus_threshold", "Solar Surplus Threshold", "ems_backup_ratio_pct", "%", "mdi:solar-power-variant", 0, 100, 5, enhanced_only=True),
+]
+
+
+POWEROCEAN_SELECTS: list[EcoFlowSelectDef] = [
+    # Work mode select. Phase 1 scope: SELFUSE (0) and AI_SCHEDULE (12),
+    # which are the modes that work without TouParam/BackupParam sub-data.
+    EcoFlowSelectDef(
+        "work_mode",
+        "Work Mode",
+        "ems_work_mode",
+        ("self_use", "ai_schedule"),
+        icon="mdi:cog-transfer",
+        enhanced_only=True,
+    ),
 ]
 
 

--- a/custom_components/ecoflow_energy/coordinator.py
+++ b/custom_components/ecoflow_energy/coordinator.py
@@ -1168,6 +1168,82 @@ class EcoFlowDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._log_event("set_soc_limits_fail", f"max={max_charge_soc}, min={min_discharge_soc}")
         return ok
 
+    async def async_set_powerocean_soc(
+        self, backup_reserve_pct: int, solar_surplus_pct: int,
+    ) -> bool:
+        """Send a 3-field SoC SET to PowerOcean (app-replay format).
+
+        Wire: cmd_id=112 SysBatChgDsgSet with field 1=100, field 2=backup,
+        field 4=solar_surplus, plus extended envelope (check_type, from=ios,
+        device_sn). Verified 2026-05-06 against the official EcoFlow app
+        traffic. The legacy `async_set_soc_limits` only sends fields 1+2
+        and is silently ignored by the device for backup-reserve changes.
+        """
+        if not self._enhanced_mode:
+            _LOGGER.warning("PowerOcean SoC SET requires Enhanced Mode (%s)", self.device_sn)
+            return False
+        if self._mqtt_client is None or not self._mqtt_client.is_connected():
+            _LOGGER.warning("Cannot send PowerOcean SoC - MQTT not connected (%s)", self.device_sn)
+            return False
+        if backup_reserve_pct > solar_surplus_pct:
+            _LOGGER.warning(
+                "PowerOcean SoC SET rejected locally: backup_reserve (%d) > "
+                "solar_surplus (%d). Device requires backup <= solar.",
+                backup_reserve_pct, solar_surplus_pct,
+            )
+            return False
+
+        from .ecoflow.energy_stream import build_powerocean_soc_set_payload
+
+        payload = build_powerocean_soc_set_payload(
+            backup_reserve_pct,
+            solar_surplus_pct,
+            device_sn=self.device_sn,
+        )
+        ok = await self.hass.async_add_executor_job(
+            self._mqtt_client.send_proto_set, payload,
+        )
+        label = f"backup={backup_reserve_pct} solar={solar_surplus_pct}"
+        if ok:
+            _LOGGER.debug("PowerOcean SoC sent: %s (%s)", label, self.device_sn)
+            self._log_event("set_powerocean_soc", label)
+        else:
+            _LOGGER.warning("PowerOcean SoC SET failed: %s (%s)", label, self.device_sn)
+            self._log_event("set_powerocean_soc_fail", label)
+        return ok
+
+    async def async_set_powerocean_work_mode(self, work_mode: int) -> bool:
+        """Send SysWorkModeSet (cmd_id=98) for PowerOcean.
+
+        Phase 1 supports only modes that work without sub-params:
+        SELFUSE (0) and AI_SCHEDULE (12). TOU (1) and BACKUP (2) require
+        TouParam/BackupParam and return result=1 if sent without them.
+        """
+        if not self._enhanced_mode:
+            _LOGGER.warning(
+                "Work-mode SET requires Enhanced Mode (%s)", self.device_sn,
+            )
+            return False
+        if self._mqtt_client is None or not self._mqtt_client.is_connected():
+            _LOGGER.warning(
+                "Cannot send work-mode - MQTT not connected (%s)", self.device_sn,
+            )
+            return False
+
+        from .ecoflow.energy_stream import build_work_mode_set_payload
+
+        payload = build_work_mode_set_payload(work_mode)
+        ok = await self.hass.async_add_executor_job(
+            self._mqtt_client.send_proto_set, payload,
+        )
+        if ok:
+            _LOGGER.debug("Work-mode sent: %d (%s)", work_mode, self.device_sn)
+            self._log_event("set_work_mode", str(work_mode))
+        else:
+            _LOGGER.warning("Work-mode SET failed: %d (%s)", work_mode, self.device_sn)
+            self._log_event("set_work_mode_fail", str(work_mode))
+        return ok
+
     async def async_send_proto_set_command(
         self, payload: bytes, label: str,
     ) -> bool:

--- a/custom_components/ecoflow_energy/ecoflow/energy_stream.py
+++ b/custom_components/ecoflow_energy/ecoflow/energy_stream.py
@@ -50,6 +50,61 @@ def build_energy_stream_activate_payload(seq: int = 0) -> bytes:
     return encode_field_bytes(1, bytes(header))
 
 
+def build_powerocean_soc_set_payload(
+    backup_reserve_pct: int,
+    solar_surplus_pct: int,
+    seq: int = 0,
+    device_sn: str = "",
+) -> bytes:
+    """Build SysBatChgDsgSet (cmd_id=112) replicating the EcoFlow app frame.
+
+    The app sends THREE fields in the inner pdata for every SoC-limit
+    change (verified 2026-05-06 against live app traffic):
+
+        field 1 = max_charge_soc       (always 100 in observed app traffic)
+        field 2 = backup_reserve_pct   (the "Backup-Reserve" slider)
+        field 4 = solar_surplus_pct    (the "Überschüssige Solarenergie" slider)
+
+    The older 2-field builder (`build_soc_limit_set_payload`) sent only
+    fields 1+2, which the device sometimes silently ignored. Using the
+    full 3-field payload plus the extended app envelope (check_type,
+    from="ios", device_sn) is accepted reliably.
+
+    Constraint enforced by the device UI: backup_reserve_pct <= solar_surplus_pct.
+    Sending values that violate this constraint can be rejected with
+    SetAck result=1.
+
+    Args:
+        backup_reserve_pct: 0..100, the Backup-Reserve floor SoC.
+        solar_surplus_pct: 0..100, the Überschüssige-Solarenergie threshold.
+        seq: Sequence number. Default 0 generates from timestamp.
+        device_sn: Device serial number for envelope field 25.
+
+    Returns:
+        Binary protobuf payload (Send_Header_Msg).
+    """
+    if not 0 <= backup_reserve_pct <= 100:
+        raise ValueError(
+            f"backup_reserve_pct must be 0..100, got {backup_reserve_pct}"
+        )
+    if not 0 <= solar_surplus_pct <= 100:
+        raise ValueError(
+            f"solar_surplus_pct must be 0..100, got {solar_surplus_pct}"
+        )
+    if backup_reserve_pct > solar_surplus_pct:
+        raise ValueError(
+            f"backup_reserve_pct ({backup_reserve_pct}) must be <= "
+            f"solar_surplus_pct ({solar_surplus_pct})"
+        )
+
+    pdata = (
+        encode_field_varint(1, 100)                       # max_charge_soc, constant
+        + encode_field_varint(2, backup_reserve_pct)      # backup reserve floor
+        + encode_field_varint(4, solar_surplus_pct)       # solar surplus threshold
+    )
+    return _build_powerocean_set_envelope(pdata, cmd_id=112, seq=seq, device_sn=device_sn)
+
+
 def build_soc_limit_set_payload(
     max_charge_soc: int,
     min_discharge_soc: int,
@@ -108,6 +163,196 @@ def build_soc_limit_set_payload(
 
     # Send_Header_Msg: field 1 = Header (length-delimited)
     return encode_field_bytes(1, bytes(header))
+
+
+def _build_powerocean_set_envelope(
+    pdata: bytes,
+    cmd_id: int,
+    seq: int = 0,
+    device_sn: str = "",
+) -> bytes:
+    """Build the PowerOcean SET envelope around a pre-encoded inner pdata.
+
+    Common header for all `cmd_func=96` SET commands. Replicates the byte
+    layout the official EcoFlow Android/iOS app uses on
+    `/app/{userId}/{sn}/thing/property/set`.
+
+    Sniffed app-frame fields (verified 2026-05-06 against live app traffic):
+      1  pdata (length-delimited)
+      2  src = 32
+      3  dest = 96
+      4  d_src = 1
+      5  d_dest = 1
+      7  check_type = 3                  (NEW: app sends this)
+      8  cmd_func = 96
+      9  cmd_id
+      10 data_len
+      11 need_ack = 1
+      14 seq
+      16 payload_ver = 3 (was: is_rw_cmd)
+      17 is_queue = 1
+      23 from = "ios"                    (NEW: client identifier)
+      25 device_sn = SN                  (NEW: target device)
+
+    The earlier short envelope (without 7/23/25) worked for some commands
+    but not for SoC-limit changes. The full envelope replicates the app
+    payload byte-for-byte and is accepted reliably.
+
+    Args:
+        pdata: Pre-encoded inner protobuf payload bytes.
+        cmd_id: Command ID (98, 99, 112, 115, ...).
+        seq: Sequence number. Default 0 generates from timestamp.
+        device_sn: Device serial number. If empty, the SN field is omitted
+            (same as the older short envelope).
+    """
+    if seq == 0:
+        seq = int(time.time() * 1000) & 0x7FFFFFFF
+
+    header = bytearray()
+    header.extend(encode_field_bytes(1, pdata))                  # pdata
+    header.extend(encode_field_varint(2, 32))                    # src
+    header.extend(encode_field_varint(3, 96))                    # dest
+    header.extend(encode_field_varint(4, 1))                     # d_src
+    header.extend(encode_field_varint(5, 1))                     # d_dest
+    header.extend(encode_field_varint(7, 3))                     # check_type
+    header.extend(encode_field_varint(8, 96))                    # cmd_func
+    header.extend(encode_field_varint(9, cmd_id))                # cmd_id
+    header.extend(encode_field_varint(10, len(pdata)))           # data_len
+    header.extend(encode_field_varint(11, 1))                    # need_ack
+    header.extend(encode_field_varint(14, seq))                  # seq
+    header.extend(encode_field_varint(16, 3))                    # payload_ver
+    header.extend(encode_field_varint(17, 1))                    # is_queue
+    header.extend(encode_field_bytes(23, b"ios"))                # from
+    if device_sn:
+        header.extend(encode_field_bytes(25, device_sn.encode("ascii")))
+
+    return encode_field_bytes(1, bytes(header))
+
+
+def build_work_mode_set_payload(work_mode: int, seq: int = 0) -> bytes:
+    """Build SysWorkModeSet (cmd_id=98) for PowerOcean work mode selection.
+
+    Sends only field 1 (`ems_word_mode` enum varint). The proto defines
+    additional oneof fields for TouParam / BackupParam but those are
+    out of scope - the EcoFlow app sends field 1 alone for plain mode
+    switches.
+
+    WorkMode enum (verified against `_WORK_MODE_MAP` in parsers/powerocean.py):
+        0 = SELFUSE, 1 = TOU, 2 = BACKUP, 3 = DBG, 4 = AC_MAKEUP,
+        5 = DRM, 6 = REMOTE_SCHED, 7 = STANDBY, 8 = SOC_CALIB,
+        9 = TIMER, 10 = FCR, 11 = THIRD_PARTY, 12 = AI_SCHEDULE, 13 = KRAKEN
+
+    User-exposed subset (HA select): SELFUSE, TOU, BACKUP, AI_SCHEDULE.
+
+    Args:
+        work_mode: WorkMode enum value (0-13).
+        seq: Sequence number. Default 0 generates from timestamp.
+    """
+    if not 0 <= work_mode <= 13:
+        raise ValueError(f"work_mode must be 0-13, got {work_mode}")
+
+    pdata = encode_field_varint(1, work_mode)
+    return _build_powerocean_set_envelope(pdata, cmd_id=98, seq=seq)
+
+
+def build_feed_mode_set_payload(feed_mode: int, seq: int = 0) -> bytes:
+    """Build SysFeedPowerSet (cmd_id=115) with field 2 only - mode selector.
+
+    Field 2 (`ems_feed_mode` uint32) is the discrete mode enum. Field 1
+    (`ems_max_feed_pwr` float) is in the same oneof and skipped here -
+    field 2 is the canonical path the official app uses.
+
+    Feed mode enum (verified against `_FEED_MODE_MAP` in parsers/powerocean.py):
+        0 = off (feed disabled)
+        1 = no_limit (feed everything available)
+        2 = zero (zero-feed, RegEnergie 0% compliance)
+        3 = limit (limited by `ems_feed_pwr` set separately)
+
+    Args:
+        feed_mode: Feed mode enum (0-3).
+        seq: Sequence number. Default 0 generates from timestamp.
+    """
+    if not 0 <= feed_mode <= 3:
+        raise ValueError(f"feed_mode must be 0-3, got {feed_mode}")
+
+    pdata = encode_field_varint(2, feed_mode)
+    return _build_powerocean_set_envelope(pdata, cmd_id=115, seq=seq)
+
+
+def build_feed_power_set_payload(feed_power_w: int, seq: int = 0) -> bytes:
+    """Build SysFeedPowerSet (cmd_id=115) with field 4 only - power cap.
+
+    Field 4 (`ems_feed_pwr` uint32, watts) sets the absolute feed-in cap.
+    Only effective when feed_mode is 3 (limit). Sending this alone does
+    not change the mode - that requires `build_feed_mode_set_payload`.
+
+    Args:
+        feed_power_w: Feed power cap in watts (0-10000 typical).
+        seq: Sequence number. Default 0 generates from timestamp.
+    """
+    if not 0 <= feed_power_w <= 100000:
+        raise ValueError(f"feed_power_w must be 0-100000, got {feed_power_w}")
+
+    pdata = encode_field_varint(4, feed_power_w)
+    return _build_powerocean_set_envelope(pdata, cmd_id=115, seq=seq)
+
+
+def build_feed_mode_and_power_set_payload(
+    feed_mode: int, feed_power_w: int, seq: int = 0,
+) -> bytes:
+    """Build SysFeedPowerSet (cmd_id=115) with mode (field 2) AND power (field 4).
+
+    Combined SET for Mode=Limit (3) which requires a power cap to be set
+    in the same message. Field 1 (float) is skipped via the oneof rule -
+    only field 2 (uint32 mode) is set, plus field 4 (uint32 power-cap watts).
+
+    Args:
+        feed_mode: Feed mode enum (0-3).
+        feed_power_w: Feed power cap in watts (0-100000).
+        seq: Sequence number. Default 0 generates from timestamp.
+    """
+    if not 0 <= feed_mode <= 3:
+        raise ValueError(f"feed_mode must be 0-3, got {feed_mode}")
+    if not 0 <= feed_power_w <= 100000:
+        raise ValueError(f"feed_power_w must be 0-100000, got {feed_power_w}")
+
+    pdata = bytearray()
+    pdata.extend(encode_field_varint(2, feed_mode))     # field 2 = mode
+    pdata.extend(encode_field_varint(4, feed_power_w))  # field 4 = power cap
+    return _build_powerocean_set_envelope(bytes(pdata), cmd_id=115, seq=seq)
+
+
+def build_backup_event_set_payload(
+    enable: bool, start_ts: int, end_ts: int, seq: int = 0,
+) -> bytes:
+    """Build SysBackupEventSet (cmd_id=99) - storm-watch / backup window.
+
+    Triggers a pre-charge to 100% before the event window, then maintains
+    backup state through the window. Used by the EcoFlow app for the
+    "Storm Watch" / scheduled backup feature.
+
+    Fields:
+        2: ems_backup_enable_disenabl (bool) - enable=true, disable=false
+        3: ems_backup_start_time (uint32 unix ts)
+        4: ems_backup_end_time (uint32 unix ts)
+
+    Args:
+        enable: True to start/enable, False to cancel.
+        start_ts: Backup window start (unix epoch seconds).
+        end_ts: Backup window end (unix epoch seconds).
+        seq: Sequence number. Default 0 generates from timestamp.
+    """
+    if start_ts < 0 or end_ts < 0:
+        raise ValueError("timestamps must be non-negative")
+    if enable and start_ts >= end_ts:
+        raise ValueError(f"start_ts ({start_ts}) must be < end_ts ({end_ts})")
+
+    pdata = bytearray()
+    pdata.extend(encode_field_varint(2, 1 if enable else 0))   # bool as varint
+    pdata.extend(encode_field_varint(3, start_ts))
+    pdata.extend(encode_field_varint(4, end_ts))
+
+    return _build_powerocean_set_envelope(bytes(pdata), cmd_id=99, seq=seq)
 
 
 def build_device_get_all_payload(seq: int = 0) -> bytes:

--- a/custom_components/ecoflow_energy/ecoflow/parsers/powerocean_proto.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/powerocean_proto.py
@@ -57,18 +57,38 @@ _WIFI_ETH_KEYS: frozenset[str] = frozenset({"wifi_status", "ethernet_status"})
 
 
 def _apply_enum_mappings(result: dict[str, Any]) -> None:
-    """Apply all enum and connectivity mappings to sensor-keyed result dict in place."""
+    """Apply all enum and connectivity mappings to sensor-keyed result dict in place.
+
+    Unknown integer values (e.g. firmware adding new states) are dropped
+    rather than passed through, because HA's enum sensors raise
+    ``ValueError: state value 'N' not in options`` for any value not in
+    the declared options list.
+    """
     for sensor_key, mapping in _PROTO_ENUM_INT.items():
         if sensor_key in result:
             iv = int(result[sensor_key]) if isinstance(result[sensor_key], (int, float)) else None
             if iv is not None and iv in mapping:
                 result[sensor_key] = mapping[iv]
+            else:
+                # Drop unknown enum value - keeping the raw int crashes the
+                # HA sensor with "not in list of options".
+                _LOGGER.debug(
+                    "Unknown enum value for %s: %r (dropped)",
+                    sensor_key, result[sensor_key],
+                )
+                result.pop(sensor_key, None)
 
     for sensor_key, mapping in _WORK_STATE_ENUM_INT.items():
         if sensor_key in result:
             iv = int(result[sensor_key]) if isinstance(result[sensor_key], (int, float)) else None
             if iv is not None and iv in mapping:
                 result[sensor_key] = mapping[iv]
+            else:
+                _LOGGER.debug(
+                    "Unknown work-state value: %r (dropped)",
+                    result[sensor_key],
+                )
+                result.pop(sensor_key, None)
 
     for sensor_key in _CONNECTIVITY_KEYS:
         if sensor_key in result:

--- a/custom_components/ecoflow_energy/manifest.json
+++ b/custom_components/ecoflow_energy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/shuette42/ecoflow-energy-ha/issues",
   "requirements": ["paho-mqtt>=2.1.0", "protobuf>=4.21.0"],
-  "version": "1.12.0"
+  "version": "1.13.0"
 }

--- a/custom_components/ecoflow_energy/number.py
+++ b/custom_components/ecoflow_energy/number.py
@@ -193,8 +193,10 @@ class EcoFlowNumber(CoordinatorEntity[EcoFlowDeviceCoordinator], NumberEntity):
     async def _async_set_powerocean_value(self, value: float) -> None:
         """Set a PowerOcean number value via WSS Protobuf.
 
-        SysBatChgDsgSet sends both limits in one message.  The unchanged
-        limit is read from coordinator data so both are always consistent.
+        SysBatChgDsgSet (cmd_id=112) is sent as a 3-field app-replay
+        payload: field 1=100 constant, field 2=backup_reserve, field
+        4=solar_surplus. The unchanged value is read from coordinator
+        data so both slider positions stay consistent with the device.
         """
         key = self._definition.key
         int_value = int(value)
@@ -203,16 +205,26 @@ class EcoFlowNumber(CoordinatorEntity[EcoFlowDeviceCoordinator], NumberEntity):
             _LOGGER.warning("No data available yet for %s", self.coordinator.device_sn)
             return
 
-        if key == "min_discharge_soc":
-            max_soc = int(self.coordinator.data.get("ems_charge_upper_limit_pct", 100))
-            min_soc = int_value
-        else:
-            _LOGGER.warning("No PowerOcean SET handler for %s", key)
+        # New 3-field handlers (verified against official app traffic).
+        if key == "backup_reserve":
+            current_solar = int(self.coordinator.data.get("ems_backup_ratio_pct", 100))
+            backup = int_value
+            solar = max(current_solar, backup)  # enforce backup <= solar
+            ok = await self.coordinator.async_set_powerocean_soc(backup, solar)
+            if ok:
+                self._apply_optimistic_number(value)
             return
 
-        ok = await self.coordinator.async_set_soc_limits(max_soc, min_soc)
-        if ok:
-            self._apply_optimistic_number(value)
+        if key == "solar_surplus_threshold":
+            current_backup = int(self.coordinator.data.get("ems_discharge_lower_limit_pct", 0))
+            solar = int_value
+            backup = min(current_backup, solar)  # enforce backup <= solar
+            ok = await self.coordinator.async_set_powerocean_soc(backup, solar)
+            if ok:
+                self._apply_optimistic_number(value)
+            return
+
+        _LOGGER.warning("No PowerOcean SET handler for %s", key)
 
 
 def _get_number_defs(device_type: str) -> list[EcoFlowNumberDef]:

--- a/custom_components/ecoflow_energy/select.py
+++ b/custom_components/ecoflow_energy/select.py
@@ -1,0 +1,161 @@
+"""Select platform for EcoFlow Energy.
+
+Currently used for PowerOcean Work Mode selection (Self-use, AI Schedule).
+Implements the same optimistic-lock pattern as switch.py and number.py:
+after a SET, the local state is updated immediately and MQTT updates for
+the same key are ignored for 5 seconds.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import (
+    DEVICE_TYPE_POWEROCEAN,
+    DOMAIN,
+    EcoFlowSelectDef,
+    POWEROCEAN_SELECTS,
+)
+from .coordinator import EcoFlowDeviceCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+OPTIMISTIC_LOCK_S = 5.0
+
+# Maps the user-facing select option (state_key value) to the wire-level
+# work-mode integer that goes into SysWorkModeSet (cmd_id=98) field 1.
+# Verified 2026-05-06 against live device probe.
+WORK_MODE_TO_INT: dict[str, int] = {
+    "self_use": 0,
+    "ai_schedule": 12,
+    # Modes that need TouParam/BackupParam are intentionally out of scope:
+    # "time_of_use": 1, "backup": 2 - device returns SetAck result=1
+    # without the nested sub-params.
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up EcoFlow select entities from a config entry."""
+    coordinators: dict[str, EcoFlowDeviceCoordinator] = hass.data[DOMAIN][entry.entry_id]
+    entities: list[EcoFlowSelect] = []
+
+    for coordinator in coordinators.values():
+        defs = _get_select_defs(coordinator.device_type)
+        for defn in defs:
+            if defn.enhanced_only and not coordinator.enhanced_mode:
+                continue
+            entities.append(EcoFlowSelect(coordinator, defn))
+
+    async_add_entities(entities)
+
+
+class EcoFlowSelect(CoordinatorEntity[EcoFlowDeviceCoordinator], SelectEntity):
+    """An EcoFlow select entity with optimistic lock."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: EcoFlowDeviceCoordinator,
+        definition: EcoFlowSelectDef,
+    ) -> None:
+        """Initialize the select."""
+        super().__init__(coordinator)
+        self._definition = definition
+        self._attr_unique_id = f"{coordinator.device_sn}_{definition.key}"
+        self._attr_translation_key = definition.key
+        self._attr_icon = definition.icon
+        self._attr_options = list(definition.options)
+        self._optimistic_value: str | None = None
+        self._optimistic_lock_until: float = 0.0
+
+    @property
+    def available(self) -> bool:
+        """Return True if the coordinator is available."""
+        return self.coordinator.device_available and super().available
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return self.coordinator.device_info
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data, honoring the optimistic lock window."""
+        if time.monotonic() < self._optimistic_lock_until:
+            # Still within lock - ignore device-reported value
+            return
+        self._optimistic_value = None
+        super()._handle_coordinator_update()
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the currently selected option."""
+        if (
+            self._optimistic_value is not None
+            and time.monotonic() < self._optimistic_lock_until
+        ):
+            return self._optimistic_value
+        if self.coordinator.data is None:
+            return None
+        value = self.coordinator.data.get(self._definition.state_key)
+        if value is None:
+            return None
+        # Coordinator stores the human-readable enum label (e.g. "self_use").
+        # If it's not in our exposed options, return None so the UI shows
+        # an empty selection rather than an invalid one.
+        if value in self._definition.options:
+            return value
+        return None
+
+    async def async_select_option(self, option: str) -> None:
+        """Send a SET command to change the selected option."""
+        if option not in self._definition.options:
+            _LOGGER.warning(
+                "Select option %s not in allowed options %s for %s",
+                option, self._definition.options, self._definition.key,
+            )
+            return
+
+        if self._definition.key == "work_mode":
+            wire_value = WORK_MODE_TO_INT.get(option)
+            if wire_value is None:
+                _LOGGER.warning("No wire mapping for work-mode option %s", option)
+                return
+            if self.coordinator.device_type != DEVICE_TYPE_POWEROCEAN:
+                _LOGGER.warning("work_mode select only supports PowerOcean")
+                return
+            ok = await self.coordinator.async_set_powerocean_work_mode(wire_value)
+            if ok:
+                self._apply_optimistic_select(option)
+            return
+
+        _LOGGER.warning("No SET handler for select %s", self._definition.key)
+
+    def _apply_optimistic_select(self, option: str) -> None:
+        """Apply the optimistic lock so the UI reflects the change immediately."""
+        state_key = self._definition.state_key
+        self.coordinator.set_device_value(state_key, option)
+        if self.coordinator.data is not None:
+            self.coordinator.data[state_key] = option
+        self._optimistic_value = option
+        self._optimistic_lock_until = time.monotonic() + OPTIMISTIC_LOCK_S
+        self.async_write_ha_state()
+
+
+def _get_select_defs(device_type: str) -> list[EcoFlowSelectDef]:
+    """Return select definitions based on device type."""
+    if device_type == DEVICE_TYPE_POWEROCEAN:
+        return POWEROCEAN_SELECTS
+    return []

--- a/custom_components/ecoflow_energy/strings.json
+++ b/custom_components/ecoflow_energy/strings.json
@@ -1188,8 +1188,11 @@
       "max_charge_soc": {
         "name": "Max Charge SoC"
       },
-      "min_discharge_soc": {
-        "name": "Min Discharge SoC"
+      "backup_reserve": {
+        "name": "Backup Reserve"
+      },
+      "solar_surplus_threshold": {
+        "name": "Solar Surplus Threshold"
       },
       "standby_timeout": {
         "name": "Standby Timeout"
@@ -1211,6 +1214,15 @@
       },
       "max_watts": {
         "name": "Max Power Limit"
+      }
+    },
+    "select": {
+      "work_mode": {
+        "name": "Work Mode",
+        "state": {
+          "self_use": "Self-use",
+          "ai_schedule": "AI Schedule"
+        }
       }
     }
   }

--- a/custom_components/ecoflow_energy/translations/de.json
+++ b/custom_components/ecoflow_energy/translations/de.json
@@ -1188,8 +1188,11 @@
       "max_charge_soc": {
         "name": "Max. Ladezustand"
       },
-      "min_discharge_soc": {
-        "name": "Min. Entladezustand"
+      "backup_reserve": {
+        "name": "Backup-Reserve"
+      },
+      "solar_surplus_threshold": {
+        "name": "Solarüberschuss-Schwelle"
       },
       "standby_timeout": {
         "name": "Standby-Zeitlimit"
@@ -1211,6 +1214,15 @@
       },
       "max_watts": {
         "name": "Max. Leistungsgrenze"
+      }
+    },
+    "select": {
+      "work_mode": {
+        "name": "Betriebsmodus",
+        "state": {
+          "self_use": "Eigenstromversorgung",
+          "ai_schedule": "Intelligenter Modus"
+        }
       }
     }
   }

--- a/custom_components/ecoflow_energy/translations/en.json
+++ b/custom_components/ecoflow_energy/translations/en.json
@@ -1188,8 +1188,11 @@
       "max_charge_soc": {
         "name": "Max Charge SoC"
       },
-      "min_discharge_soc": {
-        "name": "Min Discharge SoC"
+      "backup_reserve": {
+        "name": "Backup Reserve"
+      },
+      "solar_surplus_threshold": {
+        "name": "Solar Surplus Threshold"
       },
       "standby_timeout": {
         "name": "Standby Timeout"
@@ -1211,6 +1214,15 @@
       },
       "max_watts": {
         "name": "Max Power Limit"
+      }
+    },
+    "select": {
+      "work_mode": {
+        "name": "Work Mode",
+        "state": {
+          "self_use": "Self-use",
+          "ai_schedule": "AI Schedule"
+        }
       }
     }
   }

--- a/tests/ha/test_powerocean_number.py
+++ b/tests/ha/test_powerocean_number.py
@@ -34,23 +34,30 @@ class TestGetNumberDefs:
     def test_powerocean_returns_powerocean_numbers(self):
         defs = _get_number_defs(DEVICE_TYPE_POWEROCEAN)
         assert defs is POWEROCEAN_NUMBERS
-        assert len(defs) == 1
+        assert len(defs) == 2
 
     def test_powerocean_number_keys(self):
         defs = _get_number_defs(DEVICE_TYPE_POWEROCEAN)
         keys = {d.key for d in defs}
-        assert keys == {"min_discharge_soc"}
+        assert keys == {"backup_reserve", "solar_surplus_threshold"}
 
     def test_powerocean_numbers_are_enhanced_only(self):
         defs = _get_number_defs(DEVICE_TYPE_POWEROCEAN)
         assert all(d.enhanced_only for d in defs)
 
-    def test_powerocean_min_discharge_soc_range(self):
+    def test_powerocean_backup_reserve_range(self):
         defs = _get_number_defs(DEVICE_TYPE_POWEROCEAN)
-        min_soc = next(d for d in defs if d.key == "min_discharge_soc")
-        assert min_soc.min_value == 0
-        assert min_soc.max_value == 30
-        assert min_soc.step == 5
+        br = next(d for d in defs if d.key == "backup_reserve")
+        assert br.min_value == 0
+        assert br.max_value == 100
+        assert br.step == 5
+
+    def test_powerocean_solar_surplus_range(self):
+        defs = _get_number_defs(DEVICE_TYPE_POWEROCEAN)
+        ss = next(d for d in defs if d.key == "solar_surplus_threshold")
+        assert ss.min_value == 0
+        assert ss.max_value == 100
+        assert ss.step == 5
 
 
 # ===========================================================================
@@ -139,11 +146,13 @@ class TestAsyncSetSocLimits:
 # ===========================================================================
 
 
-class TestPowerOceanNumberSet:
+class TestPowerOceanNumberBasic:
+    """Basic native_value and failure-mode tests using backup_reserve."""
+
     def _make_number_entity(
         self, hass, entry,
     ) -> tuple[EcoFlowNumber, EcoFlowDeviceCoordinator]:
-        """Create a PowerOcean min_discharge_soc entity with mocked coordinator."""
+        """Create a PowerOcean backup_reserve entity with mocked coordinator."""
         entry.add_to_hass(hass)
         coordinator = EcoFlowDeviceCoordinator(
             hass, entry, MOCK_POWEROCEAN_DEVICE,
@@ -152,30 +161,13 @@ class TestPowerOceanNumberSet:
         coordinator._device_data = {
             "ems_charge_upper_limit_pct": 100,
             "ems_discharge_lower_limit_pct": 0,
+            "ems_backup_ratio_pct": 100,
         }
         coordinator.async_set_updated_data(dict(coordinator._device_data))
 
-        defn = next(d for d in POWEROCEAN_NUMBERS if d.key == "min_discharge_soc")
+        defn = next(d for d in POWEROCEAN_NUMBERS if d.key == "backup_reserve")
         entity = EcoFlowNumber(coordinator, defn)
         return entity, coordinator
-
-    async def test_set_min_discharge_soc(
-        self,
-        hass: HomeAssistant,
-        enhanced_config_entry: MockConfigEntry,
-    ) -> None:
-        """Setting min_discharge_soc sends both limits with current max."""
-        entity, coordinator = self._make_number_entity(
-            hass, enhanced_config_entry,
-        )
-        coordinator.async_set_soc_limits = AsyncMock(return_value=True)
-        entity.async_write_ha_state = MagicMock()
-
-        await entity.async_set_native_value(10.0)
-
-        coordinator.async_set_soc_limits.assert_called_once_with(100, 10)
-        # Optimistic update persisted in device_data
-        assert coordinator._device_data["ems_discharge_lower_limit_pct"] == 10.0
 
     async def test_set_failed_no_optimistic_update(
         self,
@@ -186,11 +178,11 @@ class TestPowerOceanNumberSet:
         entity, coordinator = self._make_number_entity(
             hass, enhanced_config_entry,
         )
-        coordinator.async_set_soc_limits = AsyncMock(return_value=False)
+        coordinator.async_set_powerocean_soc = AsyncMock(return_value=False)
 
-        await entity.async_set_native_value(10.0)
+        await entity.async_set_native_value(50.0)
 
-        coordinator.async_set_soc_limits.assert_called_once_with(100, 10)
+        coordinator.async_set_powerocean_soc.assert_called_once_with(50, 100)
         # No optimistic update — original value retained
         assert coordinator.data["ems_discharge_lower_limit_pct"] == 0
 
@@ -216,3 +208,190 @@ class TestPowerOceanNumberSet:
         )
         coordinator.async_set_updated_data(None)
         assert entity.native_value is None
+
+
+# ===========================================================================
+# 3-field PowerOcean SoC SET (verified against live app traffic 2026-05-06)
+# ===========================================================================
+
+
+class TestAsyncSetPowerOceanSoc:
+    async def test_3field_set_success(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE,
+        )
+        mock_mqtt = MagicMock()
+        mock_mqtt.is_connected.return_value = True
+        mock_mqtt.send_proto_set.return_value = True
+        coordinator._mqtt_client = mock_mqtt
+
+        result = await coordinator.async_set_powerocean_soc(25, 80)
+
+        assert result is True
+        mock_mqtt.send_proto_set.assert_called_once()
+        payload = mock_mqtt.send_proto_set.call_args[0][0]
+        # Inner pdata contains 3 fields: 1=100, 2=25, 4=80
+        assert b"\x08\x64\x10\x19\x20\x50" in payload
+
+    async def test_3field_set_rejects_backup_above_solar(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE,
+        )
+        mock_mqtt = MagicMock()
+        mock_mqtt.is_connected.return_value = True
+        coordinator._mqtt_client = mock_mqtt
+
+        result = await coordinator.async_set_powerocean_soc(80, 25)
+        assert result is False
+        mock_mqtt.send_proto_set.assert_not_called()
+
+    async def test_3field_rejects_standard_mode(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        standard_config_entry.add_to_hass(hass)
+        from .conftest import MOCK_DELTA_DEVICE
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, standard_config_entry, MOCK_DELTA_DEVICE,
+        )
+        result = await coordinator.async_set_powerocean_soc(0, 100)
+        assert result is False
+
+
+class TestAsyncSetWorkMode:
+    async def test_work_mode_self_use(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE,
+        )
+        mock_mqtt = MagicMock()
+        mock_mqtt.is_connected.return_value = True
+        mock_mqtt.send_proto_set.return_value = True
+        coordinator._mqtt_client = mock_mqtt
+
+        result = await coordinator.async_set_powerocean_work_mode(0)
+
+        assert result is True
+        payload = mock_mqtt.send_proto_set.call_args[0][0]
+        # cmd_id=98 (0x62), inner field 1 = 0
+        assert b"\x48\x62" in payload  # cmd_id=98
+
+    async def test_work_mode_ai_schedule(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE,
+        )
+        mock_mqtt = MagicMock()
+        mock_mqtt.is_connected.return_value = True
+        mock_mqtt.send_proto_set.return_value = True
+        coordinator._mqtt_client = mock_mqtt
+
+        result = await coordinator.async_set_powerocean_work_mode(12)
+
+        assert result is True
+        payload = mock_mqtt.send_proto_set.call_args[0][0]
+        # cmd_id=98 (0x62), inner field 1 = 12 (0x0c)
+        assert b"\x08\x0c" in payload
+
+
+class TestPowerOceanNumberSet3Field:
+    def _make_entity(self, hass, entry, key: str):
+        entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, entry, MOCK_POWEROCEAN_DEVICE,
+        )
+        coordinator._device_data = {
+            "ems_charge_upper_limit_pct": 100,
+            "ems_discharge_lower_limit_pct": 30,
+            "ems_backup_ratio_pct": 80,
+        }
+        coordinator.async_set_updated_data(dict(coordinator._device_data))
+        defn = next(d for d in POWEROCEAN_NUMBERS if d.key == key)
+        entity = EcoFlowNumber(coordinator, defn)
+        return entity, coordinator
+
+    async def test_set_backup_reserve_holds_solar(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """Setting backup_reserve sends backup=value, solar=current_solar."""
+        entity, coordinator = self._make_entity(
+            hass, enhanced_config_entry, "backup_reserve",
+        )
+        coordinator.async_set_powerocean_soc = AsyncMock(return_value=True)
+        entity.async_write_ha_state = MagicMock()
+
+        await entity.async_set_native_value(50.0)
+
+        coordinator.async_set_powerocean_soc.assert_called_once_with(50, 80)
+
+    async def test_set_backup_reserve_clamps_solar_when_higher(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """If new backup > current solar, raise solar to backup."""
+        entity, coordinator = self._make_entity(
+            hass, enhanced_config_entry, "backup_reserve",
+        )
+        coordinator._device_data["ems_backup_ratio_pct"] = 40
+        coordinator.async_set_updated_data(dict(coordinator._device_data))
+        coordinator.async_set_powerocean_soc = AsyncMock(return_value=True)
+        entity.async_write_ha_state = MagicMock()
+
+        await entity.async_set_native_value(60.0)
+
+        coordinator.async_set_powerocean_soc.assert_called_once_with(60, 60)
+
+    async def test_set_solar_surplus_holds_backup(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """Setting solar_surplus_threshold sends backup=current, solar=value."""
+        entity, coordinator = self._make_entity(
+            hass, enhanced_config_entry, "solar_surplus_threshold",
+        )
+        coordinator.async_set_powerocean_soc = AsyncMock(return_value=True)
+        entity.async_write_ha_state = MagicMock()
+
+        await entity.async_set_native_value(90.0)
+
+        coordinator.async_set_powerocean_soc.assert_called_once_with(30, 90)
+
+    async def test_set_solar_clamps_backup_when_lower(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """If new solar < current backup, lower backup to solar."""
+        entity, coordinator = self._make_entity(
+            hass, enhanced_config_entry, "solar_surplus_threshold",
+        )
+        coordinator.async_set_powerocean_soc = AsyncMock(return_value=True)
+        entity.async_write_ha_state = MagicMock()
+
+        # current backup = 30, set solar to 20 -> backup must clamp to 20
+        await entity.async_set_native_value(20.0)
+
+        coordinator.async_set_powerocean_soc.assert_called_once_with(20, 20)

--- a/tests/ha/test_powerocean_select.py
+++ b/tests/ha/test_powerocean_select.py
@@ -1,0 +1,145 @@
+"""Tests for the PowerOcean Select entity (Work Mode)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.ecoflow_energy.const import (
+    DEVICE_TYPE_POWEROCEAN,
+    POWEROCEAN_SELECTS,
+)
+from custom_components.ecoflow_energy.coordinator import EcoFlowDeviceCoordinator
+from custom_components.ecoflow_energy.select import (
+    EcoFlowSelect,
+    WORK_MODE_TO_INT,
+    _get_select_defs,
+)
+
+from .conftest import MOCK_POWEROCEAN_DEVICE
+
+
+class TestSelectDefs:
+    def test_powerocean_returns_powerocean_selects(self):
+        defs = _get_select_defs(DEVICE_TYPE_POWEROCEAN)
+        assert defs is POWEROCEAN_SELECTS
+
+    def test_powerocean_select_keys(self):
+        defs = _get_select_defs(DEVICE_TYPE_POWEROCEAN)
+        keys = {d.key for d in defs}
+        assert keys == {"work_mode"}
+
+    def test_work_mode_options(self):
+        defs = _get_select_defs(DEVICE_TYPE_POWEROCEAN)
+        wm = next(d for d in defs if d.key == "work_mode")
+        assert wm.options == ("self_use", "ai_schedule")
+
+    def test_work_mode_enhanced_only(self):
+        defs = _get_select_defs(DEVICE_TYPE_POWEROCEAN)
+        assert all(d.enhanced_only for d in defs)
+
+    def test_unknown_device_type_returns_empty(self):
+        defs = _get_select_defs("unknown")
+        assert defs == []
+
+
+class TestWorkModeMapping:
+    """Maps the user-facing options to wire-level integers."""
+
+    def test_self_use_maps_to_zero(self):
+        assert WORK_MODE_TO_INT["self_use"] == 0
+
+    def test_ai_schedule_maps_to_twelve(self):
+        assert WORK_MODE_TO_INT["ai_schedule"] == 12
+
+    def test_only_phase_1_modes_exposed(self):
+        # TOU and Backup require sub-params; they must NOT be in the map
+        assert "time_of_use" not in WORK_MODE_TO_INT
+        assert "backup" not in WORK_MODE_TO_INT
+
+
+class TestEcoFlowSelect:
+    def _make_entity(self, hass, entry):
+        entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, entry, MOCK_POWEROCEAN_DEVICE,
+        )
+        coordinator._device_data = {"ems_work_mode": "self_use"}
+        coordinator.async_set_updated_data(dict(coordinator._device_data))
+        defn = next(d for d in POWEROCEAN_SELECTS if d.key == "work_mode")
+        entity = EcoFlowSelect(coordinator, defn)
+        return entity, coordinator
+
+    async def test_current_option_self_use(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        entity, _ = self._make_entity(hass, enhanced_config_entry)
+        assert entity.current_option == "self_use"
+
+    async def test_current_option_unknown_value_returns_none(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """Modes not in the exposed options return None (not a crash)."""
+        entity, coordinator = self._make_entity(hass, enhanced_config_entry)
+        coordinator._device_data["ems_work_mode"] = "time_of_use"
+        coordinator.async_set_updated_data(dict(coordinator._device_data))
+        assert entity.current_option is None
+
+    async def test_async_select_option_self_use(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        entity, coordinator = self._make_entity(hass, enhanced_config_entry)
+        coordinator.async_set_powerocean_work_mode = AsyncMock(return_value=True)
+        entity.async_write_ha_state = MagicMock()
+
+        await entity.async_select_option("self_use")
+
+        coordinator.async_set_powerocean_work_mode.assert_called_once_with(0)
+
+    async def test_async_select_option_ai_schedule(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        entity, coordinator = self._make_entity(hass, enhanced_config_entry)
+        coordinator.async_set_powerocean_work_mode = AsyncMock(return_value=True)
+        entity.async_write_ha_state = MagicMock()
+
+        await entity.async_select_option("ai_schedule")
+
+        coordinator.async_set_powerocean_work_mode.assert_called_once_with(12)
+
+    async def test_async_select_option_invalid_ignored(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """Options not in the exposed list are rejected without calling SET."""
+        entity, coordinator = self._make_entity(hass, enhanced_config_entry)
+        coordinator.async_set_powerocean_work_mode = AsyncMock()
+
+        await entity.async_select_option("backup")
+
+        coordinator.async_set_powerocean_work_mode.assert_not_called()
+
+    async def test_set_failed_no_optimistic_update(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        entity, coordinator = self._make_entity(hass, enhanced_config_entry)
+        coordinator.async_set_powerocean_work_mode = AsyncMock(return_value=False)
+
+        await entity.async_select_option("ai_schedule")
+
+        # Failed SET: optimistic value not applied, current_option stays
+        assert coordinator._device_data["ems_work_mode"] == "self_use"

--- a/tests/test_energy_stream.py
+++ b/tests/test_energy_stream.py
@@ -1,9 +1,16 @@
 """Tests for EcoFlow Protobuf encoder — EnergyStreamSwitch and SoC limit SET."""
 
+import pytest
+
 from ecoflow_energy.ecoflow.energy_stream import (
+    build_backup_event_set_payload,
     build_energy_stream_activate_payload,
     build_energy_stream_deactivate_payload,
+    build_feed_mode_set_payload,
+    build_feed_power_set_payload,
+    build_powerocean_soc_set_payload,
     build_soc_limit_set_payload,
+    build_work_mode_set_payload,
 )
 from ecoflow_energy.ecoflow.proto_encoding import (
     encode_field_bytes,
@@ -144,3 +151,266 @@ class TestSocLimitSetPayload:
         payload = build_soc_limit_set_payload(100, 0, seq=1)
         # field 16 tag = (16<<3)|0 = 128 → varint 0x80 0x01, value 3 = 0x03
         assert b"\x80\x01\x03" in payload
+
+
+# ===========================================================================
+# PowerOcean 3-field SoC SET payload (cmd_id=112, app-replay format)
+# ===========================================================================
+
+
+class TestPowerOceanSocSetPayload:
+    """3-field SoC SET that replicates the official EcoFlow app payload."""
+
+    def test_payload_structure(self):
+        payload = build_powerocean_soc_set_payload(60, 100, seq=99999, device_sn="HJ31TEST")
+        assert isinstance(payload, bytes)
+        assert payload[0] == 0x0A
+
+    def test_cmd_id_112_present(self):
+        payload = build_powerocean_soc_set_payload(60, 100, seq=1)
+        assert b"\x48\x70" in payload  # cmd_id=112
+
+    def test_pdata_contains_all_three_fields(self):
+        # field 1=100 (0x64), field 2=60 (0x3c), field 4=100 (0x64)
+        payload = build_powerocean_soc_set_payload(60, 100, seq=1)
+        # Inner pdata should contain: 0x08 0x64 (f1=100), 0x10 0x3c (f2=60), 0x20 0x64 (f4=100)
+        assert b"\x08\x64\x10\x3c\x20\x64" in payload
+
+    def test_check_type_field7_present(self):
+        # New envelope adds field 7 (check_type) = 3
+        # field 7 tag = (7<<3)|0 = 56 = 0x38, value 3 = 0x03
+        payload = build_powerocean_soc_set_payload(0, 100, seq=1)
+        assert b"\x38\x03" in payload
+
+    def test_from_ios_field23_present(self):
+        # field 23 = "ios" string. tag for length-delimited = (23<<3)|2
+        # = 186 = 0xBA 0x01 (multi-byte varint), then len 3, then "ios"
+        payload = build_powerocean_soc_set_payload(0, 100, seq=1)
+        assert b"\xba\x01\x03ios" in payload
+
+    def test_device_sn_field25_present_when_provided(self):
+        # field 25 = SN string. tag = (25<<3)|2 = 202 = 0xCA 0x01
+        sn = "HJ31TEST"
+        payload = build_powerocean_soc_set_payload(0, 100, seq=1, device_sn=sn)
+        assert b"\xca\x01" + bytes([len(sn)]) + sn.encode() in payload
+
+    def test_device_sn_omitted_when_empty(self):
+        sn_marker = b"\xca\x01"
+        payload_with_sn = build_powerocean_soc_set_payload(0, 100, seq=1, device_sn="X")
+        payload_without = build_powerocean_soc_set_payload(0, 100, seq=1, device_sn="")
+        assert sn_marker in payload_with_sn
+        assert sn_marker not in payload_without
+
+    def test_rejects_backup_above_solar(self):
+        with pytest.raises(ValueError):
+            build_powerocean_soc_set_payload(70, 60)
+
+    def test_rejects_backup_below_zero(self):
+        with pytest.raises(ValueError):
+            build_powerocean_soc_set_payload(-1, 100)
+
+    def test_rejects_solar_above_100(self):
+        with pytest.raises(ValueError):
+            build_powerocean_soc_set_payload(50, 101)
+
+    def test_equal_values_allowed(self):
+        # backup_reserve == solar_surplus is allowed (boundary)
+        payload = build_powerocean_soc_set_payload(50, 50, seq=1)
+        assert isinstance(payload, bytes)
+
+    def test_zero_zero_allowed(self):
+        payload = build_powerocean_soc_set_payload(0, 0, seq=1)
+        assert isinstance(payload, bytes)
+
+    def test_deterministic_with_fixed_seq(self):
+        p1 = build_powerocean_soc_set_payload(60, 100, seq=42, device_sn="X")
+        p2 = build_powerocean_soc_set_payload(60, 100, seq=42, device_sn="X")
+        assert p1 == p2
+
+    def test_different_values_produce_different_payload(self):
+        p1 = build_powerocean_soc_set_payload(0, 100, seq=42)
+        p2 = build_powerocean_soc_set_payload(60, 100, seq=42)
+        assert p1 != p2
+
+    def test_max_charge_field1_always_100(self):
+        # field 1 should always be 100 regardless of inputs
+        payload = build_powerocean_soc_set_payload(0, 0, seq=1)
+        # field 1 tag = 0x08, value 100 = 0x64
+        assert b"\x08\x64" in payload
+
+
+# ===========================================================================
+# Work Mode SET payload (SysWorkModeSet, cmd_id=98)
+# ===========================================================================
+
+
+class TestWorkModeSetPayload:
+    def test_payload_structure(self):
+        payload = build_work_mode_set_payload(0, seq=99999)
+        assert isinstance(payload, bytes)
+        assert payload[0] == 0x0A
+
+    def test_cmd_id_98_present(self):
+        """cmd_id=98 (field 9, varint) must be encoded in the header."""
+        payload = build_work_mode_set_payload(0, seq=1)
+        # field 9 tag = 0x48, value 98 = 0x62
+        assert b"\x48\x62" in payload
+
+    def test_cmd_func_96_present(self):
+        payload = build_work_mode_set_payload(0, seq=1)
+        assert b"\x40\x60" in payload
+
+    def test_payload_contains_work_mode_value(self):
+        # Inner pdata = field 1 varint with mode value
+        payload = build_work_mode_set_payload(2, seq=1)  # BACKUP
+        assert b"\x08\x02" in payload
+
+    def test_self_use_zero_encoded(self):
+        # WorkMode SELFUSE=0 must still be present on the wire
+        payload = build_work_mode_set_payload(0, seq=1)
+        assert b"\x08\x00" in payload
+
+    def test_ai_schedule_value(self):
+        # WorkMode AI_SCHEDULE=12
+        payload = build_work_mode_set_payload(12, seq=1)
+        assert b"\x08\x0c" in payload
+
+    def test_deterministic_with_fixed_seq(self):
+        p1 = build_work_mode_set_payload(1, seq=42)
+        p2 = build_work_mode_set_payload(1, seq=42)
+        assert p1 == p2
+
+    def test_different_modes_produce_different_payload(self):
+        p1 = build_work_mode_set_payload(0, seq=42)
+        p2 = build_work_mode_set_payload(2, seq=42)
+        assert p1 != p2
+
+    def test_rejects_negative(self):
+        with pytest.raises(ValueError):
+            build_work_mode_set_payload(-1)
+
+    def test_rejects_above_13(self):
+        with pytest.raises(ValueError):
+            build_work_mode_set_payload(14)
+
+    def test_default_seq(self):
+        payload = build_work_mode_set_payload(0)
+        assert isinstance(payload, bytes)
+
+
+# ===========================================================================
+# Feed Mode SET payload (SysFeedPowerSet field 2, cmd_id=115)
+# ===========================================================================
+
+
+class TestFeedModeSetPayload:
+    def test_payload_structure(self):
+        payload = build_feed_mode_set_payload(0, seq=99999)
+        assert isinstance(payload, bytes)
+        assert payload[0] == 0x0A
+
+    def test_cmd_id_115_present(self):
+        """cmd_id=115 (field 9, varint) must be encoded in the header."""
+        payload = build_feed_mode_set_payload(0, seq=1)
+        # field 9 tag = 0x48, value 115 = 0x73
+        assert b"\x48\x73" in payload
+
+    def test_payload_contains_feed_mode_field2(self):
+        # Inner pdata = field 2 varint
+        # field 2 varint tag = (2<<3)|0 = 0x10
+        payload = build_feed_mode_set_payload(3, seq=1)  # limit mode
+        assert b"\x10\x03" in payload
+
+    def test_off_mode_zero_encoded(self):
+        payload = build_feed_mode_set_payload(0, seq=1)
+        assert b"\x10\x00" in payload
+
+    def test_zero_feed_mode(self):
+        # mode=2 (zero-feed for RegEnergie 0%)
+        payload = build_feed_mode_set_payload(2, seq=1)
+        assert b"\x10\x02" in payload
+
+    def test_rejects_negative(self):
+        with pytest.raises(ValueError):
+            build_feed_mode_set_payload(-1)
+
+    def test_rejects_above_3(self):
+        with pytest.raises(ValueError):
+            build_feed_mode_set_payload(4)
+
+
+# ===========================================================================
+# Feed Power Limit SET payload (SysFeedPowerSet field 4, cmd_id=115)
+# ===========================================================================
+
+
+class TestFeedPowerSetPayload:
+    def test_payload_structure(self):
+        payload = build_feed_power_set_payload(800, seq=99999)
+        assert isinstance(payload, bytes)
+        assert payload[0] == 0x0A
+
+    def test_cmd_id_115_present(self):
+        payload = build_feed_power_set_payload(800, seq=1)
+        # field 9 tag = 0x48, value 115 = 0x73
+        assert b"\x48\x73" in payload
+
+    def test_payload_contains_feed_power_field4(self):
+        # field 4 varint tag = (4<<3)|0 = 0x20
+        # 800W = varint 0xA0 0x06
+        payload = build_feed_power_set_payload(800, seq=1)
+        assert b"\x20\xa0\x06" in payload
+
+    def test_zero_watts_encoded(self):
+        payload = build_feed_power_set_payload(0, seq=1)
+        assert b"\x20\x00" in payload
+
+    def test_rejects_negative(self):
+        with pytest.raises(ValueError):
+            build_feed_power_set_payload(-1)
+
+    def test_accepts_high_value(self):
+        # 10kW typical inverter ceiling
+        payload = build_feed_power_set_payload(10000, seq=1)
+        assert isinstance(payload, bytes)
+
+
+# ===========================================================================
+# Backup Event SET payload (SysBackupEventSet, cmd_id=99)
+# ===========================================================================
+
+
+class TestBackupEventSetPayload:
+    def test_payload_structure(self):
+        payload = build_backup_event_set_payload(True, 1700000000, 1700003600, seq=1)
+        assert isinstance(payload, bytes)
+        assert payload[0] == 0x0A
+
+    def test_cmd_id_99_present(self):
+        payload = build_backup_event_set_payload(True, 1700000000, 1700003600, seq=1)
+        # field 9 tag = 0x48, value 99 = 0x63
+        assert b"\x48\x63" in payload
+
+    def test_enable_field2_set(self):
+        # field 2 varint tag = 0x10, enable=true (1)
+        payload = build_backup_event_set_payload(True, 1700000000, 1700003600, seq=1)
+        assert b"\x10\x01" in payload
+
+    def test_disable_field2_zero(self):
+        # disable=false (0). start/end_ts can be 0 when disabling.
+        payload = build_backup_event_set_payload(False, 0, 0, seq=1)
+        assert b"\x10\x00" in payload
+
+    def test_rejects_inverted_window(self):
+        # When enabling, start must be < end
+        with pytest.raises(ValueError):
+            build_backup_event_set_payload(True, 1700003600, 1700000000)
+
+    def test_rejects_negative_timestamp(self):
+        with pytest.raises(ValueError):
+            build_backup_event_set_payload(True, -1, 1700000000)
+
+    def test_disable_with_zero_window_allowed(self):
+        # Disabling doesn't require valid window
+        payload = build_backup_event_set_payload(False, 0, 0, seq=1)
+        assert isinstance(payload, bytes)


### PR DESCRIPTION
## Summary

Adds the controls needed for full feature parity with the EcoFlow app energy strategy tab. Wire-format verified against live app traffic by replicating the byte-for-byte SET payload the official app sends.

**New entities:**
- `number.backup_reserve` (0-100%, step 5) - "Backup-Reserve" slider
- `number.solar_surplus_threshold` (0-100%, step 5) - "Überschüssige Solarenergie" threshold
- `select.work_mode` - Self-use / AI Schedule (TOU and Backup deferred)

**Removed:**
- `number.min_discharge_soc` (legacy, sent only 2 of 3 required fields, silently ignored by device). Migration note in CHANGELOG. Replaced by `number.backup_reserve`.

**Robustness:**
- Enum sensors no longer crash with `ValueError: state value not in options` when the device emits a previously-unseen enum value. Unknown values are dropped.

## Test plan

- [x] 892 unit tests pass (~50 new for the 3-field SoC payload, work mode, select, robustness)
- [x] Probe script verified against live PowerOcean: SetAck result=0 + value visible in EcoFlow app
- [x] Docker Desktop HA: entities load, no ERROR/WARNING in logs, 3-min soak clean
- [ ] Beta install on Prod Pi via HACS beta channel - 24-48h soak

Ref #6