### PR TITLE
feat: add Stream AC Pro support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.15.0] - 2026-06-12
+
+### Added
+- Initial Stream AC Pro (BK31) support in Enhanced Mode, including device detection, protobuf telemetry parsing, Home Assistant sensor entities, and a Backup Reserve number control.
+
 ## [1.14.0] - 2026-05-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Initial Stream AC Pro (BK31) support in Enhanced Mode, including device detection, protobuf telemetry parsing, Home Assistant sensor entities, and a Backup Reserve number control.
+- Stream AC Pro Energy Dashboard sensors (solar, home, battery charge/discharge) derived via Riemann-sum integration from the live power telemetry.
 
 ## [1.14.0] - 2026-05-18
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 | **PowerOcean** — Home Battery | 202 | 2 numbers, 1 select (Enhanced only) | 6 (solar, grid, battery, home) | ~30 s standard / ~3 s enhanced |
 | **Delta 2 Max** — Portable Power | 94 | 7 switches, 8 numbers | 4 (solar 1+2, AC in/out) | ~30 s standard / ~2 s enhanced |
 | **Smart Plug** — Switchable Outlet | 11 | 1 switch, 2 numbers | 1 (total energy) | ~30 s standard / ~3 s enhanced |
-| **Stream AC Pro** — Home Battery | 29 | 1 number (Enhanced only) | 2 (battery charge/discharge) | Enhanced only / ~3 s |
+| **Stream AC Pro** — Home Battery | 33 | 1 number (Enhanced only) | 4 (solar, home, battery charge/discharge) | Enhanced only / ~3 s |
 
 > **Tip:** Other Delta-series devices (Delta Pro, Delta 2, etc.) should work automatically with the Delta sensor set.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 | **PowerOcean** — Home Battery | 202 | 2 numbers, 1 select (Enhanced only) | 6 (solar, grid, battery, home) | ~30 s standard / ~3 s enhanced |
 | **Delta 2 Max** — Portable Power | 94 | 7 switches, 8 numbers | 4 (solar 1+2, AC in/out) | ~30 s standard / ~2 s enhanced |
 | **Smart Plug** — Switchable Outlet | 11 | 1 switch, 2 numbers | 1 (total energy) | ~30 s standard / ~3 s enhanced |
+| **Stream AC Pro** — Home Battery | 29 | 1 number (Enhanced only) | 2 (battery charge/discharge) | Enhanced only / ~3 s |
 
 > **Tip:** Other Delta-series devices (Delta Pro, Delta 2, etc.) should work automatically with the Delta sensor set.
 
@@ -73,6 +74,13 @@ Battery SoC/SoH · All input/output power, temperatures, voltages · **Expansion
 <summary><b>Smart Plug</b> — power monitoring, plug switch, automation-ready</summary>
 
 Power (W), current (A), voltage (V), frequency, temperature · Plug on/off switch · **Numbers:** LED brightness (0-100%), max power limit (0-2500 W) · Real-time MQTT push in Standard Mode · ~3 s updates in Enhanced Mode. Ideal for automating charging (e.g. charge Delta on solar surplus).
+
+</details>
+
+<details>
+<summary><b>Stream AC Pro</b> — battery telemetry and reserve control</summary>
+
+Battery SoC/SoH · solar, home, grid, and battery power · battery charge/discharge power · AC voltage and frequency · battery temperature, capacity, cell voltage, and lifetime charge/discharge diagnostics · **Number:** Backup Reserve (3-95%) in Enhanced Mode.
 
 </details>
 

--- a/custom_components/ecoflow_energy/__init__.py
+++ b/custom_components/ecoflow_energy/__init__.py
@@ -19,6 +19,7 @@ from .const import (
     DOMAIN,
     MODE_ENHANCED,
     PLATFORMS,
+    get_device_type,
 )
 from .coordinator import EcoFlowDeviceCoordinator
 
@@ -86,11 +87,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: EcoFlowConfigEntry) -> b
         sn = device_info["sn"]
         device_type = device_info.get("device_type", "")
         if not device_type or device_type == DEVICE_TYPE_UNKNOWN:
+            device_type = get_device_type(
+                device_info.get("product_name", ""),
+                sn,
+            )
+        if not device_type or device_type == DEVICE_TYPE_UNKNOWN:
             _LOGGER.debug(
                 "Skipping device %s... - no parser available",
                 sn[:4],
             )
             continue
+        device_info = {**device_info, "device_type": device_type}
         coordinator = EcoFlowDeviceCoordinator(hass, entry, device_info)
         await coordinator.async_setup()
         # First refresh — raises ConfigEntryNotReady on failure so HA retries

--- a/custom_components/ecoflow_energy/const.py
+++ b/custom_components/ecoflow_energy/const.py
@@ -547,11 +547,15 @@ STREAM_SENSORS: list[EcoFlowSensorDef] = [
     EcoFlowSensorDef("batt_w", "Battery Power", "W", "power", "measurement", "mdi:battery", suggested_display_precision=0),
     EcoFlowSensorDef("batt_charge_power_w", "Battery Charge Power", "W", "power", "measurement", "mdi:battery-charging", suggested_display_precision=0),
     EcoFlowSensorDef("batt_discharge_power_w", "Battery Discharge Power", "W", "power", "measurement", "mdi:battery", suggested_display_precision=0),
+    EcoFlowSensorDef("solar_energy_kwh", "Solar Energy", "kWh", "energy", "total_increasing", "mdi:solar-power", suggested_display_precision=2),
+    EcoFlowSensorDef("home_energy_kwh", "Home Energy", "kWh", "energy", "total_increasing", "mdi:home-lightning-bolt", suggested_display_precision=2),
+    EcoFlowSensorDef("batt_charge_energy_kwh", "Battery Charge Energy", "kWh", "energy", "total_increasing", "mdi:battery-charging", suggested_display_precision=2),
+    EcoFlowSensorDef("batt_discharge_energy_kwh", "Battery Discharge Energy", "kWh", "energy", "total_increasing", "mdi:battery", suggested_display_precision=2),
     EcoFlowSensorDef("bms_soh_pct", "Battery SoH", "%", None, "measurement", "mdi:battery-heart-variant", suggested_display_precision=0),
     EcoFlowSensorDef("batt_voltage_v", "Battery Voltage", "V", "voltage", "measurement", "mdi:flash-triangle", suggested_display_precision=1),
     EcoFlowSensorDef("batt_temp_c", "Battery Temp", "\u00b0C", "temperature", "measurement", "mdi:thermometer", suggested_display_precision=1),
-    EcoFlowSensorDef("batt_charge_energy_wh", "Battery Charge Energy", "Wh", "energy", "total_increasing", "mdi:battery-charging", suggested_display_precision=0),
-    EcoFlowSensorDef("batt_discharge_energy_wh", "Battery Discharge Energy", "Wh", "energy", "total_increasing", "mdi:battery", suggested_display_precision=0),
+    EcoFlowSensorDef("batt_charge_energy_wh", "Battery Charge Energy (Raw)", "Wh", None, "total_increasing", "mdi:battery-charging", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    EcoFlowSensorDef("batt_discharge_energy_wh", "Battery Discharge Energy (Raw)", "Wh", None, "total_increasing", "mdi:battery", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
     EcoFlowSensorDef("batt_design_cap_mah", "Design Capacity", "mAh", None, "measurement", "mdi:battery", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
     EcoFlowSensorDef("batt_remain_cap_mah", "Remaining Capacity", "mAh", None, "measurement", "mdi:battery-50", suggested_display_precision=0, disabled_by_default=True),
     EcoFlowSensorDef("batt_full_cap_mah", "Full Capacity", "mAh", None, "measurement", "mdi:battery", suggested_display_precision=0, disabled_by_default=True),
@@ -601,6 +605,19 @@ SMARTPLUG_POWER_TO_ENERGY: dict[str, str] = {
 }
 
 SMARTPLUG_ENERGY_FROM_API: list[tuple[str, str]] = []
+
+# grid_w is deliberately excluded: the Stream reports a signed grid power
+# without an import/export split. Feeding abs(grid_w) into a single energy
+# counter would conflate consumption and feed-in, making it useless for the
+# Energy Dashboard.
+STREAM_POWER_TO_ENERGY: dict[str, str] = {
+    "solar_w": "solar_energy_kwh",
+    "home_w": "home_energy_kwh",
+    "batt_charge_power_w": "batt_charge_energy_kwh",
+    "batt_discharge_power_w": "batt_discharge_energy_kwh",
+}
+
+STREAM_ENERGY_FROM_API: list[tuple[str, str]] = []
 
 
 # ===========================================================================

--- a/custom_components/ecoflow_energy/const.py
+++ b/custom_components/ecoflow_energy/const.py
@@ -10,6 +10,7 @@ from .ecoflow.const import (  # noqa: E402
     DEVICE_TYPE_DELTA,
     DEVICE_TYPE_POWEROCEAN,
     DEVICE_TYPE_SMARTPLUG,
+    DEVICE_TYPE_STREAM,
     DEVICE_TYPE_UNKNOWN,
     get_device_type,
 )
@@ -76,6 +77,7 @@ DEVICE_TYPE_DISPLAY_NAMES: dict[str, str] = {
     DEVICE_TYPE_POWEROCEAN: "PowerOcean",
     DEVICE_TYPE_DELTA: "Delta 2 Max",
     DEVICE_TYPE_SMARTPLUG: "Smart Plug",
+    DEVICE_TYPE_STREAM: "Stream AC Pro",
 }
 
 # Delta write/profile variants.
@@ -520,9 +522,52 @@ SMARTPLUG_SWITCHES: list[EcoFlowSwitchDef] = [
     EcoFlowSwitchDef("plug_switch", "Plug", "switch_state", "mdi:power-plug"),
 ]
 
+STREAM_SWITCHES: list[EcoFlowSwitchDef] = []
+
 SMARTPLUG_NUMBERS: list[EcoFlowNumberDef] = [
     EcoFlowNumberDef("led_brightness", "LED Brightness", "led_brightness", "%", "mdi:brightness-6", 0, 100, 5),
     EcoFlowNumberDef("max_watts", "Max Power Limit", "max_power_w", "W", "mdi:flash-alert", 0, 2500, 100),
+]
+
+STREAM_NUMBERS: list[EcoFlowNumberDef] = [
+    EcoFlowNumberDef("backup_reserve", "Backup Reserve", "backup_reserve_pct", "%", "mdi:battery-lock", 3, 95, 1, enhanced_only=True),
+]
+
+
+# =====================================================================
+# Stream AC Pro sensor definitions
+# =====================================================================
+
+STREAM_SENSORS: list[EcoFlowSensorDef] = [
+    EcoFlowSensorDef("soc_pct", "Battery SOC", "%", "battery", "measurement", "mdi:battery", suggested_display_precision=0),
+    EcoFlowSensorDef("soc_precise_pct", "Battery SOC (Precise)", "%", None, "measurement", "mdi:battery-sync", "diagnostic", suggested_display_precision=1, disabled_by_default=True),
+    EcoFlowSensorDef("solar_w", "Solar Power", "W", "power", "measurement", "mdi:solar-power", suggested_display_precision=0),
+    EcoFlowSensorDef("home_w", "Home Power", "W", "power", "measurement", "mdi:home-lightning-bolt", suggested_display_precision=0),
+    EcoFlowSensorDef("grid_w", "Grid Power", "W", "power", "measurement", "mdi:transmission-tower", suggested_display_precision=0),
+    EcoFlowSensorDef("batt_w", "Battery Power", "W", "power", "measurement", "mdi:battery", suggested_display_precision=0),
+    EcoFlowSensorDef("batt_charge_power_w", "Battery Charge Power", "W", "power", "measurement", "mdi:battery-charging", suggested_display_precision=0),
+    EcoFlowSensorDef("batt_discharge_power_w", "Battery Discharge Power", "W", "power", "measurement", "mdi:battery", suggested_display_precision=0),
+    EcoFlowSensorDef("bms_soh_pct", "Battery SoH", "%", None, "measurement", "mdi:battery-heart-variant", suggested_display_precision=0),
+    EcoFlowSensorDef("batt_voltage_v", "Battery Voltage", "V", "voltage", "measurement", "mdi:flash-triangle", suggested_display_precision=1),
+    EcoFlowSensorDef("batt_temp_c", "Battery Temp", "\u00b0C", "temperature", "measurement", "mdi:thermometer", suggested_display_precision=1),
+    EcoFlowSensorDef("batt_charge_energy_wh", "Battery Charge Energy", "Wh", "energy", "total_increasing", "mdi:battery-charging", suggested_display_precision=0),
+    EcoFlowSensorDef("batt_discharge_energy_wh", "Battery Discharge Energy", "Wh", "energy", "total_increasing", "mdi:battery", suggested_display_precision=0),
+    EcoFlowSensorDef("batt_design_cap_mah", "Design Capacity", "mAh", None, "measurement", "mdi:battery", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    EcoFlowSensorDef("batt_remain_cap_mah", "Remaining Capacity", "mAh", None, "measurement", "mdi:battery-50", suggested_display_precision=0, disabled_by_default=True),
+    EcoFlowSensorDef("batt_full_cap_mah", "Full Capacity", "mAh", None, "measurement", "mdi:battery", suggested_display_precision=0, disabled_by_default=True),
+    EcoFlowSensorDef("batt_charge_capacity_ah", "Battery Charge Capacity", "Ah", None, "total_increasing", "mdi:battery-plus", suggested_display_precision=2, disabled_by_default=True),
+    EcoFlowSensorDef("batt_discharge_capacity_ah", "Battery Discharge Capacity", "Ah", None, "total_increasing", "mdi:battery-minus", suggested_display_precision=2, disabled_by_default=True),
+    EcoFlowSensorDef("ac_voltage_v", "AC Voltage", "V", "voltage", "measurement", "mdi:sine-wave", suggested_display_precision=1),
+    EcoFlowSensorDef("ac_frequency_hz", "AC Frequency", "Hz", "frequency", "measurement", "mdi:sine-wave", suggested_display_precision=2),
+    EcoFlowSensorDef("batt_max_cell_temp_c", "Max Cell Temp", "\u00b0C", "temperature", "measurement", "mdi:thermometer-high", "diagnostic", suggested_display_precision=1, disabled_by_default=True),
+    EcoFlowSensorDef("batt_min_cell_temp_c", "Min Cell Temp", "\u00b0C", "temperature", "measurement", "mdi:thermometer-low", "diagnostic", suggested_display_precision=1, disabled_by_default=True),
+    EcoFlowSensorDef("batt_max_mos_temp_c", "Max MOSFET Temp", "\u00b0C", "temperature", "measurement", "mdi:thermometer-alert", "diagnostic", suggested_display_precision=1, disabled_by_default=True),
+    EcoFlowSensorDef("batt_max_cell_vol_mv", "Max Cell Voltage", "mV", "voltage", "measurement", "mdi:flash-triangle-outline", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    EcoFlowSensorDef("batt_min_cell_vol_mv", "Min Cell Voltage", "mV", "voltage", "measurement", "mdi:flash-triangle-outline", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    EcoFlowSensorDef("backup_reserve_pct", "Backup Reserve", "%", None, "measurement", "mdi:battery-lock", "diagnostic", suggested_display_precision=0),
+    EcoFlowSensorDef("max_charge_soc_pct", "Max Charge SoC", "%", None, "measurement", "mdi:battery-charging-100", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    EcoFlowSensorDef("min_discharge_soc_pct", "Min Discharge SoC", "%", None, "measurement", "mdi:battery-alert-variant-outline", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    EcoFlowSensorDef("batt_charge_discharge_state", "Battery Charge/Discharge State", None, "enum", None, "mdi:battery-sync", "diagnostic", disabled_by_default=True, options=["standby", "discharging", "charging"]),
 ]
 
 

--- a/custom_components/ecoflow_energy/coordinator.py
+++ b/custom_components/ecoflow_energy/coordinator.py
@@ -46,6 +46,7 @@ from .const import (
     APP_SURPLUS_SYNC_USER_GRACE_S,
     POWEROCEAN_SOC_DEBOUNCE_S,
     DEVICE_TYPE_SMARTPLUG,
+    DEVICE_TYPE_STREAM,
     DEVICE_TYPE_UNKNOWN,
     DOMAIN,
     ENERGY_STREAM_KEEPALIVE_S,
@@ -81,6 +82,7 @@ from .ecoflow.parsers.powerocean_proto import (
 )
 from .ecoflow.parsers.powerocean import parse_powerocean_http_quota
 from .ecoflow.parsers.smartplug import parse_smartplug_http_quota, parse_smartplug_report
+from .ecoflow.parsers.stream_proto import parse_stream_proto_message
 from .ecoflow.proto.runtime import decode_proto_runtime_frame
 
 _LOGGER = logging.getLogger(__name__)
@@ -490,6 +492,7 @@ class EcoFlowDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         subscribe_mqtt = self.device_type in (
             DEVICE_TYPE_DELTA,
             DEVICE_TYPE_SMARTPLUG,
+            DEVICE_TYPE_STREAM,
         )
         creds = await self._iot_api.get_mqtt_credentials()
         if creds is not None:
@@ -858,7 +861,11 @@ class EcoFlowDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._log_event("set_reply", f"topic={topic}")
             return
 
-        if not self._enhanced_mode and self.device_type not in (DEVICE_TYPE_DELTA, DEVICE_TYPE_SMARTPLUG):
+        if not self._enhanced_mode and self.device_type not in (
+            DEVICE_TYPE_DELTA,
+            DEVICE_TYPE_SMARTPLUG,
+            DEVICE_TYPE_STREAM,
+        ):
             return  # Standard Mode (non-Delta/SmartPlug): ignore MQTT data
         parsed = self._parse_message(topic, payload)
         if parsed:
@@ -885,6 +892,8 @@ class EcoFlowDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if b"\x0a" in payload[:4]:
                 if self.device_type == DEVICE_TYPE_POWEROCEAN:
                     return self._parse_powerocean_get_reply(payload)
+                if self.device_type == DEVICE_TYPE_STREAM:
+                    return parse_stream_proto_message(payload)
                 return self._parse_proto_device_data(payload)
             return None
 
@@ -1051,6 +1060,8 @@ class EcoFlowDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         from .ecoflow.proto.decoder import decode_header_message
 
         headers, _ = decode_header_message(payload)
+        if self.device_type == DEVICE_TYPE_STREAM:
+            return parse_stream_proto_message(payload)
         for hdr in headers:
             pdata_hex = hdr.get("pdata")
             if not pdata_hex:

--- a/custom_components/ecoflow_energy/coordinator.py
+++ b/custom_components/ecoflow_energy/coordinator.py
@@ -65,6 +65,8 @@ from .const import (
     SMARTPLUG_POWER_TO_ENERGY,
     SMARTPLUG_SOFT_UNAVAILABLE_S,
     SOFT_UNAVAILABLE_S,
+    STREAM_ENERGY_FROM_API,
+    STREAM_POWER_TO_ENERGY,
     STALE_THRESHOLD_S,
     SMARTPLUG_STALE_THRESHOLD_S,
     get_delta_profile,
@@ -228,6 +230,9 @@ class EcoFlowDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         elif self.device_type == DEVICE_TYPE_SMARTPLUG:
             self._power_to_energy = SMARTPLUG_POWER_TO_ENERGY
             self._energy_from_api = SMARTPLUG_ENERGY_FROM_API
+        elif self.device_type == DEVICE_TYPE_STREAM:
+            self._power_to_energy = STREAM_POWER_TO_ENERGY
+            self._energy_from_api = STREAM_ENERGY_FROM_API
         else:
             self._power_to_energy = {}
             self._energy_from_api = []

--- a/custom_components/ecoflow_energy/ecoflow/const.py
+++ b/custom_components/ecoflow_energy/ecoflow/const.py
@@ -1,5 +1,7 @@
 """EcoFlow API constants and default configuration."""
 
+from __future__ import annotations
+
 # MQTT Broker
 MQTT_HOST = "mqtt-e.ecoflow.com"
 MQTT_PORT_TCP = 8883
@@ -32,12 +34,14 @@ HTTP_RETRY_BACKOFF_S = 2.0
 DEVICE_TYPE_POWEROCEAN = "powerocean"
 DEVICE_TYPE_DELTA = "delta"
 DEVICE_TYPE_SMARTPLUG = "smartplug"
+DEVICE_TYPE_STREAM = "stream"
 DEVICE_TYPE_UNKNOWN = "unknown"
 
 # Keywords used to classify devices from productName strings
 _POWEROCEAN_KEYWORDS = ("powerocean", "power ocean")
 _DELTA_KEYWORDS = ("delta",)
 _SMARTPLUG_KEYWORDS = ("smart plug", "smartplug")
+_STREAM_KEYWORDS = ("stream",)
 
 _SN_PREFIX_MAP = {
     "HJ31": DEVICE_TYPE_POWEROCEAN,
@@ -45,6 +49,7 @@ _SN_PREFIX_MAP = {
     "R351": DEVICE_TYPE_DELTA,
     "R331": DEVICE_TYPE_DELTA,
     "HW52": DEVICE_TYPE_SMARTPLUG,
+    "BK31": DEVICE_TYPE_STREAM,
 }
 
 
@@ -52,7 +57,7 @@ def get_device_type(product_name: str, sn: str = "") -> str:
     """Classify a device based on its productName string or SN prefix.
 
     Returns DEVICE_TYPE_POWEROCEAN, DEVICE_TYPE_DELTA, DEVICE_TYPE_SMARTPLUG,
-    or DEVICE_TYPE_UNKNOWN.
+    DEVICE_TYPE_STREAM, or DEVICE_TYPE_UNKNOWN.
     """
     name = product_name.lower()
     for kw in _POWEROCEAN_KEYWORDS:
@@ -64,6 +69,9 @@ def get_device_type(product_name: str, sn: str = "") -> str:
     for kw in _SMARTPLUG_KEYWORDS:
         if kw in name:
             return DEVICE_TYPE_SMARTPLUG
+    for kw in _STREAM_KEYWORDS:
+        if kw in name:
+            return DEVICE_TYPE_STREAM
     if sn:
         prefix = sn[:4].upper()
         if prefix in _SN_PREFIX_MAP:

--- a/custom_components/ecoflow_energy/ecoflow/energy_stream.py
+++ b/custom_components/ecoflow_energy/ecoflow/energy_stream.py
@@ -389,6 +389,51 @@ def build_device_get_all_payload(seq: int = 0) -> bytes:
     return encode_field_bytes(1, bytes(header))
 
 
+def build_stream_backup_reserve_payload(
+    backup_soc: int, device_sn: str, seq: int = 0,
+) -> bytes:
+    """Build the Stream AC Pro (BkSeries) Backup-Reserve SET frame.
+
+    ConfigWrite { cfg_backup_reverse_soc = 102 } wrapped in a cmd_func=254,
+    cmd_id=17 header on the /app/ WSS topic, mirroring the SmartPlug builder.
+
+    Inner pdata sets field 102 (cfg_backup_reverse_soc, uint32 varint). The
+    header replicates the app frame for routing on the /app/ topic:
+      1  pdata          5  -            10 data_len
+      2  src = 32       8  cmd_func=254 11 need_ack = 1
+      3  dest = 2       9  cmd_id = 17  14 seq
+      25 device_sn (string) - required for routing on /app/
+
+    Args:
+        backup_soc: Backup reserve SoC percentage (0-100).
+        device_sn: Device serial number (required for /app/ routing).
+        seq: Sequence number (0 = auto-generate from timestamp).
+
+    Returns:
+        Binary protobuf payload ready to publish on the SET topic.
+    """
+    if not 0 <= backup_soc <= 100:
+        raise ValueError(f"backup_soc must be 0..100, got {backup_soc}")
+
+    if seq == 0:
+        seq = int(time.time() * 1000) & 0x7FFFFFFF
+
+    pdata = encode_field_varint(102, backup_soc)  # cfg_backup_reverse_soc
+
+    header = bytearray()
+    header.extend(encode_field_bytes(1, pdata))              # pdata (field 1)
+    header.extend(encode_field_varint(2, 32))                # src = 32 (field 2)
+    header.extend(encode_field_varint(3, 2))                 # dest = 2 (field 3)
+    header.extend(encode_field_varint(8, 254))               # cmd_func = 254 (field 8)
+    header.extend(encode_field_varint(9, 17))                # cmd_id = 17 (field 9)
+    header.extend(encode_field_varint(10, len(pdata)))       # data_len (field 10)
+    header.extend(encode_field_varint(11, 1))                # need_ack = 1 (field 11)
+    header.extend(encode_field_varint(14, seq))              # seq (field 14)
+    header.extend(encode_field_bytes(25, device_sn.encode("ascii")))  # deviceSn (field 25)
+
+    return encode_field_bytes(1, bytes(header))
+
+
 def build_energy_stream_deactivate_payload(seq: int = 0) -> bytes:
     """Build the payload to deactivate energy_stream_report."""
     if seq == 0:

--- a/custom_components/ecoflow_energy/ecoflow/parsers/stream_proto.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/stream_proto.py
@@ -1,0 +1,205 @@
+"""Reverse-engineered protobuf parser for EcoFlow Stream devices.
+
+Current scope targets BK31 (Stream AC Pro) in app-auth MQTT mode.
+Only fields that have been observed repeatedly in live captures are
+mapped here. The parser is intentionally conservative so we can extend
+it safely as more captures become available.
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import Any
+
+from ..proto.decoder import decode_header_message
+
+_TYPE_INT = "int"
+_TYPE_FLOAT = "float"
+
+# cmd_func/cmd_id -> field_number -> (sensor_key, scalar_type)
+_STREAM_FIELD_MAP: dict[tuple[int, int], dict[int, tuple[str, str]]] = {
+    # Main status frame (observed every few seconds)
+    (254, 21): {
+        242: ("soc_pct", _TYPE_INT),
+        262: ("soc_pct", _TYPE_INT),  # mirrored SoC
+        270: ("max_charge_soc_pct", _TYPE_INT),
+        271: ("min_discharge_soc_pct", _TYPE_INT),
+        461: ("backup_reserve_pct", _TYPE_INT),
+        515: ("grid_w", _TYPE_FLOAT),
+        516: ("home_w", _TYPE_FLOAT),
+        517: ("solar_w", _TYPE_FLOAT),
+        518: ("batt_w", _TYPE_FLOAT),
+        613: ("ac_voltage_v", _TYPE_FLOAT),
+        615: ("ac_frequency_hz", _TYPE_FLOAT),
+        616: ("_batt_w_inverted", _TYPE_FLOAT),
+        992: ("_batt_w_negated", _TYPE_FLOAT),
+    },
+    # Auxiliary status/config frame with a more precise SoC value
+    (32, 50): {
+        7: ("_batt_voltage_mv", _TYPE_INT),
+        9: ("batt_temp_c", _TYPE_INT),
+        11: ("batt_design_cap_mah", _TYPE_INT),
+        12: ("batt_remain_cap_mah", _TYPE_INT),
+        13: ("batt_full_cap_mah", _TYPE_INT),
+        15: ("bms_soh_pct", _TYPE_INT),
+        16: ("batt_max_cell_vol_mv", _TYPE_INT),
+        17: ("batt_min_cell_vol_mv", _TYPE_INT),
+        18: ("batt_max_cell_temp_c", _TYPE_INT),
+        19: ("batt_min_cell_temp_c", _TYPE_INT),
+        20: ("batt_max_mos_temp_c", _TYPE_INT),
+        25: ("soc_precise_pct", _TYPE_FLOAT),
+        32: ("_batt_charge_capacity_ah_rounded", _TYPE_INT),
+        50: ("_batt_charge_capacity_mah_total", _TYPE_INT),
+        51: ("_batt_discharge_capacity_mah_total", _TYPE_INT),
+        79: ("batt_charge_energy_wh", _TYPE_INT),
+        80: ("batt_discharge_energy_wh", _TYPE_INT),
+    },
+    # SET acknowledgement path for backup reserve slider
+    (254, 18): {
+        102: ("backup_reserve_pct", _TYPE_INT),
+    },
+}
+
+
+def _read_varint(mv: memoryview, pos: int) -> tuple[int, int]:
+    """Decode one protobuf varint from ``mv`` starting at ``pos``."""
+    shift = 0
+    value = 0
+    while True:
+        byte = mv[pos]
+        pos += 1
+        value |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return value, pos
+        shift += 7
+
+
+def _decode_scalar(wire_type: int, raw: bytes, scalar_type: str) -> float | int | None:
+    """Decode one mapped scalar field into the requested target type."""
+    if wire_type == 0:
+        value, _ = _read_varint(memoryview(raw), 0)
+        return float(value) if scalar_type == _TYPE_FLOAT else int(value)
+
+    if wire_type == 5:
+        if len(raw) != 4:
+            return None
+        fval = struct.unpack("<f", raw)[0]
+        return fval if scalar_type == _TYPE_FLOAT else int(round(fval))
+
+    if wire_type == 1:
+        if len(raw) != 8:
+            return None
+        dval = struct.unpack("<d", raw)[0]
+        return dval if scalar_type == _TYPE_FLOAT else int(round(dval))
+
+    return None
+
+
+def _decode_mapped_fields(
+    pdata: bytes,
+    field_map: dict[int, tuple[str, str]],
+) -> dict[str, Any]:
+    """Decode only the mapped fields from a protobuf payload."""
+    result: dict[str, Any] = {}
+    mv = memoryview(pdata)
+    pos = 0
+
+    while pos < len(mv):
+        tag, pos = _read_varint(mv, pos)
+        field_num = tag >> 3
+        wire_type = tag & 0x07
+
+        if wire_type == 0:
+            start = pos
+            _, pos = _read_varint(mv, pos)
+            raw = mv[start:pos].tobytes()
+        elif wire_type == 1:
+            raw = mv[pos:pos + 8].tobytes()
+            pos += 8
+        elif wire_type == 2:
+            length, pos = _read_varint(mv, pos)
+            raw = mv[pos:pos + length].tobytes()
+            pos += length
+        elif wire_type == 5:
+            raw = mv[pos:pos + 4].tobytes()
+            pos += 4
+        else:
+            break
+
+        mapping = field_map.get(field_num)
+        if mapping is None:
+            continue
+
+        sensor_key, scalar_type = mapping
+        value = _decode_scalar(wire_type, raw, scalar_type)
+        if value is not None:
+            result[sensor_key] = value
+
+    return result
+
+
+def _finalize_stream_state(parsed: dict[str, Any]) -> dict[str, Any]:
+    """Normalize mirrored fields and derive convenience sensor values."""
+    result = dict(parsed)
+
+    if "soc_pct" not in result and "soc_precise_pct" in result:
+        result["soc_pct"] = result["soc_precise_pct"]
+
+    if "batt_w" not in result and "_batt_w_negated" in result:
+        result["batt_w"] = -float(result["_batt_w_negated"])
+    if "batt_w" not in result and "_batt_w_inverted" in result:
+        result["batt_w"] = -float(result["_batt_w_inverted"])
+
+    result.pop("_batt_w_negated", None)
+    result.pop("_batt_w_inverted", None)
+    batt_voltage_mv = result.pop("_batt_voltage_mv", None)
+
+    if isinstance(batt_voltage_mv, (int, float)):
+        result["batt_voltage_v"] = float(batt_voltage_mv) / 1000.0
+
+    charge_capacity_mah = result.pop("_batt_charge_capacity_mah_total", None)
+    discharge_capacity_mah = result.pop("_batt_discharge_capacity_mah_total", None)
+    charge_capacity_rounded = result.pop("_batt_charge_capacity_ah_rounded", None)
+
+    if isinstance(charge_capacity_mah, (int, float)):
+        result["batt_charge_capacity_ah"] = float(charge_capacity_mah) / 1000.0
+    elif isinstance(charge_capacity_rounded, (int, float)):
+        result["batt_charge_capacity_ah"] = float(charge_capacity_rounded)
+
+    if isinstance(discharge_capacity_mah, (int, float)):
+        result["batt_discharge_capacity_ah"] = float(discharge_capacity_mah) / 1000.0
+
+    batt_w = result.get("batt_w")
+    if isinstance(batt_w, (int, float)):
+        result["batt_charge_power_w"] = float(batt_w) if batt_w > 0 else 0.0
+        result["batt_discharge_power_w"] = abs(float(batt_w)) if batt_w < 0 else 0.0
+
+    return result
+
+
+def parse_stream_proto_message(payload: bytes) -> dict[str, Any] | None:
+    """Parse a Stream protobuf frame into flat sensor keys."""
+    try:
+        headers, _ = decode_header_message(payload)
+        if not headers:
+            return None
+
+        merged: dict[str, Any] = {}
+        for header in headers:
+            cmd_key = (int(header.get("cmd_func", -1)), int(header.get("cmd_id", -1)))
+            field_map = _STREAM_FIELD_MAP.get(cmd_key)
+            pdata_hex = header.get("pdata")
+            if field_map is None or not isinstance(pdata_hex, str) or not pdata_hex:
+                continue
+            try:
+                pdata = bytes.fromhex(pdata_hex)
+            except ValueError:
+                continue
+            merged.update(_decode_mapped_fields(pdata, field_map))
+    except Exception:
+        return None
+    if not merged:
+        return None
+
+    finalized = _finalize_stream_state(merged)
+    return finalized or None

--- a/custom_components/ecoflow_energy/ecoflow/parsers/stream_proto.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/stream_proto.py
@@ -1,4 +1,4 @@
-"""Reverse-engineered protobuf parser for EcoFlow Stream devices.
+"""Protobuf telemetry parser for EcoFlow Stream devices.
 
 Current scope targets BK31 (Stream AC Pro) in app-auth MQTT mode.
 Only fields that have been observed repeatedly in live captures are

--- a/custom_components/ecoflow_energy/manifest.json
+++ b/custom_components/ecoflow_energy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/shuette42/ecoflow-energy-ha/issues",
   "requirements": [],
-  "version": "1.14.0"
+  "version": "1.15.0"
 }

--- a/custom_components/ecoflow_energy/number.py
+++ b/custom_components/ecoflow_energy/number.py
@@ -18,12 +18,14 @@ from .const import (
     DEVICE_TYPE_DELTA,
     DEVICE_TYPE_POWEROCEAN,
     DEVICE_TYPE_SMARTPLUG,
+    DEVICE_TYPE_STREAM,
     DOMAIN,
     EcoFlowNumberDef,
     NUMBER_COMMANDS,
     POWEROCEAN_NUMBERS,
     SMARTPLUG_NUMBER_COMMANDS,
     SMARTPLUG_NUMBERS,
+    STREAM_NUMBERS,
 )
 from .coordinator import EcoFlowDeviceCoordinator
 from .ecoflow.parsers.smartplug import (
@@ -120,6 +122,11 @@ class EcoFlowNumber(CoordinatorEntity[EcoFlowDeviceCoordinator], NumberEntity):
         # PowerOcean uses protobuf SET via Enhanced Mode (WSS)
         if self.coordinator.device_type == DEVICE_TYPE_POWEROCEAN:
             await self._async_set_powerocean_value(value)
+            return
+        if self.coordinator.device_type == DEVICE_TYPE_STREAM:
+            ok = await self._async_set_stream_value(self._definition.key, value)
+            if ok:
+                self._apply_optimistic_number(value)
             return
 
         # Smart Plug number commands
@@ -236,6 +243,29 @@ class EcoFlowNumber(CoordinatorEntity[EcoFlowDeviceCoordinator], NumberEntity):
 
         _LOGGER.warning("No PowerOcean SET handler for %s", key)
 
+    async def _async_set_stream_value(self, key: str, value: float) -> bool:
+        """Set a Stream AC Pro number value via app-style JSON SET."""
+        if key != "backup_reserve":
+            _LOGGER.warning(
+                "No Stream SET handler for %s (%s)",
+                key,
+                self.coordinator.device_sn,
+            )
+            return False
+
+        return await self.coordinator.async_send_set_command(
+            {
+                "sn": self.coordinator.device_sn,
+                "cmdId": 17,
+                "cmdFunc": 254,
+                "dirDest": 1,
+                "dirSrc": 1,
+                "dest": 2,
+                "needAck": True,
+                "params": {"cfgBackupReverseSoc": int(value)},
+            }
+        )
+
 
 def _get_number_defs(device_type: str) -> list[EcoFlowNumberDef]:
     """Return number definitions based on device type."""
@@ -245,4 +275,6 @@ def _get_number_defs(device_type: str) -> list[EcoFlowNumberDef]:
         return POWEROCEAN_NUMBERS
     if device_type == DEVICE_TYPE_SMARTPLUG:
         return SMARTPLUG_NUMBERS
+    if device_type == DEVICE_TYPE_STREAM:
+        return STREAM_NUMBERS
     return []

--- a/custom_components/ecoflow_energy/number.py
+++ b/custom_components/ecoflow_energy/number.py
@@ -28,6 +28,7 @@ from .const import (
     STREAM_NUMBERS,
 )
 from .coordinator import EcoFlowDeviceCoordinator
+from .ecoflow.energy_stream import build_stream_backup_reserve_payload
 from .ecoflow.parsers.smartplug import (
     build_plug_brightness_payload,
     build_plug_max_watts_payload,
@@ -244,7 +245,12 @@ class EcoFlowNumber(CoordinatorEntity[EcoFlowDeviceCoordinator], NumberEntity):
         _LOGGER.warning("No PowerOcean SET handler for %s", key)
 
     async def _async_set_stream_value(self, key: str, value: float) -> bool:
-        """Set a Stream AC Pro number value via app-style JSON SET."""
+        """Set a Stream AC Pro number value via WSS Protobuf SET.
+
+        JSON SET does not work on the /app/ WSS topic (SmartPlug proves
+        this). The Backup-Reserve value is sent as a protobuf ConfigWrite
+        frame (cmd_func=254, cmd_id=17).
+        """
         if key != "backup_reserve":
             _LOGGER.warning(
                 "No Stream SET handler for %s (%s)",
@@ -253,17 +259,11 @@ class EcoFlowNumber(CoordinatorEntity[EcoFlowDeviceCoordinator], NumberEntity):
             )
             return False
 
-        return await self.coordinator.async_send_set_command(
-            {
-                "sn": self.coordinator.device_sn,
-                "cmdId": 17,
-                "cmdFunc": 254,
-                "dirDest": 1,
-                "dirSrc": 1,
-                "dest": 2,
-                "needAck": True,
-                "params": {"cfgBackupReverseSoc": int(value)},
-            }
+        payload = build_stream_backup_reserve_payload(
+            int(value), self.coordinator.device_sn
+        )
+        return await self.coordinator.async_send_proto_set_command(
+            payload, label="stream_backup_reserve"
         )
 
 

--- a/custom_components/ecoflow_energy/sensor.py
+++ b/custom_components/ecoflow_energy/sensor.py
@@ -19,11 +19,13 @@ from .const import (
     DEVICE_TYPE_DELTA,
     DEVICE_TYPE_POWEROCEAN,
     DEVICE_TYPE_SMARTPLUG,
+    DEVICE_TYPE_STREAM,
     DOMAIN,
     DELTA2MAX_SENSORS,
     EcoFlowSensorDef,
     POWEROCEAN_SENSORS,
     SMARTPLUG_SENSORS,
+    STREAM_SENSORS,
 )
 from .coordinator import EcoFlowDeviceCoordinator
 
@@ -193,4 +195,6 @@ def _get_sensor_defs(device_type: str) -> list[EcoFlowSensorDef]:
         return POWEROCEAN_SENSORS
     if device_type == DEVICE_TYPE_SMARTPLUG:
         return SMARTPLUG_SENSORS
+    if device_type == DEVICE_TYPE_STREAM:
+        return STREAM_SENSORS
     return []

--- a/custom_components/ecoflow_energy/strings.json
+++ b/custom_components/ecoflow_energy/strings.json
@@ -150,6 +150,9 @@
       "batt_discharge_power_w": {
         "name": "Battery Discharge Power"
       },
+      "batt_design_cap_mah": {
+        "name": "Design Capacity"
+      },
       "grid_import_power_w": {
         "name": "Grid Import Power"
       },

--- a/custom_components/ecoflow_energy/switch.py
+++ b/custom_components/ecoflow_energy/switch.py
@@ -23,10 +23,12 @@ from .const import (
     DELTA_PROFILE_R331,
     DEVICE_TYPE_DELTA,
     DEVICE_TYPE_SMARTPLUG,
+    DEVICE_TYPE_STREAM,
     DOMAIN,
     EcoFlowSwitchDef,
     SMARTPLUG_SWITCH_COMMANDS,
     SMARTPLUG_SWITCHES,
+    STREAM_SWITCHES,
     SWITCH_COMMANDS_R331,
     SWITCH_COMMANDS_R351,
     SWITCH_DECLARATIVE_R331,
@@ -192,6 +194,8 @@ def _get_switch_defs(device_type: str) -> list[EcoFlowSwitchDef]:
         return DELTA2MAX_SWITCHES
     if device_type == DEVICE_TYPE_SMARTPLUG:
         return SMARTPLUG_SWITCHES
+    if device_type == DEVICE_TYPE_STREAM:
+        return STREAM_SWITCHES
     return []
 
 

--- a/custom_components/ecoflow_energy/translations/de.json
+++ b/custom_components/ecoflow_energy/translations/de.json
@@ -150,6 +150,21 @@
       "batt_discharge_power_w": {
         "name": "Batterieentladeleistung"
       },
+      "batt_charge_energy_wh": {
+        "name": "Batterieladeenergie"
+      },
+      "batt_discharge_energy_wh": {
+        "name": "Batterieentladeenergie"
+      },
+      "batt_design_cap_mah": {
+        "name": "Designkapazität"
+      },
+      "batt_charge_capacity_ah": {
+        "name": "Batterieladekapazität"
+      },
+      "batt_discharge_capacity_ah": {
+        "name": "Batterieentladekapazität"
+      },
       "grid_import_power_w": {
         "name": "Netzbezugsleistung"
       },
@@ -356,6 +371,24 @@
           "discharging": "Entladen",
           "charging": "Laden"
         }
+      },
+      "soc_precise_pct": {
+        "name": "Batterie Ladezustand (präzise)"
+      },
+      "ac_voltage_v": {
+        "name": "AC-Spannung"
+      },
+      "ac_frequency_hz": {
+        "name": "AC-Frequenz"
+      },
+      "backup_reserve_pct": {
+        "name": "Backup-Reserve"
+      },
+      "max_charge_soc_pct": {
+        "name": "Max. Lade-SoC"
+      },
+      "min_discharge_soc_pct": {
+        "name": "Min. Entlade-SoC"
       },
       "soc": {
         "name": "Ladezustand"

--- a/custom_components/ecoflow_energy/translations/de.json
+++ b/custom_components/ecoflow_energy/translations/de.json
@@ -151,10 +151,10 @@
         "name": "Batterieentladeleistung"
       },
       "batt_charge_energy_wh": {
-        "name": "Batterieladeenergie"
+        "name": "Batterieladeenergie (Rohwert)"
       },
       "batt_discharge_energy_wh": {
-        "name": "Batterieentladeenergie"
+        "name": "Batterieentladeenergie (Rohwert)"
       },
       "batt_design_cap_mah": {
         "name": "Designkapazität"

--- a/custom_components/ecoflow_energy/translations/en.json
+++ b/custom_components/ecoflow_energy/translations/en.json
@@ -151,10 +151,10 @@
         "name": "Battery Discharge Power"
       },
       "batt_charge_energy_wh": {
-        "name": "Battery Charge Energy"
+        "name": "Battery Charge Energy (Raw)"
       },
       "batt_discharge_energy_wh": {
-        "name": "Battery Discharge Energy"
+        "name": "Battery Discharge Energy (Raw)"
       },
       "batt_design_cap_mah": {
         "name": "Design Capacity"

--- a/custom_components/ecoflow_energy/translations/en.json
+++ b/custom_components/ecoflow_energy/translations/en.json
@@ -150,6 +150,21 @@
       "batt_discharge_power_w": {
         "name": "Battery Discharge Power"
       },
+      "batt_charge_energy_wh": {
+        "name": "Battery Charge Energy"
+      },
+      "batt_discharge_energy_wh": {
+        "name": "Battery Discharge Energy"
+      },
+      "batt_design_cap_mah": {
+        "name": "Design Capacity"
+      },
+      "batt_charge_capacity_ah": {
+        "name": "Battery Charge Capacity"
+      },
+      "batt_discharge_capacity_ah": {
+        "name": "Battery Discharge Capacity"
+      },
       "grid_import_power_w": {
         "name": "Grid Import Power"
       },
@@ -356,6 +371,24 @@
           "discharging": "Discharging",
           "charging": "Charging"
         }
+      },
+      "soc_precise_pct": {
+        "name": "Battery SOC (Precise)"
+      },
+      "ac_voltage_v": {
+        "name": "AC Voltage"
+      },
+      "ac_frequency_hz": {
+        "name": "AC Frequency"
+      },
+      "backup_reserve_pct": {
+        "name": "Backup Reserve"
+      },
+      "max_charge_soc_pct": {
+        "name": "Max Charge SoC"
+      },
+      "min_discharge_soc_pct": {
+        "name": "Min Discharge SoC"
       },
       "soc": {
         "name": "SoC"

--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -44,6 +44,7 @@ from custom_components.ecoflow_energy.const import (  # noqa: E402
     DEVICE_TYPE_DELTA,
     DEVICE_TYPE_POWEROCEAN,
     DEVICE_TYPE_SMARTPLUG,
+    DEVICE_TYPE_STREAM,
     DOMAIN,
     MODE_ENHANCED,
     MODE_STANDARD,
@@ -86,6 +87,14 @@ MOCK_SMARTPLUG_DEVICE: dict[str, Any] = {
     "name": "Smart Plug",
     "product_name": "Smart Plug",
     "device_type": DEVICE_TYPE_SMARTPLUG,
+    "online": 1,
+}
+
+MOCK_STREAM_DEVICE: dict[str, Any] = {
+    "sn": "BK31_TEST_DEVICE",
+    "name": "Stream AC Pro",
+    "product_name": "Stream AC Pro",
+    "device_type": DEVICE_TYPE_STREAM,
     "online": 1,
 }
 

--- a/tests/ha/test_coordinator.py
+++ b/tests/ha/test_coordinator.py
@@ -35,6 +35,7 @@ from custom_components.ecoflow_energy.const import (
     SMARTPLUG_STALE_THRESHOLD_S,
     SOFT_UNAVAILABLE_S,
     STALE_THRESHOLD_S,
+    STREAM_POWER_TO_ENERGY,
 )
 from custom_components.ecoflow_energy.coordinator import (
     DeviceSnapshot,
@@ -2973,6 +2974,40 @@ class TestParseMessageGetReply:
         assert result.get("batt_discharge_power_w") == pytest.approx(304.15, rel=1e-5)
         assert result.get("ac_voltage_v") == pytest.approx(227.8, rel=1e-5)
         assert result.get("ac_frequency_hz") == pytest.approx(49.99, rel=1e-5)
+
+    async def test_stream_coordinator_power_to_energy_mapping(
+        self, hass: HomeAssistant,
+    ) -> None:
+        """A Stream coordinator wires STREAM_POWER_TO_ENERGY (not empty)."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="EcoFlow Energy",
+            data={
+                CONF_AUTH_METHOD: AUTH_METHOD_APP,
+                CONF_MODE: MODE_ENHANCED,
+                CONF_EMAIL: "stream-test@example.invalid",
+                CONF_PASSWORD: "not-a-real-password",
+                CONF_USER_ID: "user123",
+                CONF_DEVICES: [MOCK_STREAM_DEVICE],
+            },
+            unique_id="stream-test@example.invalid",
+        )
+        entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(hass, entry, MOCK_STREAM_DEVICE)
+
+        assert coordinator._power_to_energy == STREAM_POWER_TO_ENERGY
+        assert coordinator._power_to_energy  # not empty
+        # The four Stream power → energy keys must be present.
+        assert coordinator._power_to_energy["solar_w"] == "solar_energy_kwh"
+        assert coordinator._power_to_energy["home_w"] == "home_energy_kwh"
+        assert (
+            coordinator._power_to_energy["batt_charge_power_w"]
+            == "batt_charge_energy_kwh"
+        )
+        assert (
+            coordinator._power_to_energy["batt_discharge_power_w"]
+            == "batt_discharge_energy_kwh"
+        )
 
     async def test_get_reply_empty_quota_map_returns_none(
         self, hass: HomeAssistant, standard_config_entry: MockConfigEntry,

--- a/tests/ha/test_coordinator.py
+++ b/tests/ha/test_coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import struct
 import time
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -44,12 +45,18 @@ from custom_components.ecoflow_energy.ecoflow.parsers.powerocean_proto import (
     remap_bp_keys,
     remap_proto_keys,
 )
+from custom_components.ecoflow_energy.ecoflow.proto_encoding import (
+    encode_field_bytes,
+    encode_field_varint,
+    encode_varint,
+)
 
 from .conftest import (
     MOCK_DELTA_DEVICE,
     MOCK_MQTT_CREDENTIALS,
     MOCK_POWEROCEAN_DEVICE,
     MOCK_SMARTPLUG_DEVICE,
+    MOCK_STREAM_DEVICE,
 )
 
 
@@ -124,6 +131,21 @@ _PROD_TIMELINE_2026_04_20: list[tuple[float, float]] = [
     (857, 490), (862, 560), (865, 580), (867, 600), (873, 580), (878, 560),
     (883, 600), (885, 610), (888, 630), (893, 660), (898, 690),
 ]
+
+
+def _encode_fixed32_field(field_number: int, value: float) -> bytes:
+    """Encode one protobuf fixed32 field for Stream tests."""
+    tag = (field_number << 3) | 5
+    return encode_varint(tag) + struct.pack("<f", value)
+
+
+def _build_proto_frame(cmd_func: int, cmd_id: int, inner: bytes) -> bytes:
+    """Build a minimal EcoFlow header frame for coordinator parser tests."""
+    header = bytearray()
+    header.extend(encode_field_bytes(1, inner))
+    header.extend(encode_field_varint(8, cmd_func))
+    header.extend(encode_field_varint(9, cmd_id))
+    return encode_field_bytes(1, bytes(header))
 
 
 # ===========================================================================
@@ -2912,6 +2934,45 @@ class TestParseMessageGetReply:
         assert result is not None
         assert result.get("power_w") == 150.0  # 1500 / 10 (deciWatt)
         assert result.get("switch_state") == 1
+
+    async def test_stream_proto_get_reply_parsed(
+        self, hass: HomeAssistant,
+    ) -> None:
+        """Stream get_reply protobuf is parsed via the BK31 proto mapper."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="EcoFlow Energy",
+            data={
+                CONF_AUTH_METHOD: AUTH_METHOD_APP,
+                CONF_MODE: MODE_ENHANCED,
+                CONF_EMAIL: "stream-test@example.invalid",
+                CONF_PASSWORD: "not-a-real-password",
+                CONF_USER_ID: "user123",
+                CONF_DEVICES: [MOCK_STREAM_DEVICE],
+            },
+            unique_id="stream-test@example.invalid",
+        )
+        entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(hass, entry, MOCK_STREAM_DEVICE)
+
+        inner = bytearray()
+        inner.extend(encode_field_varint(242, 19))
+        inner.extend(encode_field_varint(461, 20))
+        inner.extend(_encode_fixed32_field(518, -304.15))
+        inner.extend(_encode_fixed32_field(613, 227.8))
+        inner.extend(_encode_fixed32_field(615, 49.99))
+        payload = _build_proto_frame(254, 21, bytes(inner))
+        topic = "/app/user123/BK31_TEST_DEVICE/thing/property/get_reply"
+
+        result = coordinator._parse_message(topic, payload)
+
+        assert result is not None
+        assert result.get("soc_pct") == 19
+        assert result.get("backup_reserve_pct") == 20
+        assert result.get("batt_w") == pytest.approx(-304.15, rel=1e-5)
+        assert result.get("batt_discharge_power_w") == pytest.approx(304.15, rel=1e-5)
+        assert result.get("ac_voltage_v") == pytest.approx(227.8, rel=1e-5)
+        assert result.get("ac_frequency_hz") == pytest.approx(49.99, rel=1e-5)
 
     async def test_get_reply_empty_quota_map_returns_none(
         self, hass: HomeAssistant, standard_config_entry: MockConfigEntry,

--- a/tests/ha/test_entities.py
+++ b/tests/ha/test_entities.py
@@ -18,6 +18,7 @@ from custom_components.ecoflow_energy.const import (
     DEVICE_TYPE_DELTA,
     DEVICE_TYPE_POWEROCEAN,
     DEVICE_TYPE_SMARTPLUG,
+    DEVICE_TYPE_STREAM,
     DOMAIN,
     EcoFlowBinarySensorDef,
     EcoFlowNumberDef,
@@ -26,6 +27,8 @@ from custom_components.ecoflow_energy.const import (
     POWEROCEAN_BINARY_SENSORS,
     POWEROCEAN_SENSORS,
     SMARTPLUG_NUMBERS,
+    STREAM_NUMBERS,
+    STREAM_SENSORS,
 )
 from custom_components.ecoflow_energy.coordinator import EcoFlowDeviceCoordinator
 from custom_components.ecoflow_energy.sensor import (
@@ -51,7 +54,12 @@ from custom_components.ecoflow_energy.number import (
     _get_number_defs,
 )
 
-from .conftest import MOCK_DELTA_DEVICE, MOCK_POWEROCEAN_DEVICE, MOCK_SMARTPLUG_DEVICE
+from .conftest import (
+    MOCK_DELTA_DEVICE,
+    MOCK_POWEROCEAN_DEVICE,
+    MOCK_SMARTPLUG_DEVICE,
+    MOCK_STREAM_DEVICE,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -82,6 +90,9 @@ class TestSensorDefsRouting:
     def test_powerocean_sensors(self):
         assert _get_sensor_defs(DEVICE_TYPE_POWEROCEAN) is POWEROCEAN_SENSORS
 
+    def test_stream_sensors(self) -> None:
+        assert _get_sensor_defs(DEVICE_TYPE_STREAM) is STREAM_SENSORS
+
     def test_unknown_sensors_empty(self):
         assert _get_sensor_defs("unknown") == []
 
@@ -101,6 +112,9 @@ class TestSwitchDefsRouting:
     def test_delta_switches(self):
         assert _get_switch_defs(DEVICE_TYPE_DELTA) is DELTA2MAX_SWITCHES
 
+    def test_stream_switches(self) -> None:
+        assert _get_switch_defs(DEVICE_TYPE_STREAM) == []
+
     def test_powerocean_switches_empty(self):
         assert _get_switch_defs(DEVICE_TYPE_POWEROCEAN) == []
 
@@ -115,6 +129,9 @@ class TestNumberDefsRouting:
     def test_powerocean_numbers(self):
         from custom_components.ecoflow_energy.const import POWEROCEAN_NUMBERS
         assert _get_number_defs(DEVICE_TYPE_POWEROCEAN) is POWEROCEAN_NUMBERS
+
+    def test_stream_numbers(self) -> None:
+        assert _get_number_defs(DEVICE_TYPE_STREAM) is STREAM_NUMBERS
 
 
 # ===========================================================================
@@ -561,7 +578,6 @@ class TestEcoFlowSwitch:
             assert cmd["params"]["minChgSoc"] == 0
             assert cmd["params"]["minDsgSoc"] == 0
 
-
 # ===========================================================================
 # EcoFlowNumber
 # ===========================================================================
@@ -878,6 +894,59 @@ class TestEcoFlowNumber:
             assert cmd["moduleType"] == 5
             assert cmd["operateType"] == "standbyTime"
             assert cmd["params"]["standbyMins"] == 240
+
+    async def test_stream_backup_reserve_set(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Stream backup reserve uses the app-style JSON SET path."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="EcoFlow Energy",
+            data={
+                "auth_method": "app",
+                "mode": "enhanced",
+                "email": "stream-test@example.invalid",
+                "password": "not-a-real-password",
+                "user_id": "user123",
+                "devices": [MOCK_STREAM_DEVICE],
+            },
+            unique_id="stream-test@example.invalid",
+        )
+        entry.add_to_hass(hass)
+        coordinator = _make_coordinator(hass, entry, MOCK_STREAM_DEVICE)
+        coordinator.async_set_updated_data({"backup_reserve_pct": 20})
+
+        defn = EcoFlowNumberDef(
+            key="backup_reserve",
+            name="Backup Reserve",
+            state_key="backup_reserve_pct",
+            unit="%",
+            min_value=3,
+            max_value=95,
+            step=1,
+        )
+        number = EcoFlowNumber(coordinator, defn)
+
+        with (
+            patch.object(coordinator, "async_send_set_command", new_callable=AsyncMock, return_value=True) as mock_cmd,
+            patch.object(number, "async_write_ha_state"),
+        ):
+            await number.async_set_native_value(80.0)
+
+        mock_cmd.assert_awaited_once_with(
+            {
+                "sn": MOCK_STREAM_DEVICE["sn"],
+                "cmdId": 17,
+                "cmdFunc": 254,
+                "dirDest": 1,
+                "dirSrc": 1,
+                "dest": 2,
+                "needAck": True,
+                "params": {"cfgBackupReverseSoc": 80},
+            }
+        )
+        assert coordinator.device_data["backup_reserve_pct"] == 80.0
 
 
 # ===========================================================================

--- a/tests/ha/test_entities.py
+++ b/tests/ha/test_entities.py
@@ -899,7 +899,12 @@ class TestEcoFlowNumber:
         self,
         hass: HomeAssistant,
     ) -> None:
-        """Stream backup reserve uses the app-style JSON SET path."""
+        """Stream backup reserve uses the WSS protobuf SET path.
+
+        JSON SET does not work on the /app/ WSS topic, so the value is sent
+        as a protobuf ConfigWrite frame (cmd_func=254, cmd_id=17, field 102)
+        built by build_stream_backup_reserve_payload.
+        """
         entry = MockConfigEntry(
             domain=DOMAIN,
             title="EcoFlow Energy",
@@ -929,23 +934,28 @@ class TestEcoFlowNumber:
         number = EcoFlowNumber(coordinator, defn)
 
         with (
-            patch.object(coordinator, "async_send_set_command", new_callable=AsyncMock, return_value=True) as mock_cmd,
+            patch.object(coordinator, "async_send_proto_set_command", new_callable=AsyncMock, return_value=True) as mock_cmd,
             patch.object(number, "async_write_ha_state"),
         ):
             await number.async_set_native_value(80.0)
 
-        mock_cmd.assert_awaited_once_with(
-            {
-                "sn": MOCK_STREAM_DEVICE["sn"],
-                "cmdId": 17,
-                "cmdFunc": 254,
-                "dirDest": 1,
-                "dirSrc": 1,
-                "dest": 2,
-                "needAck": True,
-                "params": {"cfgBackupReverseSoc": 80},
-            }
+        mock_cmd.assert_awaited_once()
+        payload, kwargs = mock_cmd.call_args.args[0], mock_cmd.call_args.kwargs
+        assert isinstance(payload, bytes)
+        # The protobuf frame must decode back to the requested value: the
+        # outer envelope carries cmd_func=254 / cmd_id=17 with field 102=80.
+        from custom_components.ecoflow_energy.ecoflow.proto.decoder import (
+            decode_header_message,
         )
+
+        headers, _ = decode_header_message(payload)
+        assert headers, "expected a decodable header frame"
+        header = headers[0]
+        assert int(header["cmd_func"]) == 254
+        assert int(header["cmd_id"]) == 17
+        pdata = bytes.fromhex(header["pdata"])
+        # field 102, wire-type 0 (varint): tag = (102 << 3) | 0 = 816 -> b"\xb0\x06"
+        assert b"\xb0\x06\x50" in pdata  # field 102 = 0x50 = 80
         assert coordinator.device_data["backup_reserve_pct"] == 80.0
 
 

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -292,6 +292,30 @@ class TestStreamEntities:
         keys = _extract_sensor_keys("STREAM_NUMBERS")
         assert keys == ["backup_reserve"]
 
+    def test_only_soc_has_battery_device_class(self) -> None:
+        """Only the primary soc_pct should have device_class='battery'.
+
+        soc_precise_pct and bms_soh_pct are percentages too, but must NOT
+        use device_class='battery' because HA picks battery-class entities
+        for the device header (Issue #32).
+        """
+        battery_sensors = [
+            s for s in STREAM_SENSORS if s.device_class == "battery"
+        ]
+        keys = {s.key for s in battery_sensors}
+        assert keys == {"soc_pct"}, (
+            f"Expected battery device_class only on {{'soc_pct'}}, "
+            f"but found: {keys}"
+        )
+
+    def test_soh_and_precise_soc_no_battery_device_class(self) -> None:
+        """SoH and precise-SoC variants must not have device_class='battery'."""
+        for s in STREAM_SENSORS:
+            if s.key in ("bms_soh_pct", "soc_precise_pct"):
+                assert s.device_class != "battery", (
+                    f"{s.key} has device_class='battery' but is not the primary SoC"
+                )
+
 
 class TestBinarySensors:
     def test_powerocean_binary_sensors(self):

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,5 +1,7 @@
 """Tests for entity definitions in const.py — uniqueness and completeness."""
 
+from __future__ import annotations
+
 import ast
 from pathlib import Path
 
@@ -9,12 +11,16 @@ from ecoflow_energy.const import (
     POWEROCEAN_SENSORS,
     DELTA2MAX_SENSORS,
     SMARTPLUG_SENSORS,
+    STREAM_SENSORS,
+    STREAM_NUMBERS,
     DELTA2MAX_BINARY_SENSORS,
     DELTA2MAX_SWITCHES,
     DELTA2MAX_NUMBERS,
     POWEROCEAN_BINARY_SENSORS,
+    STREAM_SWITCHES,
     SMARTPLUG_SWITCHES,
     SMARTPLUG_NUMBERS,
+    get_device_type,
     get_delta_profile,
 )
 
@@ -38,6 +44,11 @@ class TestDeltaProfileRouting:
         assert get_delta_profile("Delta Pro", "XXXX123456789012") == DELTA_PROFILE_R351
 
 
+class TestDeviceTypeRouting:
+    def test_stream_detected_by_bk31_prefix(self) -> None:
+        assert get_device_type("", "BK31_TEST_DEVICE") == "stream"
+
+
 def _extract_sensor_keys(var_name: str) -> list[str]:
     """Extract sensor keys from a named list variable.
 
@@ -49,10 +60,13 @@ def _extract_sensor_keys(var_name: str) -> list[str]:
         "POWEROCEAN_SENSORS": POWEROCEAN_SENSORS,
         "DELTA2MAX_SENSORS": DELTA2MAX_SENSORS,
         "SMARTPLUG_SENSORS": SMARTPLUG_SENSORS,
+        "STREAM_SENSORS": STREAM_SENSORS,
+        "STREAM_NUMBERS": STREAM_NUMBERS,
         "DELTA2MAX_BINARY_SENSORS": DELTA2MAX_BINARY_SENSORS,
         "DELTA2MAX_SWITCHES": DELTA2MAX_SWITCHES,
         "DELTA2MAX_NUMBERS": DELTA2MAX_NUMBERS,
         "POWEROCEAN_BINARY_SENSORS": POWEROCEAN_BINARY_SENSORS,
+        "STREAM_SWITCHES": STREAM_SWITCHES,
         "SMARTPLUG_SWITCHES": SMARTPLUG_SWITCHES,
         "SMARTPLUG_NUMBERS": SMARTPLUG_NUMBERS,
     }
@@ -249,6 +263,34 @@ class TestSmartPlugEntities:
         keys = _extract_sensor_keys("SMARTPLUG_SWITCHES")
         assert len(keys) == 1
         assert "plug_switch" in keys
+
+
+class TestStreamEntities:
+    def test_sensor_keys_unique(self) -> None:
+        keys = _extract_sensor_keys("STREAM_SENSORS")
+        assert len(keys) >= 10, f"Expected 10+ sensors, got {len(keys)}"
+        assert len(keys) == len(set(keys)), "Duplicate Stream sensor keys"
+
+    def test_core_stream_sensors_exist(self) -> None:
+        keys = _extract_sensor_keys("STREAM_SENSORS")
+        for expected in (
+            "soc_pct",
+            "batt_w",
+            "batt_charge_power_w",
+            "batt_discharge_power_w",
+            "ac_voltage_v",
+            "ac_frequency_hz",
+            "backup_reserve_pct",
+        ):
+            assert expected in keys, f"Missing Stream sensor: {expected}"
+
+    def test_switch_defs_unique(self) -> None:
+        keys = _extract_sensor_keys("STREAM_SWITCHES")
+        assert keys == []
+
+    def test_number_defs_unique(self) -> None:
+        keys = _extract_sensor_keys("STREAM_NUMBERS")
+        assert keys == ["backup_reserve"]
 
 
 class TestBinarySensors:

--- a/tests/test_energy_stream.py
+++ b/tests/test_energy_stream.py
@@ -10,6 +10,7 @@ from ecoflow_energy.ecoflow.energy_stream import (
     build_feed_power_set_payload,
     build_powerocean_soc_set_payload,
     build_soc_limit_set_payload,
+    build_stream_backup_reserve_payload,
     build_work_mode_set_payload,
 )
 from ecoflow_energy.ecoflow.proto_encoding import (
@@ -439,3 +440,114 @@ class TestBackupEventSetPayload:
         # Disabling doesn't require valid window
         payload = build_backup_event_set_payload(False, 0, 0, seq=1)
         assert isinstance(payload, bytes)
+
+
+# ===========================================================================
+# Stream AC Pro Backup-Reserve SET payload (ConfigWrite field 102, cmd_id=17)
+# ===========================================================================
+
+
+class TestStreamBackupReservePayload:
+    """ConfigWrite { cfg_backup_reverse_soc=102 } in a cmd_func=254/cmd_id=17
+    header on the /app/ WSS topic, mirroring the SmartPlug builder."""
+
+    # Dummy SN: 4-char prefix convention, never a real serial.
+    SN = "BK31TESTSN0000000"
+
+    def test_payload_structure(self):
+        payload = build_stream_backup_reserve_payload(50, self.SN, seq=1)
+        assert isinstance(payload, bytes)
+        # Outer wrapper: field 1 (tag=0x0a) length-delimited
+        assert payload[0] == 0x0A
+
+    def test_build_backup_reserve_payload(self):
+        """cmd_func=254 (field 8), cmd_id=17 (field 9), field 102 = 50."""
+        payload = build_stream_backup_reserve_payload(50, self.SN, seq=1)
+        # cmd_func=254 → field 8 tag = (8<<3)|0 = 0x40, value 254 = varint 0xfe 0x01
+        assert b"\x40\xfe\x01" in payload
+        # cmd_id=17 → field 9 tag = (9<<3)|0 = 0x48, value 17 = 0x11
+        assert b"\x48\x11" in payload
+        # cfg_backup_reverse_soc → field 102 tag = (102<<3)|0 = 816
+        #   = varint 0xb0 0x06, value 50 = 0x32
+        assert b"\xb0\x06\x32" in payload
+
+    def test_decodes_via_stream_parser(self):
+        """The Stream proto parser interprets the frame as a backup ack:
+        cmd_func=254/cmd_id=18 path reads field 102 as backup_reserve_pct.
+
+        The builder emits cmd_id=17 (write). To verify field 102 is decoded
+        semantically, re-wrap the inner pdata under the parser's ack header
+        shape and confirm the value round-trips."""
+        # Decode the outer/inner structure the builder produced.
+        from ecoflow_energy.ecoflow.parsers.stream_proto import (
+            parse_stream_proto_message,
+        )
+
+        # Build a parser-recognized ack frame carrying field 102 = 50, using
+        # the same primitives the builder uses. This proves field 102 is the
+        # ConfigWrite SoC slot the parser maps to backup_reserve_pct.
+        inner = encode_field_varint(102, 50)
+        ack_header = bytearray()
+        ack_header.extend(encode_field_bytes(1, inner))
+        ack_header.extend(encode_field_varint(8, 254))
+        ack_header.extend(encode_field_varint(9, 18))
+        frame = encode_field_bytes(1, bytes(ack_header))
+
+        result = parse_stream_proto_message(frame)
+        assert result is not None
+        assert result["backup_reserve_pct"] == 50
+
+    def test_build_backup_reserve_includes_device_sn(self):
+        """device_sn is encoded as field 25 (string) in the header."""
+        payload = build_stream_backup_reserve_payload(50, self.SN, seq=1)
+        # field 25, wire type 2: tag = (25<<3)|2 = 202 = 0xca 0x01,
+        # then length, then ASCII SN
+        assert b"\xca\x01" + bytes([len(self.SN)]) + self.SN.encode("ascii") in payload
+        assert self.SN.encode("ascii") in payload
+
+    def test_field_102_encodes_value(self):
+        """Different backup_soc values encode on field 102."""
+        # backup_soc=80 → field 102 tag 0xb0 0x06, value 80 = 0x50
+        payload = build_stream_backup_reserve_payload(80, self.SN, seq=1)
+        assert b"\xb0\x06\x50" in payload
+
+    def test_zero_value_encoded(self):
+        """backup_soc=0 must still be on the wire (field 102 = 0)."""
+        payload = build_stream_backup_reserve_payload(0, self.SN, seq=1)
+        # field 102 tag 0xb0 0x06, value 0 = 0x00
+        assert b"\xb0\x06\x00" in payload
+
+    def test_need_ack_set(self):
+        """need_ack=1 (field 11, varint) must be present."""
+        payload = build_stream_backup_reserve_payload(50, self.SN, seq=1)
+        # field 11 tag = (11<<3)|0 = 0x58, value 1 = 0x01
+        assert b"\x58\x01" in payload
+
+    def test_src_and_dest_present(self):
+        """src=32 (field 2) and dest=2 (field 3) routing fields present."""
+        payload = build_stream_backup_reserve_payload(50, self.SN, seq=1)
+        # field 2 tag = 0x10, value 32 = 0x20
+        assert b"\x10\x20" in payload
+        # field 3 tag = 0x18, value 2 = 0x02
+        assert b"\x18\x02" in payload
+
+    def test_deterministic_with_fixed_seq(self):
+        p1 = build_stream_backup_reserve_payload(50, self.SN, seq=42)
+        p2 = build_stream_backup_reserve_payload(50, self.SN, seq=42)
+        assert p1 == p2
+
+    def test_different_values_produce_different_payload(self):
+        p1 = build_stream_backup_reserve_payload(50, self.SN, seq=42)
+        p2 = build_stream_backup_reserve_payload(80, self.SN, seq=42)
+        assert p1 != p2
+
+    def test_build_backup_reserve_rejects_out_of_range(self):
+        with pytest.raises(ValueError):
+            build_stream_backup_reserve_payload(150, self.SN)
+        with pytest.raises(ValueError):
+            build_stream_backup_reserve_payload(-1, self.SN)
+
+    def test_boundary_values_allowed(self):
+        for soc in (0, 100):
+            payload = build_stream_backup_reserve_payload(soc, self.SN, seq=1)
+            assert isinstance(payload, bytes)

--- a/tests/test_stream_parser.py
+++ b/tests/test_stream_parser.py
@@ -1,0 +1,120 @@
+"""Tests for the reverse-engineered Stream protobuf parser."""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from ecoflow_energy.ecoflow.parsers.stream_proto import parse_stream_proto_message
+from ecoflow_energy.ecoflow.proto_encoding import (
+    encode_field_bytes,
+    encode_field_varint,
+    encode_varint,
+)
+
+
+def _encode_fixed32_field(field_number: int, value: float) -> bytes:
+    """Encode one protobuf fixed32 field."""
+    tag = (field_number << 3) | 5
+    return encode_varint(tag) + struct.pack("<f", value)
+
+
+def _build_frame(cmd_func: int, cmd_id: int, inner: bytes) -> bytes:
+    """Build a minimal EcoFlow header frame for tests."""
+    header = bytearray()
+    header.extend(encode_field_bytes(1, inner))
+    header.extend(encode_field_varint(8, cmd_func))
+    header.extend(encode_field_varint(9, cmd_id))
+    return encode_field_bytes(1, bytes(header))
+
+
+class TestStreamProtoParser:
+    def test_parse_main_status_frame(self) -> None:
+        inner = bytearray()
+        inner.extend(encode_field_varint(242, 21))
+        inner.extend(encode_field_varint(270, 95))
+        inner.extend(encode_field_varint(271, 15))
+        inner.extend(_encode_fixed32_field(515, 1351.0))
+        inner.extend(_encode_fixed32_field(516, 309.5))
+        inner.extend(_encode_fixed32_field(517, 0.0))
+        inner.extend(encode_field_varint(461, 20))
+        inner.extend(_encode_fixed32_field(518, 1043.4))
+        inner.extend(_encode_fixed32_field(613, 228.4))
+        inner.extend(_encode_fixed32_field(615, 49.98))
+
+        result = parse_stream_proto_message(_build_frame(254, 21, bytes(inner)))
+
+        assert result is not None
+        assert result["soc_pct"] == 21
+        assert result["max_charge_soc_pct"] == 95
+        assert result["min_discharge_soc_pct"] == 15
+        assert result["grid_w"] == pytest.approx(1351.0, rel=1e-5)
+        assert result["home_w"] == pytest.approx(309.5, rel=1e-5)
+        assert result["solar_w"] == 0.0
+        assert result["backup_reserve_pct"] == 20
+        assert result["batt_w"] == pytest.approx(1043.4, rel=1e-5)
+        assert result["batt_charge_power_w"] == pytest.approx(1043.4, rel=1e-5)
+        assert result["batt_discharge_power_w"] == 0.0
+        assert result["ac_voltage_v"] == pytest.approx(228.4, rel=1e-5)
+        assert result["ac_frequency_hz"] == pytest.approx(49.98, rel=1e-5)
+
+    def test_parse_precise_soc_and_backup_ack(self) -> None:
+        precise = _build_frame(32, 50, _encode_fixed32_field(25, 21.6))
+        ack = _build_frame(254, 18, encode_field_varint(102, 80))
+
+        result = parse_stream_proto_message(precise + ack)
+
+        assert result is not None
+        assert result["soc_precise_pct"] == pytest.approx(21.6, rel=1e-5)
+        assert result["soc_pct"] == pytest.approx(21.6, rel=1e-5)
+        assert result["backup_reserve_pct"] == 80
+
+    def test_parse_cumulative_totals_and_battery_details(self) -> None:
+        aux = bytearray()
+        aux.extend(encode_field_varint(7, 20161))
+        aux.extend(encode_field_varint(9, 35))
+        aux.extend(encode_field_varint(11, 100000))
+        aux.extend(encode_field_varint(12, 46317))
+        aux.extend(encode_field_varint(13, 100000))
+        aux.extend(encode_field_varint(15, 100))
+        aux.extend(encode_field_varint(16, 3362))
+        aux.extend(encode_field_varint(17, 3357))
+        aux.extend(encode_field_varint(18, 35))
+        aux.extend(encode_field_varint(19, 33))
+        aux.extend(encode_field_varint(20, 47))
+        aux.extend(_encode_fixed32_field(25, 21.2))
+        aux.extend(encode_field_varint(32, 6))
+        aux.extend(encode_field_varint(50, 5503))
+        aux.extend(encode_field_varint(51, 15270))
+        aux.extend(encode_field_varint(79, 110))
+        aux.extend(encode_field_varint(80, 296))
+
+        result = parse_stream_proto_message(_build_frame(32, 50, bytes(aux)))
+
+        assert result is not None
+        assert result["batt_voltage_v"] == pytest.approx(20.161, rel=1e-5)
+        assert result["batt_temp_c"] == 35
+        assert result["batt_design_cap_mah"] == 100000
+        assert result["batt_remain_cap_mah"] == 46317
+        assert result["batt_full_cap_mah"] == 100000
+        assert result["bms_soh_pct"] == 100
+        assert result["batt_max_cell_vol_mv"] == 3362
+        assert result["batt_min_cell_vol_mv"] == 3357
+        assert result["batt_max_cell_temp_c"] == 35
+        assert result["batt_min_cell_temp_c"] == 33
+        assert result["batt_max_mos_temp_c"] == 47
+        assert result["batt_charge_energy_wh"] == 110
+        assert result["batt_discharge_energy_wh"] == 296
+        assert result["batt_charge_capacity_ah"] == pytest.approx(5.503, rel=1e-5)
+        assert result["batt_discharge_capacity_ah"] == pytest.approx(15.27, rel=1e-5)
+
+    def test_parse_negated_power_fallback(self) -> None:
+        inner = _encode_fixed32_field(992, 304.15)
+
+        result = parse_stream_proto_message(_build_frame(254, 21, inner))
+
+        assert result is not None
+        assert result["batt_w"] == pytest.approx(-304.15, rel=1e-5)
+        assert result["batt_charge_power_w"] == 0.0
+        assert result["batt_discharge_power_w"] == pytest.approx(304.15, rel=1e-5)

--- a/tests/test_stream_parser.py
+++ b/tests/test_stream_parser.py
@@ -1,4 +1,4 @@
-"""Tests for the reverse-engineered Stream protobuf parser."""
+"""Tests for the Stream protobuf telemetry parser."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Related Issue

Adresses #71 but for Stream AC Pro.

## Summary

Adds initial Enhanced Mode support for EcoFlow Stream AC Pro (BK31), including device detection, protobuf telemetry parsing, Stream sensor entities, and a Backup Reserve number control.

## Changes

- Added Stream AC Pro device type detection by product name and BK31 serial prefix.
- Added conservative Stream protobuf parser for observed telemetry fields.
- Added Stream sensor and number entity definitions with English/German translations.
- Added Enhanced Mode MQTT parsing and Backup Reserve SET support.
- Added tests for device routing, parser behavior, entities, and coordinator parsing.
- Updated README and CHANGELOG.

## Checklist

- [x] Tests pass (`pytest`)
- [x] CHANGELOG.md updated
- [x] Version bumped in `manifest.json` (if code change)
- [x] README updated (if new sensors, features, or behavior changes)
- [x] No secrets or real device serial numbers in code

## Transparency

I used GPT for finding and deciphering protobuf.
I also cross checked with tolwi/hassio-ecoflow-cloud who has implemented already sensors in HA for BK31.