### PR TITLE
fix: Delta 2 Max AC charge speed reads and sets the configured value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Ah battery capacity counters are disabled diagnostic entities. (beta.2)
 
 ### Fixed
+- The Delta 2 Max AC Charge Speed slider now reads and writes the actually configured charging speed. It previously displayed the rated maximum (2400 W), never picked up changes made in the EcoFlow app, and every value written from Home Assistant effectively ended up at 400 W because the command hardcoded the governing parameter. (beta.7)
 - Entities now go unavailable and recover promptly when the connection degrades or comes back. Availability changes with unchanged sensor values were filtered out by the state-write deduplication, so entities could keep showing as available long after the data stream stopped, and a recovery was only reflected once a value happened to change. (beta.7)
 - English installs now show proper connectivity state labels. The WiFi, Ethernet and 4G status sensors displayed raw state keys because the English translation carried state names copied from the grid status sensor. (beta.7)
 - Energy counters survive a lost or corrupted cache file. The totals are re-seeded from the last value Home Assistant restored instead of restarting at zero; a stale restored value can never lower a live total. (beta.7)

--- a/custom_components/ecoflow_energy/const.py
+++ b/custom_components/ecoflow_energy/const.py
@@ -495,7 +495,7 @@ DELTA2MAX_SWITCHES: list[EcoFlowSwitchDef] = [
 ]
 
 DELTA2MAX_NUMBERS: list[EcoFlowNumberDef] = [
-    EcoFlowNumberDef("ac_charge_speed", "AC Charge Speed", "ac_chg_rated_power_w", "W", "mdi:lightning-bolt", 200, 2400, 100),
+    EcoFlowNumberDef("ac_charge_speed", "AC Charge Speed", "ac_slow_chg_watts", "W", "mdi:lightning-bolt", 200, 2400, 100),
     EcoFlowNumberDef("max_charge_soc", "Max Charge SoC", "max_charge_soc", "%", "mdi:battery-charging-100", 50, 100, 1),
     EcoFlowNumberDef("min_discharge_soc", "Min Discharge SoC", "min_discharge_soc", "%", "mdi:battery-alert-variant-outline", 0, 30, 1),
     EcoFlowNumberDef("standby_timeout", "Standby Timeout", "standby_timeout_min", "min", "mdi:timer-off-outline", 0, 720, 1),
@@ -839,8 +839,13 @@ NUMBER_COMMANDS: dict[str, dict[str, Any]] = {
     "ac_charge_speed": {
         "moduleType": 3,
         "operateType": "acChgCfg",
-        "param_key": "fastChgWatts",
-        "extra_params": {"slowChgWatts": 400, "chgPauseFlag": 0},
+        # The effective AC charge speed follows slowChgWatts; fastChgWatts is
+        # mirrored to the same value so both charger paths use the user's
+        # setting (issue #95: hardcoding slowChgWatts=400 pinned the device
+        # at 400 W regardless of the requested value).
+        "param_key": "slowChgWatts",
+        "value_params": ["fastChgWatts"],
+        "extra_params": {"chgPauseFlag": 0},
     },
     "max_charge_soc": {
         "moduleType": 2,

--- a/custom_components/ecoflow_energy/ecoflow/parsers/delta.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/delta.py
@@ -86,6 +86,13 @@ DELTA2MAX_FIELD_MAP: dict[str, str] = {
     "invStatus.cfgAcOutVol": "ac_cfg_out_vol_mv",
     "invStatus.chargerType": "charger_type",
     "invStatus.acChgRatedPower": "ac_chg_rated_power_w",
+    # Configured AC charge speed (issue #95). The HTTP quota uses the
+    # capitalized keys (inv.FastChgWatts / inv.SlowChgWatts); both casings
+    # are mapped here since WSS report casing may differ per firmware.
+    "invStatus.FastChgWatts": "ac_fast_chg_watts",
+    "invStatus.SlowChgWatts": "ac_slow_chg_watts",
+    "invStatus.fastChgWatts": "ac_fast_chg_watts",
+    "invStatus.slowChgWatts": "ac_slow_chg_watts",
     "invStatus.errCode": "inv_err_code",
     # --- bmsStatus (bms.*) ---
     "bmsStatus.vol": "batt_voltage_mv",

--- a/custom_components/ecoflow_energy/number.py
+++ b/custom_components/ecoflow_energy/number.py
@@ -173,6 +173,10 @@ class EcoFlowNumber(
             return
 
         params = {cmd_template["param_key"]: int(value)}
+        # Mirror the value into additional param keys (e.g. acChgCfg sends
+        # the same watts as slowChgWatts and fastChgWatts, issue #95).
+        for extra_key in cmd_template.get("value_params", []):
+            params[extra_key] = int(value)
         if "extra_params" in cmd_template:
             params.update(cmd_template["extra_params"])
 

--- a/tests/ha/test_entities.py
+++ b/tests/ha/test_entities.py
@@ -698,6 +698,40 @@ class TestEcoFlowNumber:
             assert cmd["operateType"] == "upsConfig"
             assert cmd["params"]["maxChgSoc"] == 90
 
+    async def test_ac_charge_speed_reads_configured_speed(self) -> None:
+        """Regression #95: the number binds to the configured charge speed,
+        not the static rated power."""
+        defn = next(d for d in DELTA2MAX_NUMBERS if d.key == "ac_charge_speed")
+        assert defn.state_key == "ac_slow_chg_watts"
+
+    async def test_ac_charge_speed_set_builds_command(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+        mock_iot_api,
+        mock_mqtt_client,
+        mock_http_client,
+    ) -> None:
+        """Regression #95: acChgCfg sends the requested watts as both
+        slowChgWatts and fastChgWatts (no hardcoded 400 W fallback)."""
+        standard_config_entry.add_to_hass(hass)
+        coordinator = _make_coordinator(hass, standard_config_entry)
+        await coordinator.async_setup()
+
+        defn = next(d for d in DELTA2MAX_NUMBERS if d.key == "ac_charge_speed")
+        number = EcoFlowNumber(coordinator, defn)
+
+        with patch.object(coordinator, "async_send_set_command", new_callable=AsyncMock) as mock_cmd, \
+             patch.object(number, "async_write_ha_state"):
+            await number.async_set_native_value(800.0)
+            mock_cmd.assert_called_once()
+            cmd = mock_cmd.call_args[0][0]
+            assert cmd["moduleType"] == 3
+            assert cmd["operateType"] == "acChgCfg"
+            assert cmd["params"]["slowChgWatts"] == 800
+            assert cmd["params"]["fastChgWatts"] == 800
+            assert cmd["params"]["chgPauseFlag"] == 0
+
     async def test_smartplug_number_command_templates(self) -> None:
         """All Smart Plug number defs have matching command templates."""
         for defn in SMARTPLUG_NUMBERS:

--- a/tests/test_delta_parser.py
+++ b/tests/test_delta_parser.py
@@ -33,6 +33,26 @@ class TestDeltaParser:
         assert result["ac_out_w"] == 1500.0
         assert result["ac_in_w"] == 200.0
 
+    def test_inv_status_ac_charge_speed(self):
+        """invStatus charge-speed keys map to the configured charge speed (issue #95)."""
+        report = {
+            "typeCode": "invStatus",
+            "params": {"SlowChgWatts": 800, "FastChgWatts": 2400},
+        }
+        result = parse_delta_report(report)
+        assert result["ac_slow_chg_watts"] == 800.0
+        assert result["ac_fast_chg_watts"] == 2400.0
+
+    def test_inv_status_ac_charge_speed_lowercase(self):
+        """Lowercase casing variant of the charge-speed keys is accepted too."""
+        report = {
+            "typeCode": "invStatus",
+            "params": {"slowChgWatts": 200, "fastChgWatts": 2400},
+        }
+        result = parse_delta_report(report)
+        assert result["ac_slow_chg_watts"] == 200.0
+        assert result["ac_fast_chg_watts"] == 2400.0
+
     def test_bms_temp_offset(self):
         """bmsStatus.temp has a +15 offset that must be removed."""
         report = {"typeCode": "bmsStatus", "params": {"temp": 40}}
@@ -124,7 +144,12 @@ class TestDeltaParser:
 
     def test_field_map_coverage(self):
         """All field_map entries must have unique destination keys."""
-        dest_keys = list(DELTA2MAX_FIELD_MAP.values())
+        # Deliberate casing aliases map to the same destination key
+        # (firmware casing of the charge-speed keys is not uniform, #95).
+        casing_aliases = ("invStatus.fastChgWatts", "invStatus.slowChgWatts")
+        dest_keys = [
+            v for k, v in DELTA2MAX_FIELD_MAP.items() if k not in casing_aliases
+        ]
         # Raw keys are never in the output (replaced by processed keys)
         raw_keys = ("batt_temp_raw", "beep_mode_raw", "slave1_temp_raw", "slave2_temp_raw")
         dest_keys_without_raw = [k for k in dest_keys if k not in raw_keys]


### PR DESCRIPTION
## What

The Delta 2 Max AC Charge Speed number was bound to the static rated power field (2400 W), so it never showed the configured charge speed and never reflected changes made in the app. Setting a value from Home Assistant sent it on a parameter the device ignores while hardcoding the effective one to 400 W, which is why every write ended up at 400 W.

- The number entity now reads the configured charge speed (inv.SlowChgWatts)
- Setting a value now writes the parameter the device actually applies
- The live connection parser now maps the charge speed fields, so app changes show up promptly

## Verification

Verified against a real Delta 2 Max: full round trip 400 -> 200 -> 800 -> 400 W, each command acknowledged by the device and read back from its state. The rated power stays available as its own sensor.

- 3 new regression tests (command shape, definition guard, live-connection parser mapping)
- Full suite: 1345 tests pass
- Validated in a live Home Assistant instance: no errors

Ref #95