### PR TITLE
feat: recognize J32D serial prefix as PowerOcean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Delta 3 Max Plus controls. Both AC outputs, the 12 V output, X-Boost, the buzzer, the bypass lock and the backup reserve can now be switched from Home Assistant, and the charge limit, discharge limit and backup reserve level are adjustable. Every command was verified against a Delta 3 Max Plus before release. (beta.5)
 - Anderson port output power for the Delta 3 Max Plus. (beta.5)
 - Remaining charge and discharge time are now reported only while the battery is actually charging or discharging. The device keeps both values populated at all times and parks the inactive one on a placeholder, which would otherwise show a runtime of over 200 hours on an idle unit. (beta.4)
+- Serial prefix J32D is now recognized as PowerOcean. This European PowerOcean variant reports an empty product name through the app API, so it was previously skipped with "no parser available". Live telemetry was verified against the EcoFlow app on real hardware. Note that this variant currently works in Enhanced mode only, as the EcoFlow Developer API does not expose it (error 1006). (beta.11)
 
 ### Changed
 - Internal restructuring of the device coordinator into smaller, single-purpose modules; no functional or user-facing change. (beta.7)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Download the [latest release](https://github.com/shuette42/ecoflow-energy-ha/rel
 | **Stability** | Official EcoFlow API - supported and stable | Community-driven - unofficial, use at your own risk |
 | **Best for** | Reliable long-term operation | Real-time monitoring, fast automations, PowerOcean control |
 
-**Standard Mode** uses the official EcoFlow IoT Developer API. Apply for free API keys at [developer.ecoflow.com](https://developer.ecoflow.com).
+**Standard Mode** uses the official EcoFlow IoT Developer API. Apply for free API keys at [developer.ecoflow.com](https://developer.ecoflow.com). Note: some European PowerOcean variants (serial numbers starting with `J32D`) are currently not exposed through the Developer API and cannot be linked to an API key (error 1006). These devices work in Enhanced Mode only.
 
 **Enhanced Mode** connects with your EcoFlow email and password. No Developer API keys needed. Faster updates, but this is an unofficial, community-driven protocol that may change without notice.
 
@@ -395,6 +395,8 @@ If the devices are not linked to the API key, HTTP polling fails with error 1006
 4. If the accounts differ, bind the devices manually via their serial numbers
 
 Since v1.8.3, the integration handles this gracefully: error 1006 is logged once with a clear message and does not trigger re-authentication.
+
+**PowerOcean variants with serial prefix `J32D`:** the Developer Portal currently offers no way to link these devices to an API key, so Standard Mode entities stay unavailable (error 1006). This is an EcoFlow API limitation, not a configuration problem. Use Enhanced Mode for these devices - it delivers full real-time data.
 
 </details>
 

--- a/custom_components/ecoflow_energy/ecoflow/const.py
+++ b/custom_components/ecoflow_energy/ecoflow/const.py
@@ -54,6 +54,9 @@ _STREAM_KEYWORDS = ("stream",)
 _SN_PREFIX_MAP = {
     "HJ31": DEVICE_TYPE_POWEROCEAN,
     "HJ32": DEVICE_TYPE_POWEROCEAN,
+    # European PowerOcean variant (#89): verified against live hardware in
+    # Enhanced mode - telemetry matches the EcoFlow app (grid, battery, MPPT).
+    "J32D": DEVICE_TYPE_POWEROCEAN,
     "R351": DEVICE_TYPE_DELTA,
     "R331": DEVICE_TYPE_DELTA,
     "D3M1": DEVICE_TYPE_DELTA3,

--- a/documentation/entities/powerocean.md
+++ b/documentation/entities/powerocean.md
@@ -1,6 +1,8 @@
 # PowerOcean - Entity Reference
 
-Full list of all entities created for PowerOcean devices (HJ31 series).
+Full list of all entities created for PowerOcean devices (HJ31, HJ32, and J32D series).
+
+> **Note:** PowerOcean variants with serial prefix `J32D` (European variant) are currently not exposed through the EcoFlow Developer API and therefore require Enhanced Mode. In Standard Mode these devices report error 1006 and all entities stay unavailable.
 
 **Totals:** 202 sensors, 1 number control
 

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -54,6 +54,11 @@ class TestDeviceTypeRouting:
         # not the Delta 2 Max parser (root cause of the #110 report).
         assert get_device_type("DELTA 3 Max Plus", "") == "delta3"
 
+    def test_j32d_powerocean_by_sn_prefix(self) -> None:
+        # European PowerOcean variant (#89): app API returns empty
+        # product_name, so classification relies on the SN prefix.
+        assert get_device_type("", "J32DTEST00000001") == "powerocean"
+
     def test_delta3_by_sn_prefix(self) -> None:
         assert get_device_type("", "D3M1TEST00000001") == "delta3"
 


### PR DESCRIPTION
## Summary

Adds the serial prefix J32D to the PowerOcean classification map. This European PowerOcean variant reports an empty product name and device_type "unknown" through the app API, so classification relies on the serial-prefix fallback, which did not know J32D. Affected devices were skipped with "no parser available".

## Evidence

Live telemetry was verified against the EcoFlow app on real hardware in Enhanced mode (see #89): solar power, grid import/export, battery power and SoC, home consumption, and pack capacities are all populated and plausible.

## Standard mode limitation

The EcoFlow Developer API does not currently expose this variant. Standard mode fails with error 1006 (device cannot be linked to an API key). Documented in the README (mode table note + troubleshooting) and in the PowerOcean entity reference instead of being worked around.

## Changes

- `ecoflow/const.py`: J32D -> PowerOcean in the SN prefix map
- `tests/test_const.py`: prefix classification test
- `CHANGELOG.md`: 1.15.0 entry (beta.11)
- `README.md`, `documentation/entities/powerocean.md`: Enhanced-only note for J32D

## Testing

- Full test suite: 1382 passed

Ref #89