### PR TITLE
chore: silence Pyright attr-defined for generated _pb2 classes

### DIFF
--- a/custom_components/ecoflow_energy/coordinator.py
+++ b/custom_components/ecoflow_energy/coordinator.py
@@ -1013,7 +1013,12 @@ class EcoFlowDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     pdata = bytes.fromhex(pdata_hex)
                 except ValueError:
                     continue
-                msg_class = pb2.JTS1EmsChangeReport if cmd_id == 8 else pb2.JTS1EmsParamChangeReport
+                # Generated _pb2 classes are registered via _descriptor_pool
+                # at runtime, which Pyright/Pylance cannot resolve statically.
+                msg_class = (
+                    pb2.JTS1EmsChangeReport if cmd_id == 8  # type: ignore[attr-defined]
+                    else pb2.JTS1EmsParamChangeReport  # type: ignore[attr-defined]
+                )
                 msg = msg_class()
                 msg.ParseFromString(pdata)
                 fields = MessageToDict(msg, preserving_proto_field_name=True)


### PR DESCRIPTION
## Summary

VSCode/Pyright reported two `reportAttributeAccessIssue` errors on `coordinator.py:1016`:

```
"JTS1EmsChangeReport" is not a known attribute of module ".ecoflow.proto.ecocharge_pb2"
"JTS1EmsParamChangeReport" is not a known attribute of module ".ecoflow.proto.ecocharge_pb2"
```

These are false positives - generated `_pb2.py` modules register their classes lazily via `_descriptor_pool`, which static analysers cannot follow. The classes exist at runtime (all 913 tests + live decoder confirm).

Adding `# type: ignore[attr-defined]` with a one-line explanation.

## Test plan

- [x] `pytest`: 913 passed
- [x] `npx pyright coordinator.py`: 0 diagnostics (was 2)