### PR TITLE
feat(stream): add AC Pro read-only telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.16.0] - 2026-06-14
+
+### Added
+- Stream AC Pro read-only telemetry for individual AC outlet state and power, LED brightness diagnostics, and signed AC grid connection power matching the EcoFlow app "Netz-Anschluss" value.
+
+### Changed
+- Stream AC Pro is now modeled as an AC-coupled battery: battery charge/discharge energy stays enabled for the Energy Dashboard, while meter-dependent solar/home values remain disabled diagnostics unless an EcoFlow-compatible meter is paired in the app.
+- Ah battery capacity counters are disabled diagnostic entities.
+
+### Removed
+- Removed unconfirmed experimental write paths for Stream AC Pro AC outlets and LED brightness.
+- Removed raw Wh battery-energy entities in favor of the kWh battery charge/discharge energy sensors.
+
 ## [1.15.0] - 2026-06-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ Download the [latest release](https://github.com/shuette42/ecoflow-energy-ha/rel
 
 **Upgrading?** See [CHANGELOG.md](CHANGELOG.md) for migration notes. Most upgrades are seamless. v1.13.0 removes the legacy `min_discharge_soc` PowerOcean entity (replaced by `backup_reserve`); after upgrading you may see it as "unavailable" in HA - safe to delete via Settings > Devices & services > Entities.
 
-For Stream AC Pro, old experimental outlet switches and raw Wh battery-energy entities may remain in Home Assistant's entity registry after upgrading. They are safe to delete if shown as unavailable or duplicated; use the kWh Battery Charge Energy and Battery Discharge Energy sensors for the Energy Dashboard.
+**Upgrading a Stream AC Pro from v1.15.0?** Two things changed:
+- Old experimental outlet switches and raw Wh battery-energy entities may remain in the entity registry. They are safe to delete if shown as unavailable or duplicated; use the kWh Battery Charge Energy and Battery Discharge Energy sensors for the Energy Dashboard.
+- Solar Power, Home Power, and Grid Power are now meter-dependent diagnostics, disabled by default for new installs. Existing installs keep them enabled, so nothing disappears. If your Stream has no EcoFlow-paired meter these report unreliable values and can be disabled under Settings > Devices & services > Entities.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 | **PowerOcean** — Home Battery | 202 | 2 numbers, 1 select (Enhanced only) | 6 (solar, grid, battery, home) | ~30 s standard / ~3 s enhanced |
 | **Delta 2 Max** — Portable Power | 94 | 7 switches, 8 numbers | 4 (solar 1+2, AC in/out) | ~30 s standard / ~2 s enhanced |
 | **Smart Plug** — Switchable Outlet | 11 | 1 switch, 2 numbers | 1 (total energy) | ~30 s standard / ~3 s enhanced |
-| **Stream AC Pro** — Home Battery | 33 | 1 number (Enhanced only) | 4 (solar, home, battery charge/discharge) | Enhanced only / ~3 s |
+| **Stream AC Pro** — AC-coupled Battery | 39 + 2 binary | 1 number (Enhanced only) | 2 default (battery charge/discharge), 2 optional diagnostic (solar/home) | Enhanced only / ~3 s |
 
 > **Tip:** Other Delta-series devices (Delta Pro, Delta 2, etc.) should work automatically with the Delta sensor set.
 
@@ -78,9 +78,11 @@ Power (W), current (A), voltage (V), frequency, temperature · Plug on/off switc
 </details>
 
 <details>
-<summary><b>Stream AC Pro</b> — battery telemetry and reserve control</summary>
+<summary><b>Stream AC Pro</b> — AC-coupled battery telemetry and reserve control</summary>
 
-Battery SoC/SoH · solar, home, grid, and battery power · battery charge/discharge power · AC voltage and frequency · battery temperature, capacity, cell voltage, and lifetime charge/discharge diagnostics · **Number:** Backup Reserve (3-95%) in Enhanced Mode.
+Battery SoC/SoH · signed battery power · battery charge/discharge power · signed AC grid connection power ("Netz-Anschluss": negative=input, positive=output/feed-in) · read-only AC outlet states and outlet power · AC voltage and frequency · battery temperature, capacity and cell voltage diagnostics · LED brightness diagnostics · **Number:** Backup Reserve (3-95%) in Enhanced Mode.
+
+The Stream AC Pro is treated as an AC-coupled battery. House/grid/solar flow values depend on an EcoFlow-paired meter and are disabled by default as diagnostic entities. Individual AC outlets and LED brightness are exposed read-only; the app write path is not yet confirmed for third-party MQTT control.
 
 </details>
 
@@ -120,6 +122,8 @@ Download the [latest release](https://github.com/shuette42/ecoflow-energy-ha/rel
 **Enhanced Mode** connects with your EcoFlow email and password. No Developer API keys needed. Faster updates, but this is an unofficial, community-driven protocol that may change without notice.
 
 **Upgrading?** See [CHANGELOG.md](CHANGELOG.md) for migration notes. Most upgrades are seamless. v1.13.0 removes the legacy `min_discharge_soc` PowerOcean entity (replaced by `backup_reserve`); after upgrading you may see it as "unavailable" in HA - safe to delete via Settings > Devices & services > Entities.
+
+For Stream AC Pro, old experimental outlet switches and raw Wh battery-energy entities may remain in Home Assistant's entity registry after upgrading. They are safe to delete if shown as unavailable or duplicated; use the kWh Battery Charge Energy and Battery Discharge Energy sensors for the Energy Dashboard.
 
 ---
 
@@ -163,6 +167,18 @@ All energy sensors are pre-configured (`state_class: total_increasing`) — just
 | Individual device | **Energy** (kWh) |
 
 Add under **Energy > Individual Devices**.
+
+</details>
+
+<details>
+<summary><b>Stream AC Pro</b> — AC-coupled Battery</summary>
+
+| Dashboard Section | Sensor |
+|:---|:---|
+| Battery charge | **Battery Charge Energy** (kWh) |
+| Battery discharge | **Battery Discharge Energy** (kWh) |
+
+Solar and home energy sensors exist as diagnostics but are disabled by default because the Stream AC Pro only reports meaningful home/grid/solar flow values when an EcoFlow-compatible meter is paired in the app. For normal AC-coupled battery use, select the two battery energy sensors above.
 
 </details>
 

--- a/custom_components/ecoflow_energy/binary_sensor.py
+++ b/custom_components/ecoflow_energy/binary_sensor.py
@@ -18,10 +18,12 @@ from .const import (
     DEVICE_TYPE_DELTA,
     DEVICE_TYPE_POWEROCEAN,
     DEVICE_TYPE_SMARTPLUG,
+    DEVICE_TYPE_STREAM,
     DOMAIN,
     EcoFlowBinarySensorDef,
     POWEROCEAN_BINARY_SENSORS,
     SMARTPLUG_BINARY_SENSORS,
+    STREAM_BINARY_SENSORS,
 )
 from .coordinator import EcoFlowDeviceCoordinator
 
@@ -120,4 +122,6 @@ def _get_binary_sensor_defs(
         return POWEROCEAN_BINARY_SENSORS
     if device_type == DEVICE_TYPE_SMARTPLUG:
         return SMARTPLUG_BINARY_SENSORS
+    if device_type == DEVICE_TYPE_STREAM:
+        return STREAM_BINARY_SENSORS
     return []

--- a/custom_components/ecoflow_energy/const.py
+++ b/custom_components/ecoflow_energy/const.py
@@ -522,6 +522,11 @@ SMARTPLUG_SWITCHES: list[EcoFlowSwitchDef] = [
     EcoFlowSwitchDef("plug_switch", "Plug", "switch_state", "mdi:power-plug"),
 ]
 
+STREAM_BINARY_SENSORS: list[EcoFlowBinarySensorDef] = [
+    EcoFlowBinarySensorDef("ac_outlet_1_enabled", "AC Outlet 1", "power", "mdi:power-socket-eu"),
+    EcoFlowBinarySensorDef("ac_outlet_2_enabled", "AC Outlet 2", "power", "mdi:power-socket-eu"),
+]
+
 STREAM_SWITCHES: list[EcoFlowSwitchDef] = []
 
 SMARTPLUG_NUMBERS: list[EcoFlowNumberDef] = [
@@ -541,26 +546,32 @@ STREAM_NUMBERS: list[EcoFlowNumberDef] = [
 STREAM_SENSORS: list[EcoFlowSensorDef] = [
     EcoFlowSensorDef("soc_pct", "Battery SOC", "%", "battery", "measurement", "mdi:battery", suggested_display_precision=0),
     EcoFlowSensorDef("soc_precise_pct", "Battery SOC (Precise)", "%", None, "measurement", "mdi:battery-sync", "diagnostic", suggested_display_precision=1, disabled_by_default=True),
-    EcoFlowSensorDef("solar_w", "Solar Power", "W", "power", "measurement", "mdi:solar-power", suggested_display_precision=0),
-    EcoFlowSensorDef("home_w", "Home Power", "W", "power", "measurement", "mdi:home-lightning-bolt", suggested_display_precision=0),
-    EcoFlowSensorDef("grid_w", "Grid Power", "W", "power", "measurement", "mdi:transmission-tower", suggested_display_precision=0),
+    EcoFlowSensorDef("solar_w", "Solar Power", "W", "power", "measurement", "mdi:solar-power", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    EcoFlowSensorDef("home_w", "Home Power", "W", "power", "measurement", "mdi:home-lightning-bolt", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    EcoFlowSensorDef("grid_w", "Grid Power", "W", "power", "measurement", "mdi:transmission-tower", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
     EcoFlowSensorDef("batt_w", "Battery Power", "W", "power", "measurement", "mdi:battery", suggested_display_precision=0),
     EcoFlowSensorDef("batt_charge_power_w", "Battery Charge Power", "W", "power", "measurement", "mdi:battery-charging", suggested_display_precision=0),
     EcoFlowSensorDef("batt_discharge_power_w", "Battery Discharge Power", "W", "power", "measurement", "mdi:battery", suggested_display_precision=0),
-    EcoFlowSensorDef("solar_energy_kwh", "Solar Energy", "kWh", "energy", "total_increasing", "mdi:solar-power", suggested_display_precision=2),
-    EcoFlowSensorDef("home_energy_kwh", "Home Energy", "kWh", "energy", "total_increasing", "mdi:home-lightning-bolt", suggested_display_precision=2),
+    EcoFlowSensorDef("ac_grid_connection_power_w", "AC Grid Connection Power", "W", "power", "measurement", "mdi:transmission-tower", suggested_display_precision=0),
+    EcoFlowSensorDef("solar_energy_kwh", "Solar Energy", "kWh", "energy", "total_increasing", "mdi:solar-power", "diagnostic", suggested_display_precision=2, disabled_by_default=True),
+    EcoFlowSensorDef("home_energy_kwh", "Home Energy", "kWh", "energy", "total_increasing", "mdi:home-lightning-bolt", "diagnostic", suggested_display_precision=2, disabled_by_default=True),
     EcoFlowSensorDef("batt_charge_energy_kwh", "Battery Charge Energy", "kWh", "energy", "total_increasing", "mdi:battery-charging", suggested_display_precision=2),
     EcoFlowSensorDef("batt_discharge_energy_kwh", "Battery Discharge Energy", "kWh", "energy", "total_increasing", "mdi:battery", suggested_display_precision=2),
+    EcoFlowSensorDef("home_from_batt_w", "Home From Battery", "W", "power", "measurement", "mdi:home-battery-outline", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    EcoFlowSensorDef("home_from_grid_w", "Home From Grid", "W", "power", "measurement", "mdi:home-import-outline", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    EcoFlowSensorDef("ac_outlet_1_w", "AC Outlet 1 Power", "W", "power", "measurement", "mdi:power-socket-eu", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    EcoFlowSensorDef("ac_outlet_2_w", "AC Outlet 2 Power", "W", "power", "measurement", "mdi:power-socket-eu", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    EcoFlowSensorDef("led_brightness", "LED Brightness", "%", None, "measurement", "mdi:brightness-6", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    EcoFlowSensorDef("grid_connection_power_w", "Grid Connection Power", "W", "power", "measurement", "mdi:transmission-tower", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    EcoFlowSensorDef("sys_grid_connection_power_w", "System Grid Connection Power", "W", "power", "measurement", "mdi:transmission-tower-export", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
     EcoFlowSensorDef("bms_soh_pct", "Battery SoH", "%", None, "measurement", "mdi:battery-heart-variant", suggested_display_precision=0),
     EcoFlowSensorDef("batt_voltage_v", "Battery Voltage", "V", "voltage", "measurement", "mdi:flash-triangle", suggested_display_precision=1),
     EcoFlowSensorDef("batt_temp_c", "Battery Temp", "\u00b0C", "temperature", "measurement", "mdi:thermometer", suggested_display_precision=1),
-    EcoFlowSensorDef("batt_charge_energy_wh", "Battery Charge Energy (Raw)", "Wh", None, "total_increasing", "mdi:battery-charging", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
-    EcoFlowSensorDef("batt_discharge_energy_wh", "Battery Discharge Energy (Raw)", "Wh", None, "total_increasing", "mdi:battery", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
     EcoFlowSensorDef("batt_design_cap_mah", "Design Capacity", "mAh", None, "measurement", "mdi:battery", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
     EcoFlowSensorDef("batt_remain_cap_mah", "Remaining Capacity", "mAh", None, "measurement", "mdi:battery-50", suggested_display_precision=0, disabled_by_default=True),
     EcoFlowSensorDef("batt_full_cap_mah", "Full Capacity", "mAh", None, "measurement", "mdi:battery", suggested_display_precision=0, disabled_by_default=True),
-    EcoFlowSensorDef("batt_charge_capacity_ah", "Battery Charge Capacity", "Ah", None, "total_increasing", "mdi:battery-plus", suggested_display_precision=2, disabled_by_default=True),
-    EcoFlowSensorDef("batt_discharge_capacity_ah", "Battery Discharge Capacity", "Ah", None, "total_increasing", "mdi:battery-minus", suggested_display_precision=2, disabled_by_default=True),
+    EcoFlowSensorDef("batt_charge_capacity_ah", "Battery Charge Capacity", "Ah", None, "total_increasing", "mdi:battery-plus", "diagnostic", suggested_display_precision=2, disabled_by_default=True),
+    EcoFlowSensorDef("batt_discharge_capacity_ah", "Battery Discharge Capacity", "Ah", None, "total_increasing", "mdi:battery-minus", "diagnostic", suggested_display_precision=2, disabled_by_default=True),
     EcoFlowSensorDef("ac_voltage_v", "AC Voltage", "V", "voltage", "measurement", "mdi:sine-wave", suggested_display_precision=1),
     EcoFlowSensorDef("ac_frequency_hz", "AC Frequency", "Hz", "frequency", "measurement", "mdi:sine-wave", suggested_display_precision=2),
     EcoFlowSensorDef("batt_max_cell_temp_c", "Max Cell Temp", "\u00b0C", "temperature", "measurement", "mdi:thermometer-high", "diagnostic", suggested_display_precision=1, disabled_by_default=True),

--- a/custom_components/ecoflow_energy/ecoflow/parsers/stream_proto.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/stream_proto.py
@@ -25,10 +25,12 @@ Current field notes from dump analysis:
   it may be absent or misleading, and in zero-export setups it can remain
   zero until surplus power would be exported.
 - LED brightness is confirmed separately from battery health:
-  `254/18 field 384` carries the set/ack value and `254/21 field 994`
-  carries the live brightness percentage. `32/50 field 15` stayed at
-  `100` throughout the dedicated LED capture and does not track
-  brightness changes.
+  `254/21 field 994` carries the live brightness percentage and is the
+  only field mapped to `led_brightness`. `254/18 field 384` carries the
+  set/ack (slider target) value and is intentionally not mapped, so the
+  live value never flaps to the slider target on a SET acknowledgement.
+  `32/50 field 15` stayed at `100` throughout the dedicated LED capture
+  and does not track brightness changes.
 """
 
 from __future__ import annotations
@@ -53,7 +55,6 @@ _STREAM_FIELD_MAP: dict[tuple[int, int], dict[int, tuple[str, str]]] = {
         271: ("min_discharge_soc_pct", _TYPE_INT),
         380: ("ac_outlet_1_enabled", _TYPE_INT),
         381: ("ac_outlet_2_enabled", _TYPE_INT),
-        384: ("led_brightness", _TYPE_INT),
         461: ("backup_reserve_pct", _TYPE_INT),
         # Summed AC intake from grid. Charge-dump correlation:
         # grid_w ~= batt_w + home_from_grid_w.
@@ -68,10 +69,16 @@ _STREAM_FIELD_MAP: dict[tuple[int, int], dict[int, tuple[str, str]]] = {
         613: ("ac_voltage_v", _TYPE_FLOAT),
         615: ("ac_frequency_hz", _TYPE_FLOAT),
         616: ("grid_connection_power_w", _TYPE_FLOAT),
+        # Mirror fields for the AC outlet enable flags. They carry the same
+        # on/off semantics as 380/381; whichever appears last in the frame
+        # wins, which is harmless because both encode the same boolean state.
         980: ("ac_outlet_1_enabled", _TYPE_INT),
         982: ("ac_outlet_2_enabled", _TYPE_INT),
-        994: ("led_brightness", _TYPE_INT),
         992: ("sys_grid_connection_power_w", _TYPE_FLOAT),
+        # Live LED brightness percentage. The set/ack value (field 384) is
+        # intentionally NOT mapped to the same key: it carries the slider
+        # target rather than the live value and would otherwise flap with 994.
+        994: ("led_brightness", _TYPE_INT),
         1003: ("home_from_batt_w", _TYPE_FLOAT),
         # House/system load supplied from grid, excluding battery path.
         1004: ("home_from_grid_w", _TYPE_FLOAT),
@@ -99,14 +106,11 @@ _STREAM_FIELD_MAP: dict[tuple[int, int], dict[int, tuple[str, str]]] = {
         32: ("_batt_charge_capacity_ah_rounded", _TYPE_INT),
         50: ("_batt_charge_capacity_mah_total", _TYPE_INT),
         51: ("_batt_discharge_capacity_mah_total", _TYPE_INT),
-        79: ("batt_charge_energy_wh", _TYPE_INT),
-        80: ("batt_discharge_energy_wh", _TYPE_INT),
     },
     # SET acknowledgement path for backup reserve slider
     (254, 18): {
         380: ("ac_outlet_1_enabled", _TYPE_INT),
         381: ("ac_outlet_2_enabled", _TYPE_INT),
-        384: ("led_brightness", _TYPE_INT),
         102: ("backup_reserve_pct", _TYPE_INT),
     },
 }
@@ -231,12 +235,11 @@ def _finalize_stream_state(parsed: dict[str, Any]) -> dict[str, Any]:
     if isinstance(batt_w, (int, float)):
         result["batt_charge_power_w"] = float(batt_w) if batt_w > 0 else 0.0
         result["batt_discharge_power_w"] = abs(float(batt_w)) if batt_w < 0 else 0.0
-        if batt_w > 0:
-            result["batt_charge_discharge_state"] = "charging"
-        elif batt_w < 0:
-            result["batt_charge_discharge_state"] = "discharging"
-        else:
-            result["batt_charge_discharge_state"] = "standby"
+        # batt_charge_discharge_state is intentionally NOT set here. The
+        # coordinator pops any parser-provided value and derives the state
+        # from a hysteresis window over batt_w (see _derive_battery_state,
+        # issue #50). Setting it from instantaneous sign would only be used
+        # by unit tests and never reaches the live entity.
 
     return result
 

--- a/custom_components/ecoflow_energy/ecoflow/parsers/stream_proto.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/stream_proto.py
@@ -4,17 +4,44 @@ Current scope targets BK31 (Stream AC Pro) in app-auth MQTT mode.
 Only fields that have been observed repeatedly in live captures are
 mapped here. The parser is intentionally conservative so we can extend
 it safely as more captures become available.
+
+Current field notes from dump analysis:
+- `grid_w` tracks the summed AC grid intake seen in the app "grid
+  connection" view and matches `batt_w + home_from_grid_w` during
+  charging cycles.
+- `ac_grid_connection_power_w` is derived from the signed system grid
+  connection path and matches the app "grid connection" / "Netz-Anschluss"
+  value. It includes battery charging plus AC outlet pass-through load:
+  negative = input from grid, positive = output/feed-in.
+- `batt_w` is the signed battery power path. Most charging/discharging
+  frames line up with real battery behavior, while AC outlet activity is
+  exposed separately via `ac_outlet_1_w` / `ac_outlet_2_w`.
+- `home_w` behaves like the overall active load path. In zero-export
+  discharge captures, `home_w` stays aligned with `abs(batt_w)` while
+  `ac_outlet_1_w` remains a diagnostic breakdown of that total rather
+  than an extra load to add on top.
+- `solar_w` appears to be Smart-Meter/App energy-flow data rather than
+  direct PV production on the AC-coupled battery. Without a paired meter
+  it may be absent or misleading, and in zero-export setups it can remain
+  zero until surplus power would be exported.
+- LED brightness is confirmed separately from battery health:
+  `254/18 field 384` carries the set/ack value and `254/21 field 994`
+  carries the live brightness percentage. `32/50 field 15` stayed at
+  `100` throughout the dedicated LED capture and does not track
+  brightness changes.
 """
 
 from __future__ import annotations
 
 import struct
+from math import isfinite
 from typing import Any
 
 from ..proto.decoder import decode_header_message
 
 _TYPE_INT = "int"
 _TYPE_FLOAT = "float"
+_FLOAT_ZERO_EPS = 1e-6
 
 # cmd_func/cmd_id -> field_number -> (sensor_key, scalar_type)
 _STREAM_FIELD_MAP: dict[tuple[int, int], dict[int, tuple[str, str]]] = {
@@ -24,15 +51,35 @@ _STREAM_FIELD_MAP: dict[tuple[int, int], dict[int, tuple[str, str]]] = {
         262: ("soc_pct", _TYPE_INT),  # mirrored SoC
         270: ("max_charge_soc_pct", _TYPE_INT),
         271: ("min_discharge_soc_pct", _TYPE_INT),
+        380: ("ac_outlet_1_enabled", _TYPE_INT),
+        381: ("ac_outlet_2_enabled", _TYPE_INT),
+        384: ("led_brightness", _TYPE_INT),
         461: ("backup_reserve_pct", _TYPE_INT),
+        # Summed AC intake from grid. Charge-dump correlation:
+        # grid_w ~= batt_w + home_from_grid_w.
         515: ("grid_w", _TYPE_FLOAT),
+        # Overall active load path. Outlet power appears to be included in
+        # this total and is published separately for diagnostics.
         516: ("home_w", _TYPE_FLOAT),
         517: ("solar_w", _TYPE_FLOAT),
+        # Signed battery power path: positive = charging, negative = discharging.
         518: ("batt_w", _TYPE_FLOAT),
+        602: ("_batt_w_fallback", _TYPE_FLOAT),
         613: ("ac_voltage_v", _TYPE_FLOAT),
         615: ("ac_frequency_hz", _TYPE_FLOAT),
-        616: ("_batt_w_inverted", _TYPE_FLOAT),
-        992: ("_batt_w_negated", _TYPE_FLOAT),
+        616: ("grid_connection_power_w", _TYPE_FLOAT),
+        980: ("ac_outlet_1_enabled", _TYPE_INT),
+        982: ("ac_outlet_2_enabled", _TYPE_INT),
+        994: ("led_brightness", _TYPE_INT),
+        992: ("sys_grid_connection_power_w", _TYPE_FLOAT),
+        1003: ("home_from_batt_w", _TYPE_FLOAT),
+        # House/system load supplied from grid, excluding battery path.
+        1004: ("home_from_grid_w", _TYPE_FLOAT),
+        # Confirmed by live load dumps on AC1/AC2 outlets. These values act
+        # as a diagnostic split of the total load path, not an extra load
+        # that should be summed on top of `home_w`.
+        1210: ("ac_outlet_1_w", _TYPE_FLOAT),
+        1211: ("ac_outlet_2_w", _TYPE_FLOAT),
     },
     # Auxiliary status/config frame with a more precise SoC value
     (32, 50): {
@@ -41,6 +88,7 @@ _STREAM_FIELD_MAP: dict[tuple[int, int], dict[int, tuple[str, str]]] = {
         11: ("batt_design_cap_mah", _TYPE_INT),
         12: ("batt_remain_cap_mah", _TYPE_INT),
         13: ("batt_full_cap_mah", _TYPE_INT),
+        # Stable 100 even during a dedicated LED brightness sweep.
         15: ("bms_soh_pct", _TYPE_INT),
         16: ("batt_max_cell_vol_mv", _TYPE_INT),
         17: ("batt_min_cell_vol_mv", _TYPE_INT),
@@ -56,6 +104,9 @@ _STREAM_FIELD_MAP: dict[tuple[int, int], dict[int, tuple[str, str]]] = {
     },
     # SET acknowledgement path for backup reserve slider
     (254, 18): {
+        380: ("ac_outlet_1_enabled", _TYPE_INT),
+        381: ("ac_outlet_2_enabled", _TYPE_INT),
+        384: ("led_brightness", _TYPE_INT),
         102: ("backup_reserve_pct", _TYPE_INT),
     },
 }
@@ -142,16 +193,17 @@ def _finalize_stream_state(parsed: dict[str, Any]) -> dict[str, Any]:
     """Normalize mirrored fields and derive convenience sensor values."""
     result = dict(parsed)
 
+    for key, value in list(result.items()):
+        if isinstance(value, float) and isfinite(value) and abs(value) < _FLOAT_ZERO_EPS:
+            result[key] = 0.0
+
     if "soc_pct" not in result and "soc_precise_pct" in result:
         result["soc_pct"] = result["soc_precise_pct"]
 
-    if "batt_w" not in result and "_batt_w_negated" in result:
-        result["batt_w"] = -float(result["_batt_w_negated"])
-    if "batt_w" not in result and "_batt_w_inverted" in result:
-        result["batt_w"] = -float(result["_batt_w_inverted"])
+    if "batt_w" not in result and "_batt_w_fallback" in result:
+        result["batt_w"] = float(result["_batt_w_fallback"])
 
-    result.pop("_batt_w_negated", None)
-    result.pop("_batt_w_inverted", None)
+    result.pop("_batt_w_fallback", None)
     batt_voltage_mv = result.pop("_batt_voltage_mv", None)
 
     if isinstance(batt_voltage_mv, (int, float)):
@@ -169,10 +221,22 @@ def _finalize_stream_state(parsed: dict[str, Any]) -> dict[str, Any]:
     if isinstance(discharge_capacity_mah, (int, float)):
         result["batt_discharge_capacity_ah"] = float(discharge_capacity_mah) / 1000.0
 
+    grid_connection = result.get("sys_grid_connection_power_w")
+    if not isinstance(grid_connection, (int, float)):
+        grid_connection = result.get("grid_connection_power_w")
+    if isinstance(grid_connection, (int, float)):
+        result["ac_grid_connection_power_w"] = float(grid_connection)
+
     batt_w = result.get("batt_w")
     if isinstance(batt_w, (int, float)):
         result["batt_charge_power_w"] = float(batt_w) if batt_w > 0 else 0.0
         result["batt_discharge_power_w"] = abs(float(batt_w)) if batt_w < 0 else 0.0
+        if batt_w > 0:
+            result["batt_charge_discharge_state"] = "charging"
+        elif batt_w < 0:
+            result["batt_charge_discharge_state"] = "discharging"
+        else:
+            result["batt_charge_discharge_state"] = "standby"
 
     return result
 

--- a/custom_components/ecoflow_energy/manifest.json
+++ b/custom_components/ecoflow_energy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/shuette42/ecoflow-energy-ha/issues",
   "requirements": [],
-  "version": "1.15.0"
+  "version": "1.16.0"
 }

--- a/custom_components/ecoflow_energy/number.py
+++ b/custom_components/ecoflow_energy/number.py
@@ -248,23 +248,22 @@ class EcoFlowNumber(CoordinatorEntity[EcoFlowDeviceCoordinator], NumberEntity):
         """Set a Stream AC Pro number value via WSS Protobuf SET.
 
         JSON SET does not work on the /app/ WSS topic (SmartPlug proves
-        this). The Backup-Reserve value is sent as a protobuf ConfigWrite
-        frame (cmd_func=254, cmd_id=17).
+        this). Stream numbers are sent as protobuf ConfigWrite frames.
         """
-        if key != "backup_reserve":
-            _LOGGER.warning(
-                "No Stream SET handler for %s (%s)",
-                key,
-                self.coordinator.device_sn,
+        if key == "backup_reserve":
+            payload = build_stream_backup_reserve_payload(
+                int(value), self.coordinator.device_sn
             )
-            return False
+            return await self.coordinator.async_send_proto_set_command(
+                payload, label="stream_backup_reserve"
+            )
 
-        payload = build_stream_backup_reserve_payload(
-            int(value), self.coordinator.device_sn
+        _LOGGER.warning(
+            "No Stream SET handler for %s (%s)",
+            key,
+            self.coordinator.device_sn,
         )
-        return await self.coordinator.async_send_proto_set_command(
-            payload, label="stream_backup_reserve"
-        )
+        return False
 
 
 def _get_number_defs(device_type: str) -> list[EcoFlowNumberDef]:

--- a/custom_components/ecoflow_energy/strings.json
+++ b/custom_components/ecoflow_energy/strings.json
@@ -150,6 +150,27 @@
       "batt_discharge_power_w": {
         "name": "Battery Discharge Power"
       },
+      "ac_grid_connection_power_w": {
+        "name": "AC Grid Connection Power"
+      },
+      "home_from_batt_w": {
+        "name": "Home From Battery"
+      },
+      "home_from_grid_w": {
+        "name": "Home From Grid"
+      },
+      "ac_outlet_1_w": {
+        "name": "AC Outlet 1 Power"
+      },
+      "ac_outlet_2_w": {
+        "name": "AC Outlet 2 Power"
+      },
+      "grid_connection_power_w": {
+        "name": "Grid Connection Power"
+      },
+      "sys_grid_connection_power_w": {
+        "name": "System Grid Connection Power"
+      },
       "batt_design_cap_mah": {
         "name": "Design Capacity"
       },
@@ -1156,6 +1177,12 @@
       },
       "switch_state": {
         "name": "Relay"
+      },
+      "ac_outlet_1_enabled": {
+        "name": "AC Outlet 1"
+      },
+      "ac_outlet_2_enabled": {
+        "name": "AC Outlet 2"
       }
     },
     "switch": {

--- a/custom_components/ecoflow_energy/translations/de.json
+++ b/custom_components/ecoflow_energy/translations/de.json
@@ -150,11 +150,26 @@
       "batt_discharge_power_w": {
         "name": "Batterieentladeleistung"
       },
-      "batt_charge_energy_wh": {
-        "name": "Batterieladeenergie (Rohwert)"
+      "ac_grid_connection_power_w": {
+        "name": "AC-Netzanschlussleistung"
       },
-      "batt_discharge_energy_wh": {
-        "name": "Batterieentladeenergie (Rohwert)"
+      "home_from_batt_w": {
+        "name": "Hausverbrauch aus Batterie"
+      },
+      "home_from_grid_w": {
+        "name": "Hausverbrauch aus Netz"
+      },
+      "ac_outlet_1_w": {
+        "name": "AC-Ausgang 1 Leistung"
+      },
+      "ac_outlet_2_w": {
+        "name": "AC-Ausgang 2 Leistung"
+      },
+      "grid_connection_power_w": {
+        "name": "Netzanschlussleistung"
+      },
+      "sys_grid_connection_power_w": {
+        "name": "System-Netzanschlussleistung"
       },
       "batt_design_cap_mah": {
         "name": "Designkapazität"
@@ -1186,6 +1201,12 @@
       },
       "switch_state": {
         "name": "Relais"
+      },
+      "ac_outlet_1_enabled": {
+        "name": "AC-Ausgang 1"
+      },
+      "ac_outlet_2_enabled": {
+        "name": "AC-Ausgang 2"
       }
     },
     "switch": {

--- a/custom_components/ecoflow_energy/translations/en.json
+++ b/custom_components/ecoflow_energy/translations/en.json
@@ -150,11 +150,26 @@
       "batt_discharge_power_w": {
         "name": "Battery Discharge Power"
       },
-      "batt_charge_energy_wh": {
-        "name": "Battery Charge Energy (Raw)"
+      "ac_grid_connection_power_w": {
+        "name": "AC Grid Connection Power"
       },
-      "batt_discharge_energy_wh": {
-        "name": "Battery Discharge Energy (Raw)"
+      "home_from_batt_w": {
+        "name": "Home From Battery"
+      },
+      "home_from_grid_w": {
+        "name": "Home From Grid"
+      },
+      "ac_outlet_1_w": {
+        "name": "AC Outlet 1 Power"
+      },
+      "ac_outlet_2_w": {
+        "name": "AC Outlet 2 Power"
+      },
+      "grid_connection_power_w": {
+        "name": "Grid Connection Power"
+      },
+      "sys_grid_connection_power_w": {
+        "name": "System Grid Connection Power"
       },
       "batt_design_cap_mah": {
         "name": "Design Capacity"
@@ -1186,6 +1201,12 @@
       },
       "switch_state": {
         "name": "Relay"
+      },
+      "ac_outlet_1_enabled": {
+        "name": "AC Outlet 1"
+      },
+      "ac_outlet_2_enabled": {
+        "name": "AC Outlet 2"
       }
     },
     "switch": {

--- a/tests/ha/test_entities.py
+++ b/tests/ha/test_entities.py
@@ -27,6 +27,8 @@ from custom_components.ecoflow_energy.const import (
     POWEROCEAN_BINARY_SENSORS,
     POWEROCEAN_SENSORS,
     SMARTPLUG_NUMBERS,
+    STREAM_BINARY_SENSORS,
+    STREAM_SWITCHES,
     STREAM_NUMBERS,
     STREAM_SENSORS,
 )
@@ -104,6 +106,9 @@ class TestBinarySensorDefsRouting:
     def test_powerocean_binary_sensors(self):
         assert _get_binary_sensor_defs(DEVICE_TYPE_POWEROCEAN) is POWEROCEAN_BINARY_SENSORS
 
+    def test_stream_binary_sensors(self):
+        assert _get_binary_sensor_defs(DEVICE_TYPE_STREAM) is STREAM_BINARY_SENSORS
+
     def test_unknown_binary_sensors_empty(self):
         assert _get_binary_sensor_defs("unknown") == []
 
@@ -113,7 +118,7 @@ class TestSwitchDefsRouting:
         assert _get_switch_defs(DEVICE_TYPE_DELTA) is DELTA2MAX_SWITCHES
 
     def test_stream_switches(self) -> None:
-        assert _get_switch_defs(DEVICE_TYPE_STREAM) == []
+        assert _get_switch_defs(DEVICE_TYPE_STREAM) is STREAM_SWITCHES
 
     def test_powerocean_switches_empty(self):
         assert _get_switch_defs(DEVICE_TYPE_POWEROCEAN) == []
@@ -957,7 +962,6 @@ class TestEcoFlowNumber:
         # field 102, wire-type 0 (varint): tag = (102 << 3) | 0 = 816 -> b"\xb0\x06"
         assert b"\xb0\x06\x50" in pdata  # field 102 = 0x50 = 80
         assert coordinator.device_data["backup_reserve_pct"] == 80.0
-
 
 # ===========================================================================
 # EcoFlowDiagnosticSensor

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -13,6 +13,7 @@ from ecoflow_energy.const import (
     SMARTPLUG_SENSORS,
     STREAM_SENSORS,
     STREAM_NUMBERS,
+    STREAM_BINARY_SENSORS,
     DELTA2MAX_BINARY_SENSORS,
     DELTA2MAX_SWITCHES,
     DELTA2MAX_NUMBERS,
@@ -62,6 +63,7 @@ def _extract_sensor_keys(var_name: str) -> list[str]:
         "SMARTPLUG_SENSORS": SMARTPLUG_SENSORS,
         "STREAM_SENSORS": STREAM_SENSORS,
         "STREAM_NUMBERS": STREAM_NUMBERS,
+        "STREAM_BINARY_SENSORS": STREAM_BINARY_SENSORS,
         "DELTA2MAX_BINARY_SENSORS": DELTA2MAX_BINARY_SENSORS,
         "DELTA2MAX_SWITCHES": DELTA2MAX_SWITCHES,
         "DELTA2MAX_NUMBERS": DELTA2MAX_NUMBERS,
@@ -278,15 +280,43 @@ class TestStreamEntities:
             "batt_w",
             "batt_charge_power_w",
             "batt_discharge_power_w",
+            "ac_grid_connection_power_w",
             "ac_voltage_v",
             "ac_frequency_hz",
             "backup_reserve_pct",
         ):
             assert expected in keys, f"Missing Stream sensor: {expected}"
 
+    def test_meter_dependent_stream_sensors_disabled_by_default(self) -> None:
+        sensors = {sensor.key: sensor for sensor in STREAM_SENSORS}
+        for key in (
+            "solar_w",
+            "home_w",
+            "grid_w",
+            "solar_energy_kwh",
+            "home_energy_kwh",
+        ):
+            assert sensors[key].disabled_by_default is True
+            assert sensors[key].entity_category == "diagnostic"
+
+    def test_stream_raw_battery_energy_not_exposed(self) -> None:
+        keys = _extract_sensor_keys("STREAM_SENSORS")
+        assert "batt_charge_energy_wh" not in keys
+        assert "batt_discharge_energy_wh" not in keys
+
+    def test_stream_battery_capacity_ah_is_diagnostic(self) -> None:
+        sensors = {sensor.key: sensor for sensor in STREAM_SENSORS}
+        for key in ("batt_charge_capacity_ah", "batt_discharge_capacity_ah"):
+            assert sensors[key].disabled_by_default is True
+            assert sensors[key].entity_category == "diagnostic"
+
     def test_switch_defs_unique(self) -> None:
         keys = _extract_sensor_keys("STREAM_SWITCHES")
         assert keys == []
+
+    def test_binary_sensor_defs_unique(self) -> None:
+        keys = _extract_sensor_keys("STREAM_BINARY_SENSORS")
+        assert keys == ["ac_outlet_1_enabled", "ac_outlet_2_enabled"]
 
     def test_number_defs_unique(self) -> None:
         keys = _extract_sensor_keys("STREAM_NUMBERS")

--- a/tests/test_energy_stream.py
+++ b/tests/test_energy_stream.py
@@ -13,7 +13,6 @@ from ecoflow_energy.ecoflow.energy_stream import (
     build_stream_backup_reserve_payload,
     build_work_mode_set_payload,
 )
-from ecoflow_energy.ecoflow.proto.decoder import decode_header_message
 from ecoflow_energy.ecoflow.proto_encoding import (
     encode_field_bytes,
     encode_field_varint,
@@ -221,8 +220,6 @@ class TestPowerOceanSocSetPayload:
         payload = build_powerocean_soc_set_payload(0, 100, seq=1, device_sn=sn)
         assert b"\xca\x01" + bytes([len(sn)]) + sn.encode() in payload
 
-
-class TestPowerOceanSocSetPayloadContinuation:
     def test_device_sn_omitted_when_empty(self):
         sn_marker = b"\xca\x01"
         payload_with_sn = build_powerocean_soc_set_payload(0, 100, seq=1, device_sn="X")

--- a/tests/test_energy_stream.py
+++ b/tests/test_energy_stream.py
@@ -13,6 +13,7 @@ from ecoflow_energy.ecoflow.energy_stream import (
     build_stream_backup_reserve_payload,
     build_work_mode_set_payload,
 )
+from ecoflow_energy.ecoflow.proto.decoder import decode_header_message
 from ecoflow_energy.ecoflow.proto_encoding import (
     encode_field_bytes,
     encode_field_varint,
@@ -220,6 +221,8 @@ class TestPowerOceanSocSetPayload:
         payload = build_powerocean_soc_set_payload(0, 100, seq=1, device_sn=sn)
         assert b"\xca\x01" + bytes([len(sn)]) + sn.encode() in payload
 
+
+class TestPowerOceanSocSetPayloadContinuation:
     def test_device_sn_omitted_when_empty(self):
         sn_marker = b"\xca\x01"
         payload_with_sn = build_powerocean_soc_set_payload(0, 100, seq=1, device_sn="X")

--- a/tests/test_stream_parser.py
+++ b/tests/test_stream_parser.py
@@ -66,7 +66,9 @@ class TestStreamProtoParser:
         assert result["batt_w"] == pytest.approx(1043.4, rel=1e-5)
         assert result["batt_charge_power_w"] == pytest.approx(1043.4, rel=1e-5)
         assert result["batt_discharge_power_w"] == 0.0
-        assert result["batt_charge_discharge_state"] == "charging"
+        # batt_charge_discharge_state is derived by the coordinator (#50),
+        # not by the parser, so it must not appear in parser output.
+        assert "batt_charge_discharge_state" not in result
         assert result["ac_grid_connection_power_w"] == pytest.approx(-2020.0, rel=1e-5)
         assert result["grid_connection_power_w"] == pytest.approx(-967.2, rel=1e-5)
         assert result["sys_grid_connection_power_w"] == pytest.approx(-2020.0, rel=1e-5)
@@ -88,14 +90,30 @@ class TestStreamProtoParser:
         assert result["soc_pct"] == pytest.approx(21.6, rel=1e-5)
         assert result["backup_reserve_pct"] == 80
 
-    def test_parse_led_brightness_live_and_ack(self) -> None:
+    def test_parse_led_brightness_live_only(self) -> None:
+        """Live brightness (994) is mapped; the set/ack slider target (384)
+        is intentionally ignored so it cannot overwrite the live value."""
         live = _build_frame(254, 21, encode_field_varint(994, 50))
         ack = _build_frame(254, 18, encode_field_varint(384, 60))
 
         result = parse_stream_proto_message(live + ack)
 
         assert result is not None
-        assert result["led_brightness"] == 60
+        assert result["led_brightness"] == 50
+
+    def test_parse_led_brightness_ack_field_is_ignored(self) -> None:
+        """A SET acknowledgement frame's slider-target field 384 must not
+        produce a led_brightness value (only the live field 994 does)."""
+        inner = bytearray()
+        inner.extend(encode_field_varint(102, 80))  # backup_reserve ack
+        inner.extend(encode_field_varint(384, 60))  # led brightness target
+        ack = _build_frame(254, 18, bytes(inner))
+
+        result = parse_stream_proto_message(ack)
+
+        assert result is not None
+        assert result["backup_reserve_pct"] == 80
+        assert "led_brightness" not in result
 
     def test_parse_cumulative_totals_battery_details_and_outlet_mirrors(self) -> None:
         aux = bytearray()
@@ -114,8 +132,6 @@ class TestStreamProtoParser:
         aux.extend(encode_field_varint(32, 6))
         aux.extend(encode_field_varint(50, 5503))
         aux.extend(encode_field_varint(51, 15270))
-        aux.extend(encode_field_varint(79, 110))
-        aux.extend(encode_field_varint(80, 296))
 
         mirror = bytearray()
         mirror.extend(encode_field_varint(980, 1))
@@ -139,8 +155,10 @@ class TestStreamProtoParser:
         assert result["batt_max_cell_temp_c"] == 35
         assert result["batt_min_cell_temp_c"] == 33
         assert result["batt_max_mos_temp_c"] == 47
-        assert result["batt_charge_energy_wh"] == 110
-        assert result["batt_discharge_energy_wh"] == 296
+        # Raw Wh battery-energy fields (79/80) are no longer parsed: the
+        # entities were replaced by the kWh charge/discharge energy sensors.
+        assert "batt_charge_energy_wh" not in result
+        assert "batt_discharge_energy_wh" not in result
         assert result["batt_charge_capacity_ah"] == pytest.approx(5.503, rel=1e-5)
         assert result["batt_discharge_capacity_ah"] == pytest.approx(15.27, rel=1e-5)
 
@@ -157,7 +175,10 @@ class TestStreamProtoParser:
         assert result["ac_grid_connection_power_w"] == pytest.approx(304.15, rel=1e-5)
         assert result["sys_grid_connection_power_w"] == pytest.approx(304.15, rel=1e-5)
 
-    def test_parse_zero_battery_power_reports_standby(self):
+    def test_parse_zero_battery_power_splits_to_zero(self):
+        """At zero battery power both charge and discharge splits are 0.
+        State derivation is the coordinator's job, so the parser emits no
+        batt_charge_discharge_state."""
         inner = _encode_fixed32_field(518, 0.0)
 
         result = parse_stream_proto_message(_build_frame(254, 21, inner))
@@ -166,7 +187,7 @@ class TestStreamProtoParser:
         assert result["batt_w"] == 0.0
         assert result["batt_charge_power_w"] == 0.0
         assert result["batt_discharge_power_w"] == 0.0
-        assert result["batt_charge_discharge_state"] == "standby"
+        assert "batt_charge_discharge_state" not in result
 
     def test_parse_tiny_negative_float_is_normalized_to_zero(self):
         inner = bytearray()
@@ -194,3 +215,44 @@ class TestStreamProtoParser:
         assert result is not None
         assert result["ac_outlet_1_w"] == pytest.approx(201.47, rel=1e-5)
         assert result["ac_outlet_2_w"] == pytest.approx(228.18, rel=1e-5)
+
+    def test_parse_batt_w_fallback_field_602(self):
+        """When the primary signed battery power (518) is absent, field 602
+        provides the fallback value (positive sign preserved)."""
+        inner = _encode_fixed32_field(602, 512.5)
+
+        result = parse_stream_proto_message(_build_frame(254, 21, inner))
+
+        assert result is not None
+        assert result["batt_w"] == pytest.approx(512.5, rel=1e-5)
+        assert result["batt_charge_power_w"] == pytest.approx(512.5, rel=1e-5)
+        assert result["batt_discharge_power_w"] == 0.0
+
+    def test_parse_primary_batt_w_wins_over_fallback(self):
+        """If both 518 and 602 are present, the primary signed value (518)
+        takes precedence over the 602 fallback."""
+        inner = bytearray()
+        inner.extend(_encode_fixed32_field(518, -300.0))
+        inner.extend(_encode_fixed32_field(602, 999.0))
+
+        result = parse_stream_proto_message(_build_frame(254, 21, bytes(inner)))
+
+        assert result is not None
+        assert result["batt_w"] == pytest.approx(-300.0, rel=1e-5)
+        assert result["batt_discharge_power_w"] == pytest.approx(300.0, rel=1e-5)
+
+    def test_parse_outlet_enable_primary_and_mirror_same_frame(self):
+        """Fields 380/381 and their mirrors 980/982 may co-occur in one
+        frame. Both encode the same boolean state, so the result is stable
+        regardless of wire order."""
+        inner = bytearray()
+        inner.extend(encode_field_varint(380, 1))
+        inner.extend(encode_field_varint(980, 1))
+        inner.extend(encode_field_varint(381, 0))
+        inner.extend(encode_field_varint(982, 0))
+
+        result = parse_stream_proto_message(_build_frame(254, 21, bytes(inner)))
+
+        assert result is not None
+        assert result["ac_outlet_1_enabled"] == 1
+        assert result["ac_outlet_2_enabled"] == 0

--- a/tests/test_stream_parser.py
+++ b/tests/test_stream_parser.py
@@ -35,11 +35,19 @@ class TestStreamProtoParser:
         inner.extend(encode_field_varint(242, 21))
         inner.extend(encode_field_varint(270, 95))
         inner.extend(encode_field_varint(271, 15))
+        inner.extend(encode_field_varint(380, 1))
+        inner.extend(encode_field_varint(381, 0))
         inner.extend(_encode_fixed32_field(515, 1351.0))
         inner.extend(_encode_fixed32_field(516, 309.5))
         inner.extend(_encode_fixed32_field(517, 0.0))
         inner.extend(encode_field_varint(461, 20))
         inner.extend(_encode_fixed32_field(518, 1043.4))
+        inner.extend(_encode_fixed32_field(616, -967.2))
+        inner.extend(_encode_fixed32_field(992, -2020.0))
+        inner.extend(_encode_fixed32_field(1003, 0.0))
+        inner.extend(_encode_fixed32_field(1004, 309.5))
+        inner.extend(_encode_fixed32_field(1210, 0.0))
+        inner.extend(_encode_fixed32_field(1211, -0.0))
         inner.extend(_encode_fixed32_field(613, 228.4))
         inner.extend(_encode_fixed32_field(615, 49.98))
 
@@ -49,6 +57,8 @@ class TestStreamProtoParser:
         assert result["soc_pct"] == 21
         assert result["max_charge_soc_pct"] == 95
         assert result["min_discharge_soc_pct"] == 15
+        assert result["ac_outlet_1_enabled"] == 1
+        assert result["ac_outlet_2_enabled"] == 0
         assert result["grid_w"] == pytest.approx(1351.0, rel=1e-5)
         assert result["home_w"] == pytest.approx(309.5, rel=1e-5)
         assert result["solar_w"] == 0.0
@@ -56,6 +66,14 @@ class TestStreamProtoParser:
         assert result["batt_w"] == pytest.approx(1043.4, rel=1e-5)
         assert result["batt_charge_power_w"] == pytest.approx(1043.4, rel=1e-5)
         assert result["batt_discharge_power_w"] == 0.0
+        assert result["batt_charge_discharge_state"] == "charging"
+        assert result["ac_grid_connection_power_w"] == pytest.approx(-2020.0, rel=1e-5)
+        assert result["grid_connection_power_w"] == pytest.approx(-967.2, rel=1e-5)
+        assert result["sys_grid_connection_power_w"] == pytest.approx(-2020.0, rel=1e-5)
+        assert result["home_from_batt_w"] == 0.0
+        assert result["home_from_grid_w"] == pytest.approx(309.5, rel=1e-5)
+        assert result["ac_outlet_1_w"] == 0.0
+        assert result["ac_outlet_2_w"] == 0.0
         assert result["ac_voltage_v"] == pytest.approx(228.4, rel=1e-5)
         assert result["ac_frequency_hz"] == pytest.approx(49.98, rel=1e-5)
 
@@ -70,7 +88,16 @@ class TestStreamProtoParser:
         assert result["soc_pct"] == pytest.approx(21.6, rel=1e-5)
         assert result["backup_reserve_pct"] == 80
 
-    def test_parse_cumulative_totals_and_battery_details(self) -> None:
+    def test_parse_led_brightness_live_and_ack(self) -> None:
+        live = _build_frame(254, 21, encode_field_varint(994, 50))
+        ack = _build_frame(254, 18, encode_field_varint(384, 60))
+
+        result = parse_stream_proto_message(live + ack)
+
+        assert result is not None
+        assert result["led_brightness"] == 60
+
+    def test_parse_cumulative_totals_battery_details_and_outlet_mirrors(self) -> None:
         aux = bytearray()
         aux.extend(encode_field_varint(7, 20161))
         aux.extend(encode_field_varint(9, 35))
@@ -90,9 +117,17 @@ class TestStreamProtoParser:
         aux.extend(encode_field_varint(79, 110))
         aux.extend(encode_field_varint(80, 296))
 
-        result = parse_stream_proto_message(_build_frame(32, 50, bytes(aux)))
+        mirror = bytearray()
+        mirror.extend(encode_field_varint(980, 1))
+        mirror.extend(encode_field_varint(982, 0))
+
+        result = parse_stream_proto_message(
+            _build_frame(32, 50, bytes(aux)) + _build_frame(254, 21, bytes(mirror))
+        )
 
         assert result is not None
+        assert result["ac_outlet_1_enabled"] == 1
+        assert result["ac_outlet_2_enabled"] == 0
         assert result["batt_voltage_v"] == pytest.approx(20.161, rel=1e-5)
         assert result["batt_temp_c"] == 35
         assert result["batt_design_cap_mah"] == 100000
@@ -109,12 +144,53 @@ class TestStreamProtoParser:
         assert result["batt_charge_capacity_ah"] == pytest.approx(5.503, rel=1e-5)
         assert result["batt_discharge_capacity_ah"] == pytest.approx(15.27, rel=1e-5)
 
-    def test_parse_negated_power_fallback(self) -> None:
+    def test_parse_grid_connection_without_battery_power(self) -> None:
         inner = _encode_fixed32_field(992, 304.15)
 
         result = parse_stream_proto_message(_build_frame(254, 21, inner))
 
         assert result is not None
-        assert result["batt_w"] == pytest.approx(-304.15, rel=1e-5)
+        assert "batt_w" not in result
+        assert "batt_charge_power_w" not in result
+        assert "batt_discharge_power_w" not in result
+        assert "batt_charge_discharge_state" not in result
+        assert result["ac_grid_connection_power_w"] == pytest.approx(304.15, rel=1e-5)
+        assert result["sys_grid_connection_power_w"] == pytest.approx(304.15, rel=1e-5)
+
+    def test_parse_zero_battery_power_reports_standby(self):
+        inner = _encode_fixed32_field(518, 0.0)
+
+        result = parse_stream_proto_message(_build_frame(254, 21, inner))
+
+        assert result is not None
+        assert result["batt_w"] == 0.0
         assert result["batt_charge_power_w"] == 0.0
-        assert result["batt_discharge_power_w"] == pytest.approx(304.15, rel=1e-5)
+        assert result["batt_discharge_power_w"] == 0.0
+        assert result["batt_charge_discharge_state"] == "standby"
+
+    def test_parse_tiny_negative_float_is_normalized_to_zero(self):
+        inner = bytearray()
+        inner.extend(_encode_fixed32_field(992, -0.0))
+        inner.extend(_encode_fixed32_field(1003, -0.0))
+        inner.extend(_encode_fixed32_field(1211, -0.0))
+
+        result = parse_stream_proto_message(_build_frame(254, 21, bytes(inner)))
+
+        assert result is not None
+        assert result["sys_grid_connection_power_w"] == 0.0
+        assert result["home_from_batt_w"] == 0.0
+        assert result["ac_outlet_2_w"] == 0.0
+        assert result["ac_grid_connection_power_w"] == 0.0
+        assert "batt_w" not in result
+        assert "batt_charge_discharge_state" not in result
+
+    def test_parse_confirmed_ac_outlet_power_fields(self):
+        inner = bytearray()
+        inner.extend(_encode_fixed32_field(1210, 201.47))
+        inner.extend(_encode_fixed32_field(1211, 228.18))
+
+        result = parse_stream_proto_message(_build_frame(254, 21, bytes(inner)))
+
+        assert result is not None
+        assert result["ac_outlet_1_w"] == pytest.approx(201.47, rel=1e-5)
+        assert result["ac_outlet_2_w"] == pytest.approx(228.18, rel=1e-5)


### PR DESCRIPTION
## Related Issue

Closes #98 

## Summary

Expose Stream AC Pro AC outlet state and power as read-only entities, add LED brightness diagnostics, and keep unconfirmed outlet/LED write paths out of the integration.

Add signed AC grid connection power for the app Netz-Anschluss value, preserve battery power as the dedicated battery path, and keep meter-dependent solar/home values disabled by default.

Remove raw Wh battery-energy entities, mark Ah capacity counters as disabled diagnostics, and document Stream AC Pro Energy Dashboard and upgrade cleanup guidance.

## Changes

- Add read-only Stream AC Pro AC outlet state and outlet power entities.
- Add LED brightness as a disabled diagnostic read-only sensor.
- Add signed AC grid connection power matching the EcoFlow app Netz-Anschluss value.
- Keep battery power derived from the dedicated battery telemetry path instead of grid connection fallback frames.
- Keep meter-dependent solar/home energy sensors disabled by default as diagnostics.
- Remove raw Wh battery energy entities in favor of kWh charge/discharge energy sensors.
- Mark Ah battery capacity counters as disabled diagnostic entities.
- Update README and CHANGELOG for Stream AC Pro behavior, Energy Dashboard setup, and upgrade cleanup notes.
- Extend Stream parser, entity, translation, and energy tests.

## Checklist

- [x] Tests pass (`pytest`)
- [x] CHANGELOG.md updated
- [x] Version bumped in `manifest.json` (if code change)
- [x] README updated (if new sensors, features, or behavior changes)
- [x] No secrets or real device serial numbers in code

## Transparency 

Used GPT 5.5 for debugging protobuf and vibe coding changes.
Tested with
- Home Assistant OS
- Core 2026.6.3
- Supervisor 2026.06.1
- Operating System 17.3
- Frontend 20260527.6
- on a Raspberry Pi 4