### PR TITLE
fix: debounce battery state transitions with a confirmation window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Ah battery capacity counters are disabled diagnostic entities. (beta.2)
 
 ### Fixed
+- The PowerOcean battery state sensor (charging/discharging/standby) is now stable through short power swings around zero. At dawn and dusk, when solar production and house load balance, the sensor could change state dozens of times a day. A state change now has to persist for ten minutes before the sensor follows it; sustained changes still come through reliably. (beta.8)
 - The Delta 2 Max AC Charge Speed slider now reads and writes the actually configured charging speed. It previously displayed the rated maximum (2400 W), never picked up changes made in the EcoFlow app, and every value written from Home Assistant effectively ended up at 400 W because the command hardcoded the governing parameter. (beta.7)
 - Entities now go unavailable and recover promptly when the connection degrades or comes back. Availability changes with unchanged sensor values were filtered out by the state-write deduplication, so entities could keep showing as available long after the data stream stopped, and a recovery was only reflected once a value happened to change. (beta.7)
 - English installs now show proper connectivity state labels. The WiFi, Ethernet and 4G status sensors displayed raw state keys because the English translation carried state names copied from the grid status sensor. (beta.7)

--- a/custom_components/ecoflow_energy/coordinator/core.py
+++ b/custom_components/ecoflow_energy/coordinator/core.py
@@ -198,15 +198,18 @@ class EcoFlowDeviceCoordinator(
         # Each heartbeat contains only one pack; this map ensures the same
         # physical pack always maps to the same pack{n}_* sensor keys.
         self._bp_sn_to_index: dict[str, int] = {}
-        # Battery charge/discharge state: rolling-average derivation (#63).
-        # State is derived from a 3-minute moving average of signed batt_w,
+        # Battery charge/discharge state: rolling-average derivation (#63, #50).
+        # State is derived from a short moving average of signed batt_w,
         # not the instantaneous value. This filters short oscillations that
         # occur when solar production and house load balance (morning/evening),
         # where instantaneous power swings from +1000W to -300W within seconds.
-        # Min hold time prevents rapid flipping even if the average crosses
-        # a threshold right after a transition.
+        # A confirmation window requires a diverging candidate state to persist
+        # before the transition is committed; min hold time additionally blocks
+        # a new transition right after a commit.
         self._batt_w_samples: list[tuple[float, float]] = []  # (monotonic_ts, batt_w)
         self._batt_state_changed_at: float = 0.0  # monotonic timestamp
+        self._batt_pending_state: str | None = None  # candidate awaiting confirmation
+        self._batt_pending_since: float = 0.0  # monotonic ts when candidate appeared
 
         # Energy integrator for power → kWh Riemann sum (all device types)
         state_path = hass.config.path(f".storage/ecoflow_energy_{self.device_sn}.json")

--- a/custom_components/ecoflow_energy/coordinator/state_apply.py
+++ b/custom_components/ecoflow_energy/coordinator/state_apply.py
@@ -181,16 +181,17 @@ class StateApplyMixin:
             return
         self._energy_integrator.set_total(key, total_kwh)
 
-    # Battery state derivation parameters (#63).
+    # Battery state derivation parameters (#63, #50).
     # These are class-level so tests can override without touching instance state.
-    BATT_WINDOW_S = 180       # 3-minute rolling window
+    BATT_WINDOW_S = 120       # 2-minute rolling window (confirmation does the rest)
     BATT_MIN_SAMPLES = 10     # minimum samples before derivation is trusted
     BATT_OUTER_W = 150        # |avg| > 150W -> charging/discharging
     BATT_INNER_W = 50         # |avg| < 50W  -> standby
     BATT_MIN_HOLD_S = 120     # min seconds a state must be held before it can change
+    BATT_CONFIRM_S = 600      # a diverging candidate must persist this long to commit
 
     def _derive_battery_state(self) -> None:
-        """Derive battery charge/discharge state from a rolling-average power (#63).
+        """Derive battery charge/discharge state from a rolling-average power (#63, #50).
 
         The raw EMS field bp_chg_dsg_sta reports the controller MODE, not the
         physical state, so we override it from signed batt_w. Using the
@@ -203,9 +204,16 @@ class StateApplyMixin:
           2. Drop samples older than BATT_WINDOW_S seconds.
           3. Compute the mean over the buffer.
           4. Apply thresholds to the mean, not the raw sample.
-          5. A deadband between BATT_INNER_W and BATT_OUTER_W keeps prev state.
+          5. A deadband between BATT_INNER_W and BATT_OUTER_W keeps prev state
+             (and deliberately leaves any pending candidate untouched, so a
+             brief dip into the deadband does not restart the confirmation).
           6. A transition requires the previous state to have been held for
              at least BATT_MIN_HOLD_S seconds.
+          7. Confirmation gate: a candidate state that differs from the
+             previous state must persist for BATT_CONFIRM_S seconds before
+             the change is committed. Only the average returning to the
+             previous state's band drops the pending candidate. The very
+             first derived state (no previous state) commits immediately.
 
         Prefers signed `batt_w` when available, falls back to the derived
         charge/discharge power split for HTTP-only paths that never expose
@@ -242,22 +250,51 @@ class StateApplyMixin:
             return  # deadband: keep previous state
 
         if derived == prev:
+            # Settled back into the previous state's band: drop any pending
+            # candidate so a later divergence starts a fresh confirmation.
+            self._batt_pending_state = None
             return
 
         hold_elapsed = now_mono - self._batt_state_changed_at
         if prev is not None and hold_elapsed < self.BATT_MIN_HOLD_S:
             return
 
+        if prev is not None:
+            # Confirmation gate (#50): the diverging candidate must persist
+            # BATT_CONFIRM_S before the transition commits. Deadband samples
+            # neither reset nor clear the pending timer (noreset semantics).
+            if self._batt_pending_state != derived:
+                self._batt_pending_state = derived
+                self._batt_pending_since = now_mono
+                _LOGGER.debug(
+                    "Battery state for %s: avg(%ds)=%.1fW pending %s "
+                    "(was %s, commit in %ds, n=%d)",
+                    self.device_sn,
+                    self.BATT_WINDOW_S,
+                    avg,
+                    derived,
+                    prev,
+                    self.BATT_CONFIRM_S,
+                    len(self._batt_w_samples),
+                )
+                return
+            confirm_elapsed = now_mono - self._batt_pending_since
+            if confirm_elapsed < self.BATT_CONFIRM_S:
+                return
+            self._batt_pending_state = None
+
         self._device_data["batt_charge_discharge_state"] = derived
         self._batt_state_changed_at = now_mono
         _LOGGER.debug(
-            "Battery state for %s: avg(%ds)=%.1fW -> %s (was %s, held %.0fs, n=%d)",
+            "Battery state for %s: avg(%ds)=%.1fW -> %s "
+            "(was %s, held %.0fs, confirmed %.0fs, n=%d)",
             self.device_sn,
             self.BATT_WINDOW_S,
             avg,
             derived,
             prev,
             hold_elapsed,
+            now_mono - self._batt_pending_since if prev is not None else 0.0,
             len(self._batt_w_samples),
         )
 

--- a/tests/ha/test_coordinator.py
+++ b/tests/ha/test_coordinator.py
@@ -90,6 +90,29 @@ def _feed_samples(
             coordinator._apply_data({"batt_w": float(v)})
 
 
+def _feed_timeline(
+    coordinator,
+    points: list[tuple[float, float]],
+    start_ts: float = 1000.0,
+) -> list[str]:
+    """Feed (offset_seconds, batt_w) points through _apply_data with mocked time.
+
+    Returns the sequence of distinct battery states observed after each
+    sample (deduplicated), so tests can assert on the transition history.
+    """
+    states: list[str] = []
+    with patch(
+        "custom_components.ecoflow_energy.coordinator.time.monotonic"
+    ) as mock_mono:
+        for offset, v in points:
+            mock_mono.return_value = start_ts + offset
+            coordinator._apply_data({"batt_w": float(v)})
+            s = coordinator.device_data.get("batt_charge_discharge_state")
+            if s and (not states or states[-1] != s):
+                states.append(s)
+    return states
+
+
 # Real PowerOcean batt_w timeline sampled from the Prod Raspberry Pi on
 # 2026-04-20 between 06:45 and 07:00 UTC (15 min). The old instantaneous
 # logic produced 8 state flips across this window; the rolling-average
@@ -2557,6 +2580,191 @@ class TestApplyData:
         # Old logic produced 8+ in the same window.
         assert len(transitions) <= 3, f"Expected <=3 transitions, got: {transitions}"
         assert transitions  # must have derived at least one state
+
+    # -------------------------------------------------------------------
+    # Confirmation-time gate (#50): a diverging candidate must persist
+    # BATT_CONFIRM_S before the state commits. Synthetic sequences modeled
+    # on real Prod flip classes (dawn oscillation, cloud swing, load
+    # cycling) with relative times and rounded values.
+    # -------------------------------------------------------------------
+
+    async def test_battery_confirm_dawn_oscillation_no_flip(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """Dawn pattern: batt_w oscillates within +-150W around zero for
+        several minutes. No candidate persists BATT_CONFIRM_S, so the
+        state never leaves discharging."""
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        points: list[tuple[float, float]] = []
+        # Bootstrap: steady discharge (first derived state commits)
+        points += [(i * 10.0, -300.0) for i in range(15)]           # t=0..140
+        # Oscillation around zero for ~500s (< BATT_CONFIRM_S)
+        for i in range(50):                                          # t=150..640
+            points.append((150.0 + i * 10.0, 140.0 if i % 2 == 0 else -140.0))
+        # Back to steady discharge (candidate dropped via derived == prev)
+        points += [(650.0 + i * 10.0, -300.0) for i in range(12)]    # t=650..760
+        states = _feed_timeline(coordinator, points)
+        assert states == ["discharging"], f"Unexpected flips: {states}"
+
+    async def test_battery_confirm_cloud_swing_no_flip(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """Cloud pattern: a multi-kW swing from discharge to charge that
+        lasts under BATT_CONFIRM_S does not commit a transition."""
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        points: list[tuple[float, float]] = []
+        points += [(i * 10.0, -400.0) for i in range(15)]            # t=0..140
+        # Ramp -400W -> +1700W over 300s, then hold +1700W for ~180s
+        for i in range(30):                                          # t=150..440
+            points.append((150.0 + i * 10.0, -400.0 + (i + 1) * 70.0))
+        points += [(460.0 + i * 10.0, 1700.0) for i in range(19)]    # t=460..640
+        states = _feed_timeline(coordinator, points)
+        assert states == ["discharging"], f"Unexpected flips: {states}"
+
+    async def test_battery_confirm_load_cycling_no_flip(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """Load-cycling pattern: a ~90s -1700W appliance burst inside a
+        charging phase does not flip the state."""
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        points: list[tuple[float, float]] = []
+        points += [(i * 10.0, 1000.0) for i in range(15)]            # t=0..140
+        points += [(150.0 + i * 10.0, -1700.0) for i in range(10)]   # t=150..240
+        points += [(250.0 + i * 10.0, 600.0) for i in range(26)]     # t=250..500
+        states = _feed_timeline(coordinator, points)
+        assert states == ["charging"], f"Unexpected flips: {states}"
+
+    async def test_battery_confirm_sustained_change_commits(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """A sustained regime change commits after BATT_CONFIRM_S and is
+        not swallowed."""
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        points: list[tuple[float, float]] = []
+        points += [(i * 10.0, 900.0) for i in range(15)]             # t=0..140
+        points += [(150.0 + i * 10.0, -900.0) for i in range(67)]    # t=150..810
+        _feed_timeline(coordinator, points)
+        # Candidate registered at ~t=220 (first avg < -150 past hold);
+        # 600s not yet elapsed at t=810 -> still charging.
+        assert coordinator.device_data["batt_charge_discharge_state"] == "charging"
+        # One more sample past the confirmation window -> commit.
+        _feed_timeline(coordinator, [(0.0, -900.0)], start_ts=1000.0 + 830.0)
+        assert coordinator.device_data["batt_charge_discharge_state"] == "discharging"
+
+    async def test_battery_confirm_deadband_does_not_reset_timer(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """noreset semantics: while a candidate is pending, a dip of the
+        average into the deadband keeps the confirmation timer running.
+        The commit happens BATT_CONFIRM_S after the candidate first
+        appeared, not after the deadband excursion."""
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        points: list[tuple[float, float]] = []
+        points += [(i * 10.0, 0.0) for i in range(15)]               # t=0..140 standby
+        points += [(150.0 + i * 10.0, 900.0) for i in range(7)]      # t=150..210 candidate
+        # Deadband excursion: window average settles at 100W (50..150)
+        points += [(220.0 + i * 10.0, 100.0) for i in range(13)]     # t=220..340
+        # Candidate band again until just before the 600s confirmation
+        points += [(350.0 + i * 10.0, 900.0) for i in range(46)]     # t=350..800
+        _feed_timeline(coordinator, points)
+        # Pending since ~t=210; at t=800 confirmation not yet elapsed.
+        assert coordinator.device_data["batt_charge_discharge_state"] == "standby"
+        # t=820 -> more than 600s since the candidate appeared -> commit,
+        # proving the deadband excursion did not restart the timer.
+        _feed_timeline(coordinator, [(0.0, 900.0)], start_ts=1000.0 + 820.0)
+        assert coordinator.device_data["batt_charge_discharge_state"] == "charging"
+
+    async def test_battery_confirm_return_to_prev_drops_pending(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """Returning to the previous state's band drops the pending
+        candidate; a later candidate starts a fresh confirmation timer."""
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        points: list[tuple[float, float]] = []
+        points += [(i * 10.0, 0.0) for i in range(15)]               # t=0..140 standby
+        points += [(150.0 + i * 10.0, 900.0) for i in range(16)]     # t=150..300 candidate
+        points += [(310.0 + i * 10.0, 0.0) for i in range(16)]       # t=310..460 back to standby
+        _feed_timeline(coordinator, points)
+        assert coordinator._batt_pending_state is None
+        # Fresh candidate from t=470; old timer (started ~t=210) would
+        # have committed at ~t=810 - the state must still be standby well
+        # past that point.
+        points_d = [(470.0 + i * 10.0, 900.0) for i in range(60)]    # t=470..1060
+        _feed_timeline(coordinator, points_d)
+        assert coordinator.device_data["batt_charge_discharge_state"] == "standby"
+        # The fresh timer commits ~600s after the new candidate appeared.
+        points_e = [(1070.0 + i * 10.0, 900.0) for i in range(9)]    # t=1070..1150
+        _feed_timeline(coordinator, points_e)
+        assert coordinator.device_data["batt_charge_discharge_state"] == "charging"
+
+    async def test_battery_confirm_first_state_commits_immediately(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """First derived state (no previous state) commits without
+        confirmation delay."""
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        _feed_samples(coordinator, [-900.0] * 10)
+        assert coordinator.device_data["batt_charge_discharge_state"] == "discharging"
+        assert coordinator._batt_pending_state is None
+
+    async def test_battery_confirm_hold_gate_still_active(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """Within BATT_MIN_HOLD_S after a confirmed commit, no new
+        transition starts - the hold gate blocks even candidate
+        registration."""
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        points: list[tuple[float, float]] = []
+        points += [(i * 10.0, 900.0) for i in range(15)]             # t=0..140 charging
+        points += [(150.0 + i * 10.0, -900.0) for i in range(69)]    # t=150..830 confirm+commit
+        _feed_timeline(coordinator, points)
+        assert coordinator.device_data["batt_charge_discharge_state"] == "discharging"
+        # Strong opposite swing right after the commit (t=840..930, within
+        # the 120s hold window) -> blocked, and no pending timer starts.
+        swing = [(840.0 + i * 10.0, 900.0) for i in range(10)]       # t=840..930
+        _feed_timeline(coordinator, swing)
+        assert coordinator.device_data["batt_charge_discharge_state"] == "discharging"
+        assert coordinator._batt_pending_state is None
 
     async def test_integrate_energy_prefers_api_total(
         self,


### PR DESCRIPTION
The PowerOcean battery state sensor flipped dozens of times per day at dawn and dusk when battery power oscillates around zero (avg 42/day measured over 7 days, release gate requires <20).

A diverging candidate state must now persist 600s before the transition commits. The rolling window shrinks from 180s to 120s since the confirmation gate does the smoothing. Deadband samples keep the pending timer running, so clean transitions commit with low lag (median ~3 min against the recorded 7-day trace, expected ~9 flips/day avg).

- 8 new unit tests covering oscillation, cloud swings, load cycling, sustained transitions, deadband no-reset, hold-gate interaction
- Full suite: 1353 passed
- Docker validation: 2h live run, 0 errors, noise suppressed while a real sustained transition committed after ~10 min

Ref #50