### PR TITLE
fix: restore switch and number states after a restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Ah battery capacity counters are disabled diagnostic entities. (beta.2)
 
 ### Fixed
+- Switches and numbers now restore their last known state after a Home Assistant restart instead of showing unknown until the first full device status arrives; live device data always replaces the restored value. (beta.10)
 - App API devices reported with an unknown device type are now classified locally using their product name or supported serial-number prefix. (beta.10)
 - Entities no longer stay unavailable indefinitely after a Home Assistant restart that happens while their device is between transmissions. When a device (for example an idle Delta 3) was silent during startup, its entities were written as unavailable and the later recovery was filtered out by the state-write deduplication if the sensor value had not changed, so they never came back without a manual reload. (beta.9)
 - The PowerOcean battery state sensor (charging/discharging/standby) is now stable through short power swings around zero. At dawn and dusk, when solar production and house load balance, the sensor could change state dozens of times a day. A state change now has to persist for ten minutes before the sensor follows it; sustained changes still come through reliably. (beta.8)

--- a/custom_components/ecoflow_energy/number.py
+++ b/custom_components/ecoflow_energy/number.py
@@ -6,7 +6,7 @@ import logging
 import time
 from typing import Any
 
-from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.components.number import NumberMode, RestoreNumber
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -63,9 +63,9 @@ async def async_setup_entry(
 
 
 class EcoFlowNumber(
-    EcoFlowWriteGateMixin, CoordinatorEntity[EcoFlowDeviceCoordinator], NumberEntity
+    EcoFlowWriteGateMixin, CoordinatorEntity[EcoFlowDeviceCoordinator], RestoreNumber
 ):
-    """An EcoFlow number entity."""
+    """An EcoFlow number entity with state restore across restarts."""
 
     _attr_has_entity_name = True
     _attr_mode = NumberMode.BOX
@@ -86,6 +86,7 @@ class EcoFlowNumber(
         self._attr_native_max_value = definition.max_value
         self._attr_native_step = definition.step
 
+        self._restored_value: float | None = None
         self._last_written_value: float | None = None
         self._optimistic_lock_until: float = 0.0
 
@@ -93,6 +94,30 @@ class EcoFlowNumber(
     def available(self) -> bool:
         """Return True if entity is available."""
         return self.coordinator.device_available and super().available
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last known value when the entity is added.
+
+        Enhanced Mode devices can take up to two minutes before the first
+        full status frame arrives. Without a restored value HA renders the
+        number as an empty field for that whole window. The restored value
+        is only a placeholder: as soon as live data delivers the key, the
+        live value always wins (see ``native_value``).
+        """
+        await super().async_added_to_hass()
+        data = self.coordinator.data
+        if data is not None and self._definition.state_key in data:
+            return  # live value already present, nothing to restore
+        last = await self.async_get_last_number_data()
+        if last is None or last.native_value is None:
+            return  # nothing restorable (e.g. state was unknown/unavailable)
+        value = float(last.native_value)
+        if value < self._attr_native_min_value or value > self._attr_native_max_value:
+            return  # out-of-range restored values are discarded
+        self._restored_value = value
+        # Seed the write gate so an identical first live frame does not
+        # trigger a redundant recorder write (mirrors the sensor restore).
+        self._last_written_value = value
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -108,10 +133,16 @@ class EcoFlowNumber(
 
     @property
     def native_value(self) -> float | None:
-        """Return the current value."""
-        if self.coordinator.data is None:
-            return None
-        value = self.coordinator.data.get(self._definition.state_key)
+        """Return the current value, falling back to the restored one.
+
+        Only a MISSING key falls back to the restored value. A key present
+        with value None is an explicit clear and shows as unknown. A live
+        value always beats the restored one.
+        """
+        data = self.coordinator.data
+        if data is None or self._definition.state_key not in data:
+            return self._restored_value
+        value = data[self._definition.state_key]
         if value is None:
             return None
         try:

--- a/custom_components/ecoflow_energy/switch.py
+++ b/custom_components/ecoflow_energy/switch.py
@@ -16,6 +16,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .ecoflow.delta3_commands import (
@@ -66,9 +67,12 @@ async def async_setup_entry(
 
 
 class EcoFlowSwitch(
-    EcoFlowWriteGateMixin, CoordinatorEntity[EcoFlowDeviceCoordinator], SwitchEntity
+    EcoFlowWriteGateMixin,
+    CoordinatorEntity[EcoFlowDeviceCoordinator],
+    SwitchEntity,
+    RestoreEntity,
 ):
-    """An EcoFlow switch entity with optimistic lock."""
+    """An EcoFlow switch entity with optimistic lock and state restore."""
 
     _attr_has_entity_name = True
 
@@ -88,12 +92,34 @@ class EcoFlowSwitch(
         self._optimistic_value: bool | None = None
         self._optimistic_lock_until: float = 0.0
 
+        self._restored_is_on: bool | None = None
         self._last_written_value: bool | None = None
 
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
         return self.coordinator.device_available and super().available
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last known on/off state when the entity is added.
+
+        Enhanced Mode devices can take up to two minutes before the first
+        full status frame arrives. Without a restored state HA renders the
+        switch as unknown for that whole window. The restored state is only
+        a placeholder: as soon as live data delivers the key, the live
+        value always wins (see ``is_on``).
+        """
+        await super().async_added_to_hass()
+        data = self.coordinator.data
+        if data is not None and self._definition.state_key in data:
+            return  # live value already present, nothing to restore
+        last = await self.async_get_last_state()
+        if last is None or last.state not in ("on", "off"):
+            return  # discard unavailable/unknown restored states
+        self._restored_is_on = last.state == "on"
+        # Seed the write gate so an identical first live frame does not
+        # trigger a redundant recorder write (mirrors the sensor restore).
+        self._last_written_value = self._restored_is_on
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -105,19 +131,23 @@ class EcoFlowSwitch(
         """Return true if the switch is on.
 
         During the optimistic lock window, returns the locally set value
-        instead of the coordinator data to prevent flicker.
+        instead of the coordinator data to prevent flicker. When the key
+        is missing from the coordinator data (e.g. right after a restart,
+        before the first full status frame), falls back to the restored
+        state. A live value always beats the restored one.
         """
         if time.monotonic() < self._optimistic_lock_until:
             return self._optimistic_value
 
-        if self.coordinator.data is None:
-            return None
-        value = self.coordinator.data.get(self._definition.state_key)
-        if value is None:
-            return None
-        if isinstance(value, (int, float)):
-            return value != 0
-        return bool(value)
+        data = self.coordinator.data
+        if data is not None and self._definition.state_key in data:
+            value = data[self._definition.state_key]
+            if value is None:
+                return None
+            if isinstance(value, (int, float)):
+                return value != 0
+            return bool(value)
+        return self._restored_is_on
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""

--- a/tests/ha/test_restore_switch_number.py
+++ b/tests/ha/test_restore_switch_number.py
@@ -1,0 +1,359 @@
+"""Tests for switch and number state restore after a Home Assistant restart.
+
+Enhanced Mode devices (e.g. Delta 3) send a full status frame only every
+two minutes. Without restore, switches render as unknown (HA shows buttons
+instead of a toggle) and numbers as empty fields until the first frame
+arrives. These tests verify the restore placeholder, that live data always
+wins, that invalid restored states are discarded, and that the restore
+seed cooperates with the shared write gate and availability sentinel.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.ecoflow_energy.const import (
+    EcoFlowNumberDef,
+    EcoFlowSwitchDef,
+)
+from custom_components.ecoflow_energy.coordinator import EcoFlowDeviceCoordinator
+from custom_components.ecoflow_energy.number import EcoFlowNumber
+from custom_components.ecoflow_energy.switch import EcoFlowSwitch
+
+from .conftest import MOCK_DELTA_DEVICE
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_coordinator(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+) -> EcoFlowDeviceCoordinator:
+    """Create a coordinator without calling async_setup."""
+    return EcoFlowDeviceCoordinator(hass, entry, MOCK_DELTA_DEVICE)
+
+
+def _make_switch(coordinator: EcoFlowDeviceCoordinator) -> EcoFlowSwitch:
+    defn = EcoFlowSwitchDef(key="ac_switch", name="AC Output", state_key="ac_enabled")
+    return EcoFlowSwitch(coordinator, defn)
+
+
+def _make_number(coordinator: EcoFlowDeviceCoordinator) -> EcoFlowNumber:
+    defn = EcoFlowNumberDef(
+        key="ac_charge_speed",
+        name="AC Charge Speed",
+        state_key="ac_charge_watts",
+        unit="W",
+        min_value=200,
+        max_value=2400,
+        step=100,
+    )
+    return EcoFlowNumber(coordinator, defn)
+
+
+async def _add_switch(switch: EcoFlowSwitch, last_state: object) -> None:
+    """Run async_added_to_hass with a mocked restore chain."""
+    with (
+        patch.object(CoordinatorEntity, "async_added_to_hass", new_callable=AsyncMock),
+        patch.object(
+            switch, "async_get_last_state", new_callable=AsyncMock, return_value=last_state
+        ),
+    ):
+        await switch.async_added_to_hass()
+
+
+async def _add_number(number: EcoFlowNumber, last_data: object) -> None:
+    """Run async_added_to_hass with a mocked restore chain."""
+    with (
+        patch.object(CoordinatorEntity, "async_added_to_hass", new_callable=AsyncMock),
+        patch.object(
+            number,
+            "async_get_last_number_data",
+            new_callable=AsyncMock,
+            return_value=last_data,
+        ),
+    ):
+        await number.async_added_to_hass()
+
+
+def _last_state(state: str) -> MagicMock:
+    mock = MagicMock()
+    mock.state = state
+    return mock
+
+
+def _last_number(native_value: float | None) -> MagicMock:
+    mock = MagicMock()
+    mock.native_value = native_value
+    return mock
+
+
+# ===========================================================================
+# Switch restore
+# ===========================================================================
+
+
+class TestSwitchRestore:
+    async def test_restored_on_state_shows_after_add(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        """No live data yet: the restored 'on' state is shown as placeholder."""
+        standard_config_entry.add_to_hass(hass)
+        coordinator = _make_coordinator(hass, standard_config_entry)
+        switch = _make_switch(coordinator)
+
+        await _add_switch(switch, _last_state("on"))
+
+        assert switch.is_on is True
+        assert switch._last_written_value is True
+
+    async def test_restored_off_state_shows_after_add(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        standard_config_entry.add_to_hass(hass)
+        coordinator = _make_coordinator(hass, standard_config_entry)
+        switch = _make_switch(coordinator)
+
+        await _add_switch(switch, _last_state("off"))
+
+        assert switch.is_on is False
+        assert switch._last_written_value is False
+
+    async def test_live_data_replaces_restored_state(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        """The first live frame always beats the restored placeholder."""
+        standard_config_entry.add_to_hass(hass)
+        coordinator = _make_coordinator(hass, standard_config_entry)
+        switch = _make_switch(coordinator)
+
+        await _add_switch(switch, _last_state("on"))
+        assert switch.is_on is True
+
+        coordinator.async_set_updated_data({"ac_enabled": 0})
+        assert switch.is_on is False
+
+    async def test_live_data_at_add_time_skips_restore(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        """A live value present at add time wins; the restore is skipped."""
+        standard_config_entry.add_to_hass(hass)
+        coordinator = _make_coordinator(hass, standard_config_entry)
+        coordinator.async_set_updated_data({"ac_enabled": 0})
+        switch = _make_switch(coordinator)
+
+        await _add_switch(switch, _last_state("on"))
+
+        assert switch._restored_is_on is None
+        assert switch.is_on is False
+
+    @pytest.mark.parametrize("state", ["unavailable", "unknown"])
+    async def test_invalid_restored_state_is_discarded(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+        state: str,
+    ) -> None:
+        standard_config_entry.add_to_hass(hass)
+        coordinator = _make_coordinator(hass, standard_config_entry)
+        switch = _make_switch(coordinator)
+
+        await _add_switch(switch, _last_state(state))
+
+        assert switch._restored_is_on is None
+        assert switch.is_on is None
+
+    async def test_no_previous_state_leaves_switch_unknown(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        standard_config_entry.add_to_hass(hass)
+        coordinator = _make_coordinator(hass, standard_config_entry)
+        switch = _make_switch(coordinator)
+
+        await _add_switch(switch, None)
+
+        assert switch._restored_is_on is None
+        assert switch.is_on is None
+
+    async def test_no_double_write_on_identical_live_value(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        """Restore seeds the write gate: identical live data skips the write."""
+        standard_config_entry.add_to_hass(hass)
+        coordinator = _make_coordinator(hass, standard_config_entry)
+        switch = _make_switch(coordinator)
+
+        await _add_switch(switch, _last_state("on"))
+
+        coordinator.async_set_updated_data({"ac_enabled": 1})
+        with patch.object(switch, "async_write_ha_state") as mock_write:
+            switch._handle_coordinator_update()
+            assert mock_write.call_count == 0
+
+    async def test_availability_sentinel_seeded_via_super_chain(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        """The write-gate mixin's availability seed still runs on add."""
+        standard_config_entry.add_to_hass(hass)
+        coordinator = _make_coordinator(hass, standard_config_entry)
+        switch = _make_switch(coordinator)
+        assert switch._last_written_available is None
+
+        await _add_switch(switch, _last_state("on"))
+
+        assert switch._last_written_available is not None
+
+
+# ===========================================================================
+# Number restore
+# ===========================================================================
+
+
+class TestNumberRestore:
+    async def test_restored_value_shows_after_add(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        """No live data yet: the restored value is shown as placeholder."""
+        standard_config_entry.add_to_hass(hass)
+        coordinator = _make_coordinator(hass, standard_config_entry)
+        number = _make_number(coordinator)
+
+        await _add_number(number, _last_number(800.0))
+
+        assert number.native_value == 800.0
+        assert number._last_written_value == 800.0
+
+    async def test_live_data_replaces_restored_value(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        """The first live frame always beats the restored placeholder."""
+        standard_config_entry.add_to_hass(hass)
+        coordinator = _make_coordinator(hass, standard_config_entry)
+        number = _make_number(coordinator)
+
+        await _add_number(number, _last_number(800.0))
+        assert number.native_value == 800.0
+
+        coordinator.async_set_updated_data({"ac_charge_watts": 1200})
+        assert number.native_value == 1200
+
+    async def test_live_data_at_add_time_skips_restore(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        """A live value present at add time wins; the restore is skipped."""
+        standard_config_entry.add_to_hass(hass)
+        coordinator = _make_coordinator(hass, standard_config_entry)
+        coordinator.async_set_updated_data({"ac_charge_watts": 1200})
+        number = _make_number(coordinator)
+
+        await _add_number(number, _last_number(800.0))
+
+        assert number._restored_value is None
+        assert number.native_value == 1200
+
+    @pytest.mark.parametrize("restored", [100.0, 5000.0])
+    async def test_out_of_range_restored_value_is_discarded(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+        restored: float,
+    ) -> None:
+        """Values below min or above max are never restored."""
+        standard_config_entry.add_to_hass(hass)
+        coordinator = _make_coordinator(hass, standard_config_entry)
+        number = _make_number(coordinator)
+
+        await _add_number(number, _last_number(restored))
+
+        assert number._restored_value is None
+        assert number.native_value is None
+
+    async def test_none_restored_value_is_discarded(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        """A previous unknown/unavailable state restores no native value."""
+        standard_config_entry.add_to_hass(hass)
+        coordinator = _make_coordinator(hass, standard_config_entry)
+        number = _make_number(coordinator)
+
+        await _add_number(number, _last_number(None))
+
+        assert number._restored_value is None
+        assert number.native_value is None
+
+    async def test_no_previous_data_leaves_number_unknown(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        standard_config_entry.add_to_hass(hass)
+        coordinator = _make_coordinator(hass, standard_config_entry)
+        number = _make_number(coordinator)
+
+        await _add_number(number, None)
+
+        assert number._restored_value is None
+        assert number.native_value is None
+
+    async def test_no_double_write_on_identical_live_value(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        """Restore seeds the write gate: identical live data skips the write."""
+        standard_config_entry.add_to_hass(hass)
+        coordinator = _make_coordinator(hass, standard_config_entry)
+        number = _make_number(coordinator)
+
+        await _add_number(number, _last_number(800.0))
+
+        coordinator.async_set_updated_data({"ac_charge_watts": 800})
+        with patch.object(number, "async_write_ha_state") as mock_write:
+            number._handle_coordinator_update()
+            assert mock_write.call_count == 0
+
+    async def test_availability_sentinel_seeded_via_super_chain(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        """The write-gate mixin's availability seed still runs on add."""
+        standard_config_entry.add_to_hass(hass)
+        coordinator = _make_coordinator(hass, standard_config_entry)
+        number = _make_number(coordinator)
+        assert number._last_written_available is None
+
+        await _add_number(number, _last_number(800.0))
+
+        assert number._last_written_available is not None


### PR DESCRIPTION
After a Home Assistant restart, switch and number entities sat in an unknown state until the device sent its next full status message, which takes up to two minutes in Enhanced mode. Home Assistant rendered switches as button pairs and numbers as empty fields during that window.

Both platforms now restore their last known state on startup, the same way sensors already do. Live device data always wins: a present data key takes priority over the restored value, restore is skipped entirely when live data is already available at add time, and invalid restored states (unavailable, unknown, out of range) are discarded.

- switch.py: RestoreEntity, restores on/off with validity checks
- number.py: RestoreNumber, restores native_value with min/max bounds check
- 18 new tests including write-gate interaction and the availability-sentinel super() chain
- Full suite: 1381 passed

Ref #119