### PR TITLE
chore: consolidate Stream AC Pro into 1.15.0 beta cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.16.0] - 2026-06-14
+## [1.15.0] - 2026-06-14
 
 ### Added
-- Stream AC Pro read-only telemetry for individual AC outlet state and power, LED brightness diagnostics, and signed AC grid connection power matching the EcoFlow app "Netz-Anschluss" value.
+- Initial Stream AC Pro (BK31) support in Enhanced Mode, including device detection, protobuf telemetry parsing, Home Assistant sensor entities, and a Backup Reserve number control. (beta.1)
+- Stream AC Pro Energy Dashboard sensors (battery charge/discharge) derived via Riemann-sum integration from the live power telemetry. (beta.1)
+- Stream AC Pro read-only telemetry for individual AC outlet state and power, LED brightness diagnostics, and signed AC grid connection power matching the EcoFlow app "Netz-Anschluss" value. (beta.2)
 
 ### Changed
-- Stream AC Pro is now modeled as an AC-coupled battery: battery charge/discharge energy stays enabled for the Energy Dashboard, while meter-dependent solar/home values remain disabled diagnostics unless an EcoFlow-compatible meter is paired in the app.
-- Ah battery capacity counters are disabled diagnostic entities.
+- Stream AC Pro is now modeled as an AC-coupled battery: battery charge/discharge energy stays enabled for the Energy Dashboard, while meter-dependent solar/home values remain disabled diagnostics unless an EcoFlow-compatible meter is paired in the app. (beta.2)
+- Ah battery capacity counters are disabled diagnostic entities. (beta.2)
 
 ### Removed
-- Removed unconfirmed experimental write paths for Stream AC Pro AC outlets and LED brightness.
-- Removed raw Wh battery-energy entities in favor of the kWh battery charge/discharge energy sensors.
-
-## [1.15.0] - 2026-06-12
-
-### Added
-- Initial Stream AC Pro (BK31) support in Enhanced Mode, including device detection, protobuf telemetry parsing, Home Assistant sensor entities, and a Backup Reserve number control.
-- Stream AC Pro Energy Dashboard sensors (solar, home, battery charge/discharge) derived via Riemann-sum integration from the live power telemetry.
+- Removed unconfirmed experimental write paths for Stream AC Pro AC outlets and LED brightness. (beta.2)
+- Removed raw Wh battery-energy entities in favor of the kWh battery charge/discharge energy sensors. (beta.2)
 
 ## [1.14.0] - 2026-05-18
 

--- a/custom_components/ecoflow_energy/manifest.json
+++ b/custom_components/ecoflow_energy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/shuette42/ecoflow-energy-ha/issues",
   "requirements": [],
-  "version": "1.16.0"
+  "version": "1.15.0"
 }


### PR DESCRIPTION
Roll the manifest version back from 1.16.0 to 1.15.0 and merge the changelog entries into the existing 1.15.0 block.

No 1.15.0 full release exists yet, so the Stream AC Pro telemetry work belongs in the same beta cycle (beta.1 initial support, beta.2 outlet telemetry) rather than a new minor. Version and changelog only, no code change.