### PR TITLE
fix: reclassify unknown app device types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Ah battery capacity counters are disabled diagnostic entities. (beta.2)
 
 ### Fixed
+- App API devices reported with an unknown device type are now classified locally using their product name or supported serial-number prefix.
 - The Delta 2 Max AC Charge Speed slider now reads and writes the actually configured charging speed. It previously displayed the rated maximum (2400 W), never picked up changes made in the EcoFlow app, and every value written from Home Assistant effectively ended up at 400 W because the command hardcoded the governing parameter. (beta.7)
 - Entities now go unavailable and recover promptly when the connection degrades or comes back. Availability changes with unchanged sensor values were filtered out by the state-write deduplication, so entities could keep showing as available long after the data stream stopped, and a recovery was only reflected once a value happened to change. (beta.7)
 - English installs now show proper connectivity state labels. The WiFi, Ethernet and 4G status sensors displayed raw state keys because the English translation carried state names copied from the grid status sensor. (beta.7)

--- a/custom_components/ecoflow_energy/config_flow_setup.py
+++ b/custom_components/ecoflow_energy/config_flow_setup.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_SECRET_KEY,
     CONF_USER_ID,
     DEVICE_TYPE_DISPLAY_NAMES,
+    DEVICE_TYPE_UNKNOWN,
     MODE_ENHANCED,
     MODE_STANDARD,
     get_device_type,
@@ -312,7 +313,9 @@ class SetupFlowMixin:
                 continue
             product_name = dev.get("product_name", "Unknown")
             online = dev.get("online", 0)
-            device_type = dev.get("device_type", get_device_type(product_name, sn))
+            device_type = dev.get("device_type")
+            if not device_type or device_type == DEVICE_TYPE_UNKNOWN:
+                device_type = get_device_type(product_name, sn)
             devices.append(
                 {
                     "sn": sn,

--- a/tests/ha/test_config_flow.py
+++ b/tests/ha/test_config_flow.py
@@ -1889,6 +1889,57 @@ class TestNormalizeDevices:
         assert len(result) == 1
         assert result[0]["sn"] == "HJ31FAKE00000001"
 
+    def test_normalize_app_devices_reclassifies_unknown_type_by_sn(self) -> None:
+        """An unknown app API device type falls back to SN classification."""
+        from custom_components.ecoflow_energy.config_flow import (
+            EcoFlowEnergyConfigFlow,
+        )
+
+        result = EcoFlowEnergyConfigFlow._normalize_app_devices([
+            {
+                "sn": "HJ31FAKE00000001",
+                "product_name": "",
+                "online": 1,
+                "device_type": "unknown",
+            },
+        ])
+
+        assert result[0]["device_type"] == "powerocean"
+
+    def test_normalize_app_devices_reclassifies_empty_type_by_sn(self) -> None:
+        """An empty app API device type falls back to SN classification."""
+        from custom_components.ecoflow_energy.config_flow import (
+            EcoFlowEnergyConfigFlow,
+        )
+
+        result = EcoFlowEnergyConfigFlow._normalize_app_devices([
+            {
+                "sn": "HJ31FAKE00000001",
+                "product_name": "",
+                "online": 1,
+                "device_type": "",
+            },
+        ])
+
+        assert result[0]["device_type"] == "powerocean"
+
+    def test_normalize_app_devices_reclassifies_none_type_by_sn(self) -> None:
+        """A null app API device type falls back to SN classification."""
+        from custom_components.ecoflow_energy.config_flow import (
+            EcoFlowEnergyConfigFlow,
+        )
+
+        result = EcoFlowEnergyConfigFlow._normalize_app_devices([
+            {
+                "sn": "HJ31FAKE00000001",
+                "product_name": "",
+                "online": 1,
+                "device_type": None,
+            },
+        ])
+
+        assert result[0]["device_type"] == "powerocean"
+
 
 class TestFetchAppDevices:
     """Tests for the module-level _async_fetch_app_devices helper.


### PR DESCRIPTION
## Related Issue

Closes #118

## Summary

Ensures devices are classified locally when the App API returns an invalid device type.

## Changes

- Treat `"unknown"`, an empty string, and `None` as invalid device types.
- Fall back to classification using the product name and serial-number prefix.
- Add a separate regression test for each invalid value.
- Add a changelog entry.

## Checklist

- [x] Tests pass (`pytest`)
- [x] CHANGELOG.md updated
- [ ] Version bumped in `manifest.json` (if code change)
- [x] README updated (not applicable—no documentation changes required)
- [x] No secrets or real device serial numbers in code