### PR TITLE
feat: recognize J32E serial prefix as PowerOcean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Anderson port output power for the Delta 3 Max Plus. (beta.5)
 - Remaining charge and discharge time are now reported only while the battery is actually charging or discharging. The device keeps both values populated at all times and parks the inactive one on a placeholder, which would otherwise show a runtime of over 200 hours on an idle unit. (beta.4)
 - Serial prefix J32D is now recognized as PowerOcean. This European PowerOcean variant reports an empty product name through the app API, so it was previously skipped with "no parser available". Live telemetry was verified against the EcoFlow app on real hardware. Note that this variant currently works in Enhanced mode only, as the EcoFlow Developer API does not expose it (error 1006). (beta.11)
+- Serial prefix J32E (PowerOcean Single Phase) is now recognized as PowerOcean. Like J32D, this European variant reports an empty product name through the app API and is not exposed by the EcoFlow Developer API (error 1006), so it requires Enhanced mode. Verified on real hardware with full live telemetry. Single-phase units report only the phases that are physically present. (beta.12)
 
 ### Changed
 - Internal restructuring of the device coordinator into smaller, single-purpose modules; no functional or user-facing change. (beta.7)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Download the [latest release](https://github.com/shuette42/ecoflow-energy-ha/rel
 | **Stability** | Official EcoFlow API - supported and stable | Community-driven - unofficial, use at your own risk |
 | **Best for** | Reliable long-term operation | Real-time monitoring, fast automations, PowerOcean control |
 
-**Standard Mode** uses the official EcoFlow IoT Developer API. Apply for free API keys at [developer.ecoflow.com](https://developer.ecoflow.com). Note: some European PowerOcean variants (serial numbers starting with `J32D`) are currently not exposed through the Developer API and cannot be linked to an API key (error 1006). These devices work in Enhanced Mode only.
+**Standard Mode** uses the official EcoFlow IoT Developer API. Apply for free API keys at [developer.ecoflow.com](https://developer.ecoflow.com). Note: some European PowerOcean variants (serial numbers starting with `J32D` or `J32E`) are currently not exposed through the Developer API and cannot be linked to an API key (error 1006). These devices work in Enhanced Mode only.
 
 **Enhanced Mode** connects with your EcoFlow email and password. No Developer API keys needed. Faster updates, but this is an unofficial, community-driven protocol that may change without notice.
 
@@ -396,7 +396,7 @@ If the devices are not linked to the API key, HTTP polling fails with error 1006
 
 Since v1.8.3, the integration handles this gracefully: error 1006 is logged once with a clear message and does not trigger re-authentication.
 
-**PowerOcean variants with serial prefix `J32D`:** the Developer Portal currently offers no way to link these devices to an API key, so Standard Mode entities stay unavailable (error 1006). This is an EcoFlow API limitation, not a configuration problem. Use Enhanced Mode for these devices - it delivers full real-time data.
+**PowerOcean variants with serial prefix `J32D` or `J32E`:** the Developer Portal currently offers no way to link these devices to an API key, so Standard Mode entities stay unavailable (error 1006). This is an EcoFlow API limitation, not a configuration problem. Use Enhanced Mode for these devices - it delivers full real-time data.
 
 </details>
 

--- a/custom_components/ecoflow_energy/ecoflow/const.py
+++ b/custom_components/ecoflow_energy/ecoflow/const.py
@@ -57,6 +57,10 @@ _SN_PREFIX_MAP = {
     # European PowerOcean variant (#89): verified against live hardware in
     # Enhanced mode - telemetry matches the EcoFlow app (grid, battery, MPPT).
     "J32D": DEVICE_TYPE_POWEROCEAN,
+    # Single-phase European PowerOcean variant (#89): verified via reporter
+    # diagnostics in Enhanced mode - live data across grid/battery/MPPT;
+    # single-phase unit, so only grid phases A and B carry values.
+    "J32E": DEVICE_TYPE_POWEROCEAN,
     "R351": DEVICE_TYPE_DELTA,
     "R331": DEVICE_TYPE_DELTA,
     "D3M1": DEVICE_TYPE_DELTA3,

--- a/documentation/entities/powerocean.md
+++ b/documentation/entities/powerocean.md
@@ -1,8 +1,8 @@
 # PowerOcean - Entity Reference
 
-Full list of all entities created for PowerOcean devices (HJ31, HJ32, and J32D series).
+Full list of all entities created for PowerOcean devices (HJ31, HJ32, J32D, and J32E series).
 
-> **Note:** PowerOcean variants with serial prefix `J32D` (European variant) are currently not exposed through the EcoFlow Developer API and therefore require Enhanced Mode. In Standard Mode these devices report error 1006 and all entities stay unavailable.
+> **Note:** PowerOcean variants with serial prefix `J32D` or `J32E` (European variants) are currently not exposed through the EcoFlow Developer API and therefore require Enhanced Mode. In Standard Mode these devices report error 1006 and all entities stay unavailable. Single-phase variants (`J32E`) report only the phases that are physically present; the remaining phase entities stay empty.
 
 **Totals:** 202 sensors, 1 number control
 

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -59,6 +59,11 @@ class TestDeviceTypeRouting:
         # product_name, so classification relies on the SN prefix.
         assert get_device_type("", "J32DTEST00000001") == "powerocean"
 
+    def test_j32e_powerocean_by_sn_prefix(self) -> None:
+        # Single-phase European PowerOcean variant (#89): same empty
+        # product_name behavior as J32D, classified via SN prefix.
+        assert get_device_type("", "J32ETEST00000001") == "powerocean"
+
     def test_delta3_by_sn_prefix(self) -> None:
         assert get_device_type("", "D3M1TEST00000001") == "delta3"
 


### PR DESCRIPTION
Adds the J32E serial prefix (PowerOcean Single Phase, European variant) to the SN prefix map so these devices are no longer skipped with "no parser available".

- Verified on real hardware in Enhanced mode (reporter diagnostics on #89: healthy, MQTT receiving, 156 live keys)
- Like J32D, the Developer API does not expose this variant (error 1006), so Enhanced mode is required - README and entity docs updated
- Single-phase units report only grid phases A and B; remaining phase entities stay empty
- CHANGELOG entry for v1.15.0-beta.12, manifest stays 1.15.0

Ref #89