### PR TITLE
fix: PowerOcean solar surplus slider revert to old value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Enum sensors no longer crash with `ValueError: state value not in options` when the device emits a previously-unseen enum value. Unknown values are now dropped (sensor stays unavailable until a known value arrives) rather than being passed through as raw integers. Affects `ems_work_mode`, `ems_work_state`, `pcs_run_state`, and other enum fields. (beta.1)
+- PowerOcean `number.solar_surplus_threshold` ("Überschüssige Solarenergie") slider reverted to the device's stored value after every change. The 3-field `SysBatChgDsgSet` payload (cmd_id=112) wrote the surplus percentage to wire field 4, which the device silently accepts but ignores. The value now goes to wire field 3 (`sys_bat_backup_ratio`) and is reflected back via `JTS1EmsChangeReport` within ~0.5s. The Backup-Reserve slider was unaffected. (beta.2)
 
 ### Removed
 - `number.min_discharge_soc` (legacy) - sent only 2 of the 3 fields the device requires, causing writes to be silently ignored. Use the new `number.backup_reserve` instead. The wire field and read sensor are unchanged; only the entity name and range (was 0-30%, now 0-100%) differ. (beta.1)

--- a/custom_components/ecoflow_energy/coordinator.py
+++ b/custom_components/ecoflow_energy/coordinator.py
@@ -1173,10 +1173,10 @@ class EcoFlowDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     ) -> bool:
         """Send a 3-field SoC SET to PowerOcean (app-replay format).
 
-        Wire: cmd_id=112 SysBatChgDsgSet with field 1=100, field 2=backup,
-        field 4=solar_surplus, plus extended envelope (check_type, from=ios,
-        device_sn). Verified 2026-05-06 against the official EcoFlow app
-        traffic. The legacy `async_set_soc_limits` only sends fields 1+2
+        Wire: cmd_id=112 SysBatChgDsgSet with field 1=100 (sys_bat_chg_up_limit),
+        field 2=backup (sys_bat_dsg_down_limit), field 3=solar_surplus
+        (sys_bat_backup_ratio), plus extended envelope (check_type, from=ios,
+        device_sn). The legacy `async_set_soc_limits` only sends fields 1+2
         and is silently ignored by the device for backup-reserve changes.
         """
         if not self._enhanced_mode:

--- a/custom_components/ecoflow_energy/ecoflow/energy_stream.py
+++ b/custom_components/ecoflow_energy/ecoflow/energy_stream.py
@@ -59,11 +59,11 @@ def build_powerocean_soc_set_payload(
     """Build SysBatChgDsgSet (cmd_id=112) replicating the EcoFlow app frame.
 
     The app sends THREE fields in the inner pdata for every SoC-limit
-    change (verified 2026-05-06 against live app traffic):
+    change (verified against device echo via EmsChangeReport field 15):
 
-        field 1 = max_charge_soc       (always 100 in observed app traffic)
-        field 2 = backup_reserve_pct   (the "Backup-Reserve" slider)
-        field 4 = solar_surplus_pct    (the "Überschüssige Solarenergie" slider)
+        field 1 = max_charge_soc       (sys_bat_chg_up_limit, always 100)
+        field 2 = backup_reserve_pct   (sys_bat_dsg_down_limit, "Backup-Reserve" slider)
+        field 3 = solar_surplus_pct    (sys_bat_backup_ratio, "Überschüssige Solarenergie" slider)
 
     The older 2-field builder (`build_soc_limit_set_payload`) sent only
     fields 1+2, which the device sometimes silently ignored. Using the
@@ -100,7 +100,7 @@ def build_powerocean_soc_set_payload(
     pdata = (
         encode_field_varint(1, 100)                       # max_charge_soc, constant
         + encode_field_varint(2, backup_reserve_pct)      # backup reserve floor
-        + encode_field_varint(4, solar_surplus_pct)       # solar surplus threshold
+        + encode_field_varint(3, solar_surplus_pct)       # solar surplus threshold
     )
     return _build_powerocean_set_envelope(pdata, cmd_id=112, seq=seq, device_sn=device_sn)
 

--- a/tests/ha/test_powerocean_number.py
+++ b/tests/ha/test_powerocean_number.py
@@ -235,8 +235,9 @@ class TestAsyncSetPowerOceanSoc:
         assert result is True
         mock_mqtt.send_proto_set.assert_called_once()
         payload = mock_mqtt.send_proto_set.call_args[0][0]
-        # Inner pdata contains 3 fields: 1=100, 2=25, 4=80
-        assert b"\x08\x64\x10\x19\x20\x50" in payload
+        # Inner pdata contains 3 fields: 1=100, 2=25, 3=80
+        # Field 3 (0x18 tag) is sys_bat_backup_ratio per SysBatChgDsgSet proto.
+        assert b"\x08\x64\x10\x19\x18\x50" in payload
 
     async def test_3field_set_rejects_backup_above_solar(
         self,

--- a/tests/test_energy_stream.py
+++ b/tests/test_energy_stream.py
@@ -171,10 +171,23 @@ class TestPowerOceanSocSetPayload:
         assert b"\x48\x70" in payload  # cmd_id=112
 
     def test_pdata_contains_all_three_fields(self):
-        # field 1=100 (0x64), field 2=60 (0x3c), field 4=100 (0x64)
+        # field 1=100 (0x64), field 2=60 (0x3c), field 3=100 (0x64)
+        # Field 3 is sys_bat_backup_ratio per Re307Sys/JtS1Sys SysBatChgDsgSet
+        # proto definition. Earlier versions wrote field 4 (dev_soc), which
+        # the device silently ignored.
         payload = build_powerocean_soc_set_payload(60, 100, seq=1)
-        # Inner pdata should contain: 0x08 0x64 (f1=100), 0x10 0x3c (f2=60), 0x20 0x64 (f4=100)
-        assert b"\x08\x64\x10\x3c\x20\x64" in payload
+        # Inner pdata should contain: 0x08 0x64 (f1=100), 0x10 0x3c (f2=60), 0x18 0x64 (f3=100)
+        assert b"\x08\x64\x10\x3c\x18\x64" in payload
+
+    def test_solar_surplus_uses_field_3_not_4(self):
+        # Regression guard: writing solar_surplus to field 4 (dev_soc) leaves
+        # sys_bat_backup_ratio untouched on the device, so the slider reverts
+        # to the device's last value on the next EmsChangeReport.
+        payload = build_powerocean_soc_set_payload(0, 75, seq=1)
+        # Field 3 varint tag = (3<<3)|0 = 0x18, value 75 = 0x4B
+        assert b"\x18\x4b" in payload
+        # Field 4 varint tag = (4<<3)|0 = 0x20 must not carry solar_surplus
+        assert b"\x20\x4b" not in payload
 
     def test_check_type_field7_present(self):
         # New envelope adds field 7 (check_type) = 3


### PR DESCRIPTION
## Summary

- `SysBatChgDsgSet` (cmd_id=112) wrote `solar_surplus_pct` to wire field 4. Per the proto, field 4 is `dev_soc` (legacy firmware) and is undefined on Re307. The actual surplus field is field 3 (`sys_bat_backup_ratio`).
- The device accepted the SET (SetAck=0) but ignored the unknown field, so the next `JTS1EmsChangeReport` echoed the unchanged value and HA reverted the slider within seconds.
- Fix moves the value to field 3 and updates the unit-test byte assertions.

Verified against a live device: writing field 3 produces an EMS change report echo within ~0.5s carrying the exact value sent. Backup Reserve (field 2) was unaffected.

Ref #74 (introduced in v1.13.0-beta.1)
Ref #6 (parent feature)

## Test plan

- [x] `pytest` 893 passed (incl. new regression `test_solar_surplus_uses_field_3_not_4`)
- [x] Probe with old code (field 4): SetAck=0, no echo within 60s
- [x] Probe with fix (field 3): SetAck=0, echo `sys_bat_backup_ratio=75` within 0.47s
- [x] Docker dev: container restart clean, slider reads device value, no ERROR/WARNING in logs
- [ ] Beta tag `v1.13.0-beta.2` after merge
- [ ] Verify on Prod Raspberry Pi after HACS beta update