### PR TITLE
feat: add Delta 3 Max Plus controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 - Stream AC Pro Energy Dashboard sensors (battery charge/discharge) derived via Riemann-sum integration from the live power telemetry. (beta.1)
 - Stream AC Pro read-only telemetry for individual AC outlet state and power, LED brightness diagnostics, and signed AC grid connection power matching the EcoFlow app "Netz-Anschluss" value. (beta.2)
 - Initial read-only support for the Delta 3 Max Plus (D3M1) in Standard mode: sensors for battery state of charge, input and output power, AC, solar and USB port power, charge/discharge state, remaining charge and discharge times, and SoC limits, with German and English translations. All field mappings, value scaling and the charge/discharge states were checked against a Delta 3 Max Plus across idle, discharge, bypass and charge operation. Raw quota diagnostics remain available to help extend the mapping to other Delta 3 models. (beta.4)
+- Delta 3 Max Plus controls. Both AC outputs, the 12 V output, X-Boost, the buzzer, the bypass lock and the backup reserve can now be switched from Home Assistant, and the charge limit, discharge limit and backup reserve level are adjustable. Every command was verified against a Delta 3 Max Plus before release. Controls require Standard mode. (beta.5)
+- Anderson port output power for the Delta 3 Max Plus. (beta.5)
 - Remaining charge and discharge time are now reported only while the battery is actually charging or discharging. The device keeps both values populated at all times and parks the inactive one on a placeholder, which would otherwise show a runtime of over 200 hours on an idle unit. (beta.4)
 
 ### Changed
@@ -16,11 +18,14 @@ All notable changes to this project will be documented in this file.
 - Ah battery capacity counters are disabled diagnostic entities. (beta.2)
 
 ### Fixed
+- Requests carrying boolean values were signed with Python spelling instead of the JSON spelling the server expects, so any such request would have been rejected as having a wrong signature. This had no effect before because no request contained booleans. (beta.5)
 - Stream AC Pro Backup Reserve control now applies to the device. The setting was sent on a command path the device ignored, so changing the slider in Home Assistant had no effect. It now uses the correct backup-reserve config path and the value reaches the device. (beta.3)
 - Delta 3 Max Plus is no longer misrouted to the Delta 2 Max parser, which left all of its entities stuck as `unknown`. Device classification now recognizes the Delta 3 line by product name and serial prefix. (beta.4, Ref #110)
 - Unsupported devices are no longer skipped silently. Setup now emits one clear warning per unsupported device and lists them in a new `skipped_devices` diagnostics section, so a device that produces no entities is visible instead of vanishing without a trace. (beta.4, Ref #100, #111)
 
 ### Removed
+- Removed the read-only Delta 3 Max Plus entities that the new controls replace: the output and setting binary sensors, and the charge limit, discharge limit and backup reserve level sensors. Each of these reported exactly what its switch or slider now shows, so keeping both would have doubled the entity count for no gain. If you already ran beta.4, the old entities stay listed as unavailable until you delete them in Home Assistant. (beta.5)
+- Removed the Delta 3 Max Plus "Main Pack SoC" sensor. The field is not part of the documented device contract and no unit reports it, so the entity could never hold a value. (beta.5)
 - Removed unconfirmed experimental write paths for Stream AC Pro AC outlets and LED brightness. (beta.2)
 - Removed raw Wh battery-energy entities in favor of the kWh battery charge/discharge energy sensors. (beta.2)
 

--- a/custom_components/ecoflow_energy/const.py
+++ b/custom_components/ecoflow_energy/const.py
@@ -588,8 +588,6 @@ STREAM_SENSORS: list[EcoFlowSensorDef] = [
     EcoFlowSensorDef("batt_max_cell_vol_mv", "Max Cell Voltage", "mV", "voltage", "measurement", "mdi:flash-triangle-outline", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
     EcoFlowSensorDef("batt_min_cell_vol_mv", "Min Cell Voltage", "mV", "voltage", "measurement", "mdi:flash-triangle-outline", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
     EcoFlowSensorDef("backup_reserve_pct", "Backup Reserve", "%", None, "measurement", "mdi:battery-lock", "diagnostic", suggested_display_precision=0),
-    EcoFlowSensorDef("max_charge_soc_pct", "Max Charge SoC", "%", None, "measurement", "mdi:battery-charging-100", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
-    EcoFlowSensorDef("min_discharge_soc_pct", "Min Discharge SoC", "%", None, "measurement", "mdi:battery-alert-variant-outline", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
     EcoFlowSensorDef("batt_charge_discharge_state", "Battery Charge/Discharge State", None, "enum", None, "mdi:battery-sync", "diagnostic", disabled_by_default=True, options=["standby", "discharging", "charging"]),
 ]
 
@@ -605,7 +603,6 @@ STREAM_SENSORS: list[EcoFlowSensorDef] = [
 DELTA3_SENSORS: list[EcoFlowSensorDef] = [
     # --- Battery / SoC ---
     EcoFlowSensorDef("cms_batt_soc", "SoC", "%", "battery", "measurement", "mdi:battery", suggested_display_precision=0),
-    EcoFlowSensorDef("bms_batt_soc", "Main Pack SoC", "%", None, "measurement", "mdi:battery-sync", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
     # --- Power (W) ---
     EcoFlowSensorDef("pow_in_sum_w", "Input Total", "W", "power", "measurement", "mdi:flash", suggested_display_precision=0),
     EcoFlowSensorDef("pow_out_sum_w", "Output Total", "W", "power", "measurement", "mdi:flash", suggested_display_precision=0),
@@ -613,6 +610,7 @@ DELTA3_SENSORS: list[EcoFlowSensorDef] = [
     EcoFlowSensorDef("pv1_in_w", "Solar Input 1", "W", "power", "measurement", "mdi:solar-power", suggested_display_precision=0),
     EcoFlowSensorDef("pv2_in_w", "Solar Input 2", "W", "power", "measurement", "mdi:solar-power", suggested_display_precision=0),
     EcoFlowSensorDef("dc_12v_out_w", "12V Output", "W", "power", "measurement", "mdi:car-battery", suggested_display_precision=0),
+    EcoFlowSensorDef("anderson_out_w", "Anderson Output", "W", "power", "measurement", "mdi:power-plug-outline", suggested_display_precision=0),
     EcoFlowSensorDef("ac1_out_w", "AC Output 1", "W", "power", "measurement", "mdi:power-plug-outline", suggested_display_precision=0),
     EcoFlowSensorDef("ac2_out_w", "AC Output 2", "W", "power", "measurement", "mdi:power-plug-outline", suggested_display_precision=0),
     EcoFlowSensorDef("typec1_w", "Type-C 1", "W", "power", "measurement", "mdi:usb-c-port", suggested_display_precision=0),
@@ -628,19 +626,33 @@ DELTA3_SENSORS: list[EcoFlowSensorDef] = [
     # --- SoC limits / backup reserve (diagnostic) ---
     EcoFlowSensorDef("max_charge_soc_pct", "Charge Limit", "%", None, "measurement", "mdi:battery-charging-100", "diagnostic", suggested_display_precision=0),
     EcoFlowSensorDef("min_discharge_soc_pct", "Discharge Limit", "%", None, "measurement", "mdi:battery-alert-variant-outline", "diagnostic", suggested_display_precision=0),
-    EcoFlowSensorDef("backup_reserve_soc_pct", "Backup Reserve Level", "%", None, "measurement", "mdi:battery-lock", "diagnostic", suggested_display_precision=0),
 ]
 
-DELTA3_BINARY_SENSORS: list[EcoFlowBinarySensorDef] = [
-    # --- Output flow states (derived: value != 4 = flowing) ---
-    EcoFlowBinarySensorDef("ac_out_flow", "AC Output Flow", "power", "mdi:power-plug"),
-    EcoFlowBinarySensorDef("ac2_out_flow", "AC Output 2 Flow", "power", "mdi:power-plug"),
-    EcoFlowBinarySensorDef("dc_12v_out_flow", "12V Output Flow", "power", "mdi:car-battery"),
-    # --- Configuration flags (diagnostic) ---
-    EcoFlowBinarySensorDef("backup_reserve_enabled", "Backup Reserve", "power", "mdi:battery-lock", "diagnostic"),
-    EcoFlowBinarySensorDef("xboost_enabled", "X-Boost", "power", "mdi:lightning-bolt", "diagnostic"),
-    EcoFlowBinarySensorDef("beeper_enabled", "Beeper", None, "mdi:volume-high", "diagnostic"),
-    EcoFlowBinarySensorDef("bypass_out_disabled", "Bypass Output Disabled", None, "mdi:transmission-tower-off", "diagnostic", disabled_by_default=True),
+# The Delta 3 controls read back from the same fields a binary sensor would
+# expose, so a read-only twin for every switch would just double the entity
+# count. Kept empty rather than deleted: the platform still asks for a list.
+DELTA3_BINARY_SENSORS: list[EcoFlowBinarySensorDef] = []
+
+# Controls. Every switch reads back from the same field the read-only entity
+# above uses, so the device state stays the single source of truth. The params
+# keys and value ranges are vendor-documented, see
+# docs/reference/ecoflow-api-delta3-max-plus.md
+DELTA3_SWITCHES: list[EcoFlowSwitchDef] = [
+    EcoFlowSwitchDef("ac_out_switch", "AC Output", "ac_out_flow", "mdi:power-plug"),
+    EcoFlowSwitchDef("ac2_out_switch", "AC Output 2", "ac2_out_flow", "mdi:power-plug"),
+    EcoFlowSwitchDef("dc_12v_out_switch", "12V Output", "dc_12v_out_flow", "mdi:car-battery"),
+    EcoFlowSwitchDef("energy_backup_switch", "Backup Reserve", "backup_reserve_enabled", "mdi:battery-lock"),
+    EcoFlowSwitchDef("xboost_switch", "X-Boost", "xboost_enabled", "mdi:lightning-bolt"),
+    EcoFlowSwitchDef("beeper_switch", "Beeper", "beeper_enabled", "mdi:volume-high"),
+    EcoFlowSwitchDef("bypass_out_disable_switch", "Bypass Output Disabled", "bypass_out_disabled", "mdi:transmission-tower-off"),
+]
+
+# Ranges are the vendor's own bounds, not our choice. Backup reserve tops out at
+# 50 and the charge limit cannot go below 50.
+DELTA3_NUMBERS: list[EcoFlowNumberDef] = [
+    EcoFlowNumberDef("backup_reserve_soc", "Backup Reserve Level", "backup_reserve_soc_pct", "%", "mdi:battery-lock", 0, 50, 1),
+    EcoFlowNumberDef("max_charge_soc", "Charge Limit", "max_charge_soc_pct", "%", "mdi:battery-charging-100", 50, 100, 1),
+    EcoFlowNumberDef("min_discharge_soc", "Discharge Limit", "min_discharge_soc_pct", "%", "mdi:battery-alert-variant-outline", 0, 30, 1),
 ]
 
 

--- a/custom_components/ecoflow_energy/coordinator.py
+++ b/custom_components/ecoflow_energy/coordinator.py
@@ -1524,6 +1524,38 @@ class EcoFlowDeviceCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._log_event(f"proto_set_{label}_fail", "")
         return ok
 
+    async def async_send_delta3_set(self, command: dict[str, Any]) -> bool:
+        """Apply a Delta 3 setting over the official HTTP endpoint.
+
+        The Delta 3 write contract is documented and verified for HTTP
+        `PUT /iot-open/sign/device/quota`. The MQTT variant is documented too,
+        but its example spells the source-direction field differently, so the
+        proven path is used here. Standard mode only: app-auth entries have no
+        HTTP client.
+        """
+        if self._http_client is None:
+            _LOGGER.warning(
+                "Cannot apply setting for %s - controls need Standard mode "
+                "(Developer Keys); Enhanced Mode has no HTTP path",
+                self.device_sn,
+            )
+            return False
+
+        result = await self._http_client.set_quota(command)
+        params = command.get("params", {})
+        if result is None:
+            _LOGGER.warning("SET failed for %s: no response", self.device_sn)
+            self._log_event("set_cmd_fail", f"params={list(params)[:3]}")
+            return False
+
+        _LOGGER.debug("SET applied for %s: %s", self.device_sn, params)
+        self._log_event("set_cmd", f"params={list(params)[:3]}")
+        # The device needs a moment before the change shows up in the quota.
+        # The entity holds an optimistic value until then, so a plain refresh
+        # on the next scheduled poll is enough.
+        await self.async_request_refresh()
+        return True
+
     async def async_send_set_command(self, command: dict[str, Any]) -> bool:
         """Send a SET command to the device via MQTT.
 

--- a/custom_components/ecoflow_energy/ecoflow/cloud_http.py
+++ b/custom_components/ecoflow_energy/ecoflow/cloud_http.py
@@ -24,6 +24,7 @@ from .const import (
     HTTP_RETRY_BACKOFF_S,
     IOT_API_BASE,
     IOT_QUOTA_ALL_PATH,
+    IOT_QUOTA_PATH,
     QUOTA_HTTP_MIN_INTERVAL_S,
 )
 
@@ -70,6 +71,17 @@ class EcoFlowHTTPQuota:
 
         return await self._request_with_retry("GET", url, query=query)
 
+    async def set_quota(self, command: dict) -> dict | None:
+        """Apply a device setting via PUT /iot-open/sign/device/quota.
+
+        `command` is the device-specific body without the serial, which is
+        added here. Returns the decoded response, or None when the request
+        could not be delivered.
+        """
+        url = f"{self._base_url}{IOT_QUOTA_PATH}"
+        body = {"sn": self._device_sn, **command}
+        return await self._request_with_retry("PUT", url, body=body)
+
     # ------------------------------------------------------------------
     # Signature
     # ------------------------------------------------------------------
@@ -85,6 +97,11 @@ class EcoFlowHTTPQuota:
             for i, v in enumerate(obj):
                 new_key = f"{parent}[{i}]"
                 items.extend(self._flatten(v, new_key))
+        elif isinstance(obj, bool):
+            # Must be signed the way JSON spells it. str(True) yields "True",
+            # which the server never reconstructs from the body, so the request
+            # would fail with 8521 "signature is wrong".
+            items.append((parent, "true" if obj else "false"))
         else:
             items.append((parent, str(obj)))
         return items
@@ -149,10 +166,14 @@ class EcoFlowHTTPQuota:
                 headers = self._sign_headers(sign_params)
                 timeout = aiohttp.ClientTimeout(total=10)
 
-                if method == "POST":
+                if method in ("POST", "PUT"):
+                    # Content-Type belongs on body requests only. Setting it on
+                    # a GET makes the server validate the signature as if a
+                    # body were present and reject it with 8521.
                     headers["Content-Type"] = "application/json;charset=UTF-8"
                     body_json = json.dumps(body, separators=(",", ":"), ensure_ascii=False)
-                    async with self._session.post(
+                    request = self._session.post if method == "POST" else self._session.put
+                    async with request(
                         url, headers=headers, data=body_json.encode("utf-8"), timeout=timeout,
                     ) as resp:
                         return await self._handle_response(resp)

--- a/custom_components/ecoflow_energy/ecoflow/delta3_commands.py
+++ b/custom_components/ecoflow_energy/ecoflow/delta3_commands.py
@@ -1,0 +1,90 @@
+"""Delta 3 generation SET command builders.
+
+The Delta 3 line uses a flat JSON envelope with a fixed command id, documented
+in the official IoT Developer API for the DELTA 3 MAX PLUS. Every control shares
+the same envelope and differs only in the `params` payload:
+
+    {
+        "cmdId": 17, "cmdFunc": 254, "dest": 2,
+        "dirDest": 1, "dirSrc": 1, "needAck": true,
+        "params": {"cfgAcOutOpen": true}
+    }
+
+The transport wrapper (`sn`, `id`, `version`) is added by the coordinator, so
+these builders return the command body only.
+
+Value ranges below are the vendor's own bounds. They are enforced here rather
+than only on the entity, so a command built from any caller stays inside what
+the device accepts.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Shared envelope. `dirSrc` follows the HTTP examples in the official docs; the
+# MQTT example spells it `dirSoc`, which reads like a typo in the vendor docs
+# (the field is a direction *source*). Verified against hardware before release.
+_CMD_ID = 17
+_CMD_FUNC = 254
+_DEST = 2
+_DIR_DEST = 1
+_DIR_SRC = 1
+
+# Switch controls: entity key -> params key. All take a plain bool.
+DELTA3_SWITCH_PARAMS: dict[str, str] = {
+    "ac_out_switch": "cfgAcOutOpen",
+    "ac2_out_switch": "cfgAc2OutOpen",
+    "dc_12v_out_switch": "cfgDc12vOutOpen",
+    "xboost_switch": "cfgXboostEn",
+    "beeper_switch": "cfgBeepEn",
+    "bypass_out_disable_switch": "cfgBypassOutDisable",
+}
+
+# Energy backup is the only nested payload: {"cfgEnergyBackup": {"energyBackupEn": bool}}
+DELTA3_ENERGY_BACKUP_KEY = "energy_backup_switch"
+
+# Number controls: entity key -> (params key, min, max). Bounds are vendor-documented.
+DELTA3_NUMBER_PARAMS: dict[str, tuple[str, int, int]] = {
+    "backup_reserve_soc": ("cfgBackupReverseSoc", 0, 50),
+    "max_charge_soc": ("cfgMaxChgSoc", 50, 100),
+    "min_discharge_soc": ("cfgMinDsgSoc", 0, 30),
+}
+
+
+def _envelope(params: dict[str, Any], need_ack: bool = True) -> dict[str, Any]:
+    """Wrap params in the shared Delta 3 command envelope."""
+    return {
+        "cmdId": _CMD_ID,
+        "cmdFunc": _CMD_FUNC,
+        "dest": _DEST,
+        "dirDest": _DIR_DEST,
+        "dirSrc": _DIR_SRC,
+        "needAck": need_ack,
+        "params": params,
+    }
+
+
+def build_switch_command(entity_key: str, turn_on: bool) -> dict[str, Any] | None:
+    """Build a SET command for a Delta 3 switch.
+
+    Returns None for an unknown key so the caller can log instead of sending
+    a payload the device would reject.
+    """
+    if entity_key == DELTA3_ENERGY_BACKUP_KEY:
+        return _envelope({"cfgEnergyBackup": {"energyBackupEn": bool(turn_on)}})
+
+    params_key = DELTA3_SWITCH_PARAMS.get(entity_key)
+    if params_key is None:
+        return None
+    return _envelope({params_key: bool(turn_on)})
+
+
+def build_number_command(entity_key: str, value: float) -> dict[str, Any] | None:
+    """Build a SET command for a Delta 3 number, clamped to the vendor range."""
+    entry = DELTA3_NUMBER_PARAMS.get(entity_key)
+    if entry is None:
+        return None
+    params_key, low, high = entry
+    clamped = max(low, min(high, int(round(value))))
+    return _envelope({params_key: clamped})

--- a/custom_components/ecoflow_energy/ecoflow/parsers/delta3_http.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/delta3_http.py
@@ -73,7 +73,6 @@ _DELTA3_FLOW_FIELD_MAP: dict[str, str] = {
 DELTA3_HTTP_FIELD_MAP: dict[str, str] = {
     # --- Battery / SoC ---
     "cmsBattSoc": "cms_batt_soc",
-    "bmsBattSoc": "bms_batt_soc",
     # --- Power (W, direct) ---
     "powInSumW": "pow_in_sum_w",
     "powOutSumW": "pow_out_sum_w",
@@ -98,14 +97,18 @@ DELTA3_HTTP_FIELD_MAP: dict[str, str] = {
 }
 
 
-def _extract_ac_out_list(quota_data: dict) -> list[Any] | None:
-    """Return the powGetAcOutItem array from either nested or dotted form."""
-    nested = quota_data.get("powGetAcOutList")
+def _extract_list(quota_data: dict, outer: str, inner: str) -> list[Any] | None:
+    """Return an array field from either the nested or the dotted form.
+
+    HTTP `/quota/all` returns these dotted ("powGetAcOutList.powGetAcOutItem"),
+    the MQTT heartbeat returns them nested. Both forms are documented.
+    """
+    nested = quota_data.get(outer)
     if isinstance(nested, dict):
-        items = nested.get("powGetAcOutItem")
+        items = nested.get(inner)
         if isinstance(items, list):
             return items
-    dotted = quota_data.get("powGetAcOutList.powGetAcOutItem")
+    dotted = quota_data.get(f"{outer}.{inner}")
     if isinstance(dotted, list):
         return dotted
     return None
@@ -161,8 +164,9 @@ def parse_delta3_http_quota(quota_data: dict) -> dict[str, Any]:
             if v is not None:
                 result[sensor_key] = 0 if int(v) == 4 else 1
 
-    # Per-outlet AC power: nested signed array, item[0]=AC1, item[2]=AC2.
-    ac_out = _extract_ac_out_list(quota_data)
+    # Per-outlet AC power: signed array, item[0]=AC1, item[2]=AC2. Both indices
+    # were confirmed on hardware by loading each socket on its own.
+    ac_out = _extract_list(quota_data, "powGetAcOutList", "powGetAcOutItem")
     if ac_out is not None:
         if len(ac_out) >= 1:
             v = _safe_float(ac_out[0])
@@ -172,5 +176,15 @@ def parse_delta3_http_quota(quota_data: dict) -> dict[str, Any]:
             v = _safe_float(ac_out[2])
             if v is not None:
                 result["ac2_out_w"] = int(round(abs(v)))
+
+    # Anderson port power: two elements per the official field list. The
+    # per-element meaning is undocumented and both read 0 on the reference
+    # unit, so only the total is exposed until a loaded port proves otherwise.
+    anderson = _extract_list(quota_data, "powGet12vList", "powGet12vItem")
+    if anderson:
+        values = [_safe_float(v) for v in anderson]
+        known = [abs(v) for v in values if v is not None]
+        if known:
+            result["anderson_out_w"] = int(round(sum(known)))
 
     return result

--- a/custom_components/ecoflow_energy/number.py
+++ b/custom_components/ecoflow_energy/number.py
@@ -15,7 +15,9 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     DELTA2MAX_NUMBERS,
+    DELTA3_NUMBERS,
     DEVICE_TYPE_DELTA,
+    DEVICE_TYPE_DELTA3,
     DEVICE_TYPE_POWEROCEAN,
     DEVICE_TYPE_SMARTPLUG,
     DEVICE_TYPE_STREAM,
@@ -28,6 +30,9 @@ from .const import (
     STREAM_NUMBERS,
 )
 from .coordinator import EcoFlowDeviceCoordinator
+from .ecoflow.delta3_commands import (
+    build_number_command as build_delta3_number_command,
+)
 from .ecoflow.energy_stream import build_stream_backup_reserve_payload
 from .ecoflow.parsers.smartplug import (
     build_plug_brightness_payload,
@@ -126,6 +131,15 @@ class EcoFlowNumber(CoordinatorEntity[EcoFlowDeviceCoordinator], NumberEntity):
             return
         if self.coordinator.device_type == DEVICE_TYPE_STREAM:
             ok = await self._async_set_stream_value(self._definition.key, value)
+            if ok:
+                self._apply_optimistic_number(value)
+            return
+        if self.coordinator.device_type == DEVICE_TYPE_DELTA3:
+            command = build_delta3_number_command(self._definition.key, value)
+            if command is None:
+                _LOGGER.warning("No command template for number %s", self._definition.key)
+                return
+            ok = await self.coordinator.async_send_delta3_set(command)
             if ok:
                 self._apply_optimistic_number(value)
             return
@@ -276,4 +290,6 @@ def _get_number_defs(device_type: str) -> list[EcoFlowNumberDef]:
         return SMARTPLUG_NUMBERS
     if device_type == DEVICE_TYPE_STREAM:
         return STREAM_NUMBERS
+    if device_type == DEVICE_TYPE_DELTA3:
+        return DELTA3_NUMBERS
     return []

--- a/custom_components/ecoflow_energy/switch.py
+++ b/custom_components/ecoflow_energy/switch.py
@@ -18,10 +18,15 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .ecoflow.delta3_commands import (
+    build_switch_command as build_delta3_switch_command,
+)
 from .const import (
     DELTA2MAX_SWITCHES,
+    DELTA3_SWITCHES,
     DELTA_PROFILE_R331,
     DEVICE_TYPE_DELTA,
+    DEVICE_TYPE_DELTA3,
     DEVICE_TYPE_SMARTPLUG,
     DEVICE_TYPE_STREAM,
     DOMAIN,
@@ -138,6 +143,9 @@ class EcoFlowSwitch(CoordinatorEntity[EcoFlowDeviceCoordinator], SwitchEntity):
             return
 
         self._apply_optimistic(turn_on)
+        if self.coordinator.device_type == DEVICE_TYPE_DELTA3:
+            await self.coordinator.async_send_delta3_set(command)
+            return
         await self.coordinator.async_send_set_command(command)
 
     def _apply_optimistic(self, turn_on: bool) -> None:
@@ -149,6 +157,9 @@ class EcoFlowSwitch(CoordinatorEntity[EcoFlowDeviceCoordinator], SwitchEntity):
 
     def _build_command(self, turn_on: bool) -> dict[str, Any] | None:
         """Build a SET command from legacy or declarative templates."""
+        if self.coordinator.device_type == DEVICE_TYPE_DELTA3:
+            return build_delta3_switch_command(self._definition.key, turn_on)
+
         if self.coordinator.device_type == DEVICE_TYPE_DELTA:
             commands = _get_delta_switch_commands(self.coordinator.delta_profile)
             declarative_templates = _get_delta_switch_declarative(self.coordinator.delta_profile)
@@ -196,6 +207,8 @@ def _get_switch_defs(device_type: str) -> list[EcoFlowSwitchDef]:
         return SMARTPLUG_SWITCHES
     if device_type == DEVICE_TYPE_STREAM:
         return STREAM_SWITCHES
+    if device_type == DEVICE_TYPE_DELTA3:
+        return DELTA3_SWITCHES
     return []
 
 

--- a/custom_components/ecoflow_energy/translations/de.json
+++ b/custom_components/ecoflow_energy/translations/de.json
@@ -135,9 +135,6 @@
       "cms_batt_soc": {
         "name": "Ladezustand"
       },
-      "bms_batt_soc": {
-        "name": "Hauptpaket-Ladezustand"
-      },
       "pow_in_sum_w": {
         "name": "Eingang Gesamt"
       },
@@ -1217,6 +1214,9 @@
       },
       "bp_max_discharge_power_w": {
         "name": "Batterieentladeleistung (max.)"
+      },
+      "anderson_out_w": {
+        "name": "Anderson-Ausgang"
       }
     },
     "binary_sensor": {
@@ -1242,13 +1242,13 @@
         "name": "AC-Ausgang 2"
       },
       "ac_out_flow": {
-        "name": "AC-Ausgang Stromfluss"
+        "name": "AC-Ausgang aktiv"
       },
       "ac2_out_flow": {
-        "name": "AC-Ausgang 2 Stromfluss"
+        "name": "AC-Ausgang 2 aktiv"
       },
       "dc_12v_out_flow": {
-        "name": "12V-Ausgang Stromfluss"
+        "name": "12V-Ausgang aktiv"
       },
       "backup_reserve_enabled": {
         "name": "Backup-Reserve"
@@ -1287,6 +1287,21 @@
       },
       "plug_switch": {
         "name": "Steckdose"
+      },
+      "ac_out_switch": {
+        "name": "AC-Ausgang"
+      },
+      "ac2_out_switch": {
+        "name": "AC-Ausgang 2"
+      },
+      "dc_12v_out_switch": {
+        "name": "12V-Ausgang"
+      },
+      "energy_backup_switch": {
+        "name": "Notstromreserve"
+      },
+      "bypass_out_disable_switch": {
+        "name": "Bypass-Ausgang gesperrt"
       }
     },
     "number": {
@@ -1322,6 +1337,9 @@
       },
       "max_watts": {
         "name": "Max. Leistungsgrenze"
+      },
+      "min_discharge_soc": {
+        "name": "Entladegrenze"
       }
     },
     "select": {

--- a/custom_components/ecoflow_energy/translations/en.json
+++ b/custom_components/ecoflow_energy/translations/en.json
@@ -135,9 +135,6 @@
       "cms_batt_soc": {
         "name": "SoC"
       },
-      "bms_batt_soc": {
-        "name": "Main Pack SoC"
-      },
       "pow_in_sum_w": {
         "name": "Input Total"
       },
@@ -1217,6 +1214,9 @@
       },
       "bp_max_discharge_power_w": {
         "name": "Battery Discharge Power (Max)"
+      },
+      "anderson_out_w": {
+        "name": "Anderson output"
       }
     },
     "binary_sensor": {
@@ -1242,13 +1242,13 @@
         "name": "AC Outlet 2"
       },
       "ac_out_flow": {
-        "name": "AC Output Flow"
+        "name": "AC output active"
       },
       "ac2_out_flow": {
-        "name": "AC Output 2 Flow"
+        "name": "AC output 2 active"
       },
       "dc_12v_out_flow": {
-        "name": "12V Output Flow"
+        "name": "12V output active"
       },
       "backup_reserve_enabled": {
         "name": "Backup Reserve"
@@ -1287,6 +1287,21 @@
       },
       "plug_switch": {
         "name": "Plug"
+      },
+      "ac_out_switch": {
+        "name": "AC output"
+      },
+      "ac2_out_switch": {
+        "name": "AC output 2"
+      },
+      "dc_12v_out_switch": {
+        "name": "12V output"
+      },
+      "energy_backup_switch": {
+        "name": "Backup reserve"
+      },
+      "bypass_out_disable_switch": {
+        "name": "Bypass output disabled"
       }
     },
     "number": {
@@ -1322,6 +1337,9 @@
       },
       "max_watts": {
         "name": "Max Power Limit"
+      },
+      "min_discharge_soc": {
+        "name": "Discharge limit"
       }
     },
     "select": {

--- a/tests/ha/test_delta3_integration.py
+++ b/tests/ha/test_delta3_integration.py
@@ -141,17 +141,21 @@ class TestDelta3EndToEnd:
         # Charge/discharge enum: raw 2 -> translated option key "charging".
         assert state_for("sensor", "chg_dsg_state") == "charging"
 
-        # Flow binary sensors: 12V flowing (value 0 != 4) -> on;
-        # AC output not flowing (value 4) -> off.
-        assert state_for("binary_sensor", "dc_12v_out_flow") == "on"
-        assert state_for("binary_sensor", "ac_out_flow") == "off"
+        # Output states surface as switches, not read-only sensors: the same
+        # field drives the switch state, so 12V active (value != 4) is "on" and
+        # AC output inactive (value 4) is "off".
+        assert state_for("switch", "dc_12v_out_switch") == "on"
+        assert state_for("switch", "ac_out_switch") == "off"
+
+        # Controls exist with the vendor-documented ranges.
+        assert state_for("number", "max_charge_soc") is not None
 
         # None of the spot-checked entities should be unavailable.
         for platform, key in (
             ("sensor", "cms_batt_soc"),
             ("sensor", "pow_in_sum_w"),
             ("sensor", "chg_dsg_state"),
-            ("binary_sensor", "dc_12v_out_flow"),
+            ("switch", "dc_12v_out_switch"),
         ):
             assert state_for(platform, key) not in ("unavailable", "unknown")
 

--- a/tests/test_cloud_http.py
+++ b/tests/test_cloud_http.py
@@ -88,6 +88,30 @@ class TestSignature:
         result_dict = dict(result)
         assert result_dict == {"items[0]": "1", "items[1]": "2"}
 
+    def test_flatten_booleans_use_json_spelling(self):
+        """Booleans must sign as "true"/"false", never Python's "True"/"False".
+
+        The server recomputes the signature from the JSON body it receives. A
+        capitalised boolean produces a different string on our side and the
+        request comes back as 8521 "signature is wrong". Delta 3 control
+        payloads are all booleans, so this is on the hot path.
+        """
+        client = self._make_client()
+        result = dict(client._flatten({"cfgAcOutOpen": True, "cfgBeepEn": False}))
+        assert result == {"cfgAcOutOpen": "true", "cfgBeepEn": "false"}
+
+    def test_flatten_nested_boolean(self):
+        """The energy-backup command nests its boolean one level down."""
+        client = self._make_client()
+        result = dict(client._flatten({"cfgEnergyBackup": {"energyBackupEn": True}}))
+        assert result == {"cfgEnergyBackup.energyBackupEn": "true"}
+
+    def test_flatten_keeps_integers_unquoted(self):
+        """Guard against the boolean branch swallowing ints (bool subclasses int)."""
+        client = self._make_client()
+        result = dict(client._flatten({"cfgMaxChgSoc": 90, "cfgMinDsgSoc": 0}))
+        assert result == {"cfgMaxChgSoc": "90", "cfgMinDsgSoc": "0"}
+
     def test_sign_payload_sorted_then_auth_tail(self):
         """Payload params sorted, then auth tail (accessKey, nonce, timestamp) appended.
 
@@ -398,7 +422,16 @@ class TestDeadCodeRemoved:
         source = (REPO_ROOT / "custom_components/ecoflow_energy/ecoflow/cloud_http.py").read_text()
         assert "get_powerocean_quota" not in source
 
-    def test_no_iot_quota_path_import(self):
-        """IOT_QUOTA_PATH import was only used by dead code."""
+    def test_iot_quota_path_is_only_used_for_writes(self):
+        """IOT_QUOTA_PATH came back for Delta 3 controls, not for reading.
+
+        It was removed once as dead code. Reads must keep using the /quota/all
+        endpoint, so guard that the path is reachable from set_quota only.
+        """
         source = (REPO_ROOT / "custom_components/ecoflow_energy/ecoflow/cloud_http.py").read_text()
-        assert "IOT_QUOTA_PATH" not in source
+        assert "IOT_QUOTA_PATH" in source
+        set_quota_body = source.split("async def set_quota")[1].split("async def")[0]
+        assert "IOT_QUOTA_PATH" in set_quota_body
+        get_body = source.split("async def get_quota_all")[1].split("async def")[0]
+        assert "IOT_QUOTA_ALL_PATH" in get_body
+        assert "IOT_QUOTA_PATH}" not in get_body

--- a/tests/test_delta3_commands.py
+++ b/tests/test_delta3_commands.py
@@ -1,0 +1,129 @@
+"""Tests for the Delta 3 SET command builders.
+
+The envelope and the value ranges are vendor-specified, see
+docs/reference/ecoflow-api-delta3-max-plus.md. These tests pin both so a
+refactor cannot silently change what reaches the device.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.ecoflow_energy.ecoflow.delta3_commands import (
+    DELTA3_NUMBER_PARAMS,
+    DELTA3_SWITCH_PARAMS,
+    build_number_command,
+    build_switch_command,
+)
+
+EXPECTED_ENVELOPE = {
+    "cmdId": 17,
+    "cmdFunc": 254,
+    "dest": 2,
+    "dirDest": 1,
+    "dirSrc": 1,
+    "needAck": True,
+}
+
+
+class TestEnvelope:
+    def test_every_switch_carries_the_documented_envelope(self) -> None:
+        for key in DELTA3_SWITCH_PARAMS:
+            cmd = build_switch_command(key, True)
+            assert cmd is not None
+            for field, value in EXPECTED_ENVELOPE.items():
+                assert cmd[field] == value, f"{key}: {field}"
+
+    def test_every_number_carries_the_documented_envelope(self) -> None:
+        for key in DELTA3_NUMBER_PARAMS:
+            cmd = build_number_command(key, 10)
+            assert cmd is not None
+            for field, value in EXPECTED_ENVELOPE.items():
+                assert cmd[field] == value, f"{key}: {field}"
+
+    def test_source_direction_is_dir_src_not_dir_soc(self) -> None:
+        """The MQTT sample in the vendor docs spells this `dirSoc`.
+
+        That reads like a typo for a direction *source*, and the HTTP samples
+        all use `dirSrc`. Pinned so nobody "fixes" it back.
+        """
+        cmd = build_switch_command("ac_out_switch", True)
+        assert "dirSrc" in cmd
+        assert "dirSoc" not in cmd
+
+
+class TestSwitchCommands:
+    @pytest.mark.parametrize(
+        ("key", "params_key"),
+        [
+            ("ac_out_switch", "cfgAcOutOpen"),
+            ("ac2_out_switch", "cfgAc2OutOpen"),
+            ("dc_12v_out_switch", "cfgDc12vOutOpen"),
+            ("xboost_switch", "cfgXboostEn"),
+            ("beeper_switch", "cfgBeepEn"),
+            ("bypass_out_disable_switch", "cfgBypassOutDisable"),
+        ],
+    )
+    def test_flat_switches_map_to_the_documented_param(
+        self, key: str, params_key: str
+    ) -> None:
+        assert build_switch_command(key, True)["params"] == {params_key: True}
+        assert build_switch_command(key, False)["params"] == {params_key: False}
+
+    def test_energy_backup_is_nested(self) -> None:
+        """cfgEnergyBackup is the only control with a nested payload."""
+        cmd = build_switch_command("energy_backup_switch", True)
+        assert cmd["params"] == {"cfgEnergyBackup": {"energyBackupEn": True}}
+
+    def test_values_are_real_booleans(self) -> None:
+        """The contract types these as bool, not 0/1."""
+        params = build_switch_command("ac_out_switch", 1)["params"]
+        assert params["cfgAcOutOpen"] is True
+
+    def test_unknown_key_returns_none(self) -> None:
+        assert build_switch_command("no_such_switch", True) is None
+
+
+class TestNumberCommands:
+    @pytest.mark.parametrize(
+        ("key", "params_key", "value"),
+        [
+            ("backup_reserve_soc", "cfgBackupReverseSoc", 41),
+            ("max_charge_soc", "cfgMaxChgSoc", 80),
+            ("min_discharge_soc", "cfgMinDsgSoc", 20),
+        ],
+    )
+    def test_in_range_values_pass_through(
+        self, key: str, params_key: str, value: int
+    ) -> None:
+        assert build_number_command(key, value)["params"] == {params_key: value}
+
+    @pytest.mark.parametrize(
+        ("key", "params_key", "low", "high"),
+        [
+            ("backup_reserve_soc", "cfgBackupReverseSoc", 0, 50),
+            ("max_charge_soc", "cfgMaxChgSoc", 50, 100),
+            ("min_discharge_soc", "cfgMinDsgSoc", 0, 30),
+        ],
+    )
+    def test_values_are_clamped_to_the_vendor_range(
+        self, key: str, params_key: str, low: int, high: int
+    ) -> None:
+        assert build_number_command(key, low - 10)["params"][params_key] == low
+        assert build_number_command(key, high + 10)["params"][params_key] == high
+        assert build_number_command(key, low)["params"][params_key] == low
+        assert build_number_command(key, high)["params"][params_key] == high
+
+    def test_backup_reserve_tops_out_at_fifty_not_hundred(self) -> None:
+        """Easy to get wrong: this is a ratio, not a SoC target."""
+        assert build_number_command("backup_reserve_soc", 100)["params"][
+            "cfgBackupReverseSoc"
+        ] == 50
+
+    def test_float_input_is_rounded_to_int(self) -> None:
+        params = build_number_command("max_charge_soc", 79.6)["params"]
+        assert params["cfgMaxChgSoc"] == 80
+        assert isinstance(params["cfgMaxChgSoc"], int)
+
+    def test_unknown_key_returns_none(self) -> None:
+        assert build_number_command("no_such_number", 50) is None

--- a/tests/test_delta3_http_parser.py
+++ b/tests/test_delta3_http_parser.py
@@ -19,7 +19,6 @@ from ecoflow_energy.ecoflow.parsers.delta3_http import (
 FULL_QUOTA: dict = {
     # Battery / SoC
     "cmsBattSoc": 85.6,
-    "bmsBattSoc": 84.9,
     # Remaining time (minutes)
     "cmsChgRemTime": 143,
     "cmsDsgRemTime": 5999,
@@ -30,6 +29,7 @@ FULL_QUOTA: dict = {
     "powGetPv": 210.7,
     "powGetPv2": 98.2,
     "powGet12v": 24.3,
+    "powGet12vList.powGet12vItem": [12.0, 6.0],
     "powGetTypec1": 45.0,
     "powGetTypec2": 0,
     "powGetTypec3": 18.6,
@@ -56,7 +56,6 @@ FULL_QUOTA: dict = {
 
 EXPECTED_FULL: dict = {
     "cms_batt_soc": 86,
-    "bms_batt_soc": 85,
     "chg_remain_time_min": 143,
     # FULL_QUOTA is a charging snapshot, so the discharge runtime is cleared.
     "dsg_remain_time_min": None,
@@ -66,6 +65,7 @@ EXPECTED_FULL: dict = {
     "pv1_in_w": 211,
     "pv2_in_w": 98,
     "dc_12v_out_w": 24,
+    "anderson_out_w": 18,
     "typec1_w": 45,
     "typec2_w": 0,
     "typec3_w": 19,
@@ -227,3 +227,22 @@ class TestDelta3AcOutArray:
     def test_non_list_payload_is_ignored(self) -> None:
         raw = {"powGetAcOutList": {"powGetAcOutItem": "garbage"}}
         assert parse_delta3_http_quota(raw) == {}
+
+    def test_anderson_port_sums_both_elements(self) -> None:
+        """The two elements have no documented individual meaning, so only the
+        total is exposed until a loaded port proves the index semantics."""
+        result = parse_delta3_http_quota({"powGet12vList.powGet12vItem": [12.0, 6.0]})
+        assert result["anderson_out_w"] == 18
+
+    def test_anderson_port_accepts_the_nested_mqtt_form(self) -> None:
+        result = parse_delta3_http_quota(
+            {"powGet12vList": {"powGet12vItem": [5.0, 0.0]}}
+        )
+        assert result["anderson_out_w"] == 5
+
+    def test_anderson_port_absent_emits_nothing(self) -> None:
+        assert "anderson_out_w" not in parse_delta3_http_quota({"cmsBattSoc": 50})
+
+    def test_bms_batt_soc_is_not_mapped(self) -> None:
+        """Not part of the official 27-field contract; no device sends it."""
+        assert "bms_batt_soc" not in parse_delta3_http_quota({"bmsBattSoc": 85})


### PR DESCRIPTION
Makes the Delta 3 Max Plus controllable and corrects two field-map defects that surfaced when the shipped map was cross-checked against the device contract.

## Controls

Seven switches and three numbers, all applied over `PUT /iot-open/sign/device/quota`:

| Entity | Parameter | Range |
|---|---|---|
| AC output 1 / 2 | `cfgAcOutOpen`, `cfgAc2OutOpen` | bool |
| 12V output | `cfgDc12vOutOpen` | bool |
| X-Boost, buzzer, bypass lock | `cfgXboostEn`, `cfgBeepEn`, `cfgBypassOutDisable` | bool |
| Backup reserve | `cfgEnergyBackup` (nested) | bool |
| Backup reserve level | `cfgBackupReverseSoc` | 0-50 |
| Charge limit | `cfgMaxChgSoc` | 50-100 |
| Discharge limit | `cfgMinDsgSoc` | 0-30 |

The ranges are device limits, not preferences. The backup ratio tops out at 50 and the charge limit cannot go below 50.

Controls need Standard mode. Enhanced mode has no HTTP path, and the entity reports that instead of failing silently.

## Verification

Every command was applied to a Delta 3 Max Plus and read back from the device, covering all three payload shapes: a flat boolean, the nested energy-backup object, and a number. Then the same commands were driven through Home Assistant end to end, with the effect confirmed independently against the device.

Docker run on a Standard-mode instance: 41 entities, no errors, the only log line is the intended warning for an unsupported device on the same account.

## Field-map corrections

- `bmsBattSoc` was mapped to a Main Pack SoC sensor but is not part of the device contract, so the entity could never hold a value. Removed.
- The Anderson port output power was dropped instead of parsed. Now exposed.
- The read-only entities that the new controls duplicate are removed. Each reported exactly what its switch or slider now shows.

## Incidental fix

Request bodies containing booleans were signed with Python spelling rather than the JSON spelling the server recomputes, which would have failed every such request with a signature error. No request carried a boolean until now, so nothing was broken in practice.

1049 tests pass.