### PR TITLE
Feature/bkxx stream support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.15.1] - 2026-07-23
+
+### Added
+- Added serial-prefix and display-name support for the additional Stream family models Stream Ultra (BK11), Stream Max (BK41), Stream AC (BK51), and Stream Ultra X (BK61) so they are recognized correctly in Enhanced Mode and shown with their proper model names in Home Assistant.
+
 ## [1.15.0] - 2026-06-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.15.1] - 2026-07-23
-
-### Added
-- Added serial-prefix and display-name support for the additional Stream family models Stream Ultra (BK11), Stream Max (BK41), Stream AC (BK51), and Stream Ultra X (BK61) so they are recognized correctly in Enhanced Mode and shown with their proper model names in Home Assistant.
-
 ## [1.15.0] - 2026-06-14
 
 ### Added
@@ -19,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Remaining charge and discharge time are now reported only while the battery is actually charging or discharging. The device keeps both values populated at all times and parks the inactive one on a placeholder, which would otherwise show a runtime of over 200 hours on an idle unit. (beta.4)
 - Serial prefix J32D is now recognized as PowerOcean. This European PowerOcean variant reports an empty product name through the app API, so it was previously skipped with "no parser available". Live telemetry was verified against the EcoFlow app on real hardware. Note that this variant currently works in Enhanced mode only, as the EcoFlow Developer API does not expose it (error 1006). (beta.11)
 - Serial prefix J32E (PowerOcean Single Phase) is now recognized as PowerOcean. Like J32D, this European variant reports an empty product name through the app API and is not exposed by the EcoFlow Developer API (error 1006), so it requires Enhanced mode. Verified on real hardware with full live telemetry. Single-phase units report only the phases that are physically present. (beta.12)
+- Additional Stream-family models are now recognized in Enhanced Mode and shown with their model names: Stream Ultra (BK11), Stream Max (BK41), Stream AC (BK51), and Stream Ultra X (BK61), alongside the existing Stream AC Pro (BK31). (beta.13)
 
 ### Changed
 - Internal restructuring of the device coordinator into smaller, single-purpose modules; no functional or user-facing change. (beta.7)

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Power (W), current (A), voltage (V), frequency, temperature · Plug on/off switc
 
 Battery SoC/SoH · signed battery power · battery charge/discharge power · signed AC grid connection power ("Netz-Anschluss": negative=input, positive=output/feed-in) · read-only AC outlet states and outlet power · AC voltage and frequency · battery temperature, capacity and cell voltage diagnostics · LED brightness diagnostics · **Number:** Backup Reserve (3-95%) in Enhanced Mode.
 
-The Stream AC Pro is treated as an AC-coupled battery. House/grid/solar flow values depend on an EcoFlow-paired meter and are disabled by default as diagnostic entities. Individual AC outlets and LED brightness are exposed read-only; the app write path is not yet confirmed for third-party MQTT control.
+The Stream AC Pro is treated as an AC-coupled battery. House/grid/solar flow values depend on an EcoFlow-paired meter and are disabled by default as diagnostic entities. Individual AC outlets and LED brightness are exposed read-only; the app write path is not yet confirmed for third-party MQTT control. The integration also recognizes other Stream-family models in Enhanced Mode, including Stream Ultra (BK11), Stream Max (BK41), Stream AC (BK51), and Stream Ultra X (BK61), and shows their device names accordingly.
 
 </details>
 
@@ -120,7 +120,7 @@ Download the [latest release](https://github.com/shuette42/ecoflow-energy-ha/rel
 
 **Standard Mode** uses the official EcoFlow IoT Developer API. Apply for free API keys at [developer.ecoflow.com](https://developer.ecoflow.com). Note: some European PowerOcean variants (serial numbers starting with `J32D` or `J32E`) are currently not exposed through the Developer API and cannot be linked to an API key (error 1006). These devices work in Enhanced Mode only.
 
-**Enhanced Mode** connects with your EcoFlow email and password. No Developer API keys needed. Faster updates, but this is an unofficial, community-driven protocol that may change without notice.
+**Enhanced Mode** connects with your EcoFlow email and password. No Developer API keys needed. Faster updates, but this is an unofficial, community-driven protocol that may change without notice. Stream-family devices are now recognized by their serial prefixes, including BK11, BK41, BK51, and BK61, so they appear with the correct model names in Home Assistant.
 
 **Upgrading?** See [CHANGELOG.md](CHANGELOG.md) for migration notes. Most upgrades are seamless. v1.13.0 removes the legacy `min_discharge_soc` PowerOcean entity (replaced by `backup_reserve`); after upgrading you may see it as "unavailable" in HA - safe to delete via Settings > Devices & services > Entities.
 

--- a/custom_components/ecoflow_energy/config_flow_setup.py
+++ b/custom_components/ecoflow_energy/config_flow_setup.py
@@ -37,7 +37,12 @@ _LOGGER = logging.getLogger(__name__)
 
 def _device_label(device: dict[str, Any]) -> str:
     """Build a human-readable label for a device selection checkbox."""
-    name = device.get("name") or get_device_name(device.get("product_name") or "", device.get("sn", ""))
+    name = (
+        device.get("name")
+        or device.get("product_name")
+        or get_device_name("", device.get("sn", ""))
+        or DEVICE_TYPE_DISPLAY_NAMES.get(device.get("device_type", ""), "")
+    )
     sn = device.get("sn", "")
     sn_short = f"{sn[:8]}..." if len(sn) > 8 else sn
     status = "" if device.get("online", 0) else " (offline)"

--- a/custom_components/ecoflow_energy/config_flow_setup.py
+++ b/custom_components/ecoflow_energy/config_flow_setup.py
@@ -26,6 +26,7 @@ from .const import (
     DEVICE_TYPE_UNKNOWN,
     MODE_ENHANCED,
     MODE_STANDARD,
+    get_device_name,
     get_device_type,
 )
 from .ecoflow.enhanced_auth import enhanced_login, get_app_device_list
@@ -36,9 +37,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def _device_label(device: dict[str, Any]) -> str:
     """Build a human-readable label for a device selection checkbox."""
-    name = device.get("name") or device.get("product_name") or ""
-    if not name:
-        name = DEVICE_TYPE_DISPLAY_NAMES.get(device.get("device_type", ""), "")
+    name = device.get("name") or get_device_name(device.get("product_name") or "", device.get("sn", ""))
     sn = device.get("sn", "")
     sn_short = f"{sn[:8]}..." if len(sn) > 8 else sn
     status = "" if device.get("online", 0) else " (offline)"

--- a/custom_components/ecoflow_energy/const.py
+++ b/custom_components/ecoflow_energy/const.py
@@ -14,6 +14,7 @@ from .ecoflow.const import (  # noqa: E402
     DEVICE_TYPE_SMARTPLUG,
     DEVICE_TYPE_STREAM,
     DEVICE_TYPE_UNKNOWN,
+    get_device_name,
     get_device_type,
 )
 
@@ -86,7 +87,7 @@ DEVICE_TYPE_DISPLAY_NAMES: dict[str, str] = {
     DEVICE_TYPE_DELTA: "Delta 2 Max",
     DEVICE_TYPE_DELTA3: "Delta 3 Series",
     DEVICE_TYPE_SMARTPLUG: "Smart Plug",
-    DEVICE_TYPE_STREAM: "Stream AC Pro",
+    DEVICE_TYPE_STREAM: "Stream",
 }
 
 # Delta write/profile variants.

--- a/custom_components/ecoflow_energy/coordinator/core.py
+++ b/custom_components/ecoflow_energy/coordinator/core.py
@@ -47,6 +47,7 @@ from ..const import (
     STREAM_ENERGY_FROM_API,
     STREAM_POWER_TO_ENERGY,
     get_delta_profile,
+    get_device_name,
 )
 from ..ecoflow.energy_integrator import EnergyIntegrator
 from .availability import AvailabilityMixin
@@ -105,13 +106,13 @@ class EcoFlowDeviceCoordinator(
             from ..const import get_device_type
             stored_type = get_device_type(device_info.get("product_name", ""), self.device_sn)
         self.device_type: str = stored_type
-        display_name = DEVICE_TYPE_DISPLAY_NAMES.get(self.device_type, "")
+        product_name = device_info.get("product_name", "")
         self.device_name: str = (
-            device_info.get("name") or display_name or "EcoFlow Device"
+            device_info.get("name")
+            or get_device_name(product_name, self.device_sn)
+            or "EcoFlow Device"
         )
-        self.product_name: str = (
-            device_info.get("product_name") or display_name or "Unknown"
-        )
+        self.product_name: str = product_name or get_device_name(product_name, self.device_sn) or "Unknown"
         self._sw_version: str = device_info.get("sw_version", "")
         self.delta_profile: str = (
             get_delta_profile(self.product_name, self.device_sn)

--- a/custom_components/ecoflow_energy/coordinator/core.py
+++ b/custom_components/ecoflow_energy/coordinator/core.py
@@ -107,12 +107,19 @@ class EcoFlowDeviceCoordinator(
             stored_type = get_device_type(device_info.get("product_name", ""), self.device_sn)
         self.device_type: str = stored_type
         product_name = device_info.get("product_name", "")
+        display_name = DEVICE_TYPE_DISPLAY_NAMES.get(self.device_type, "")
         self.device_name: str = (
             device_info.get("name")
             or get_device_name(product_name, self.device_sn)
+            or display_name
             or "EcoFlow Device"
         )
-        self.product_name: str = product_name or get_device_name(product_name, self.device_sn) or "Unknown"
+        self.product_name: str = (
+            product_name
+            or get_device_name(product_name, self.device_sn)
+            or display_name
+            or "Unknown"
+        )
         self._sw_version: str = device_info.get("sw_version", "")
         self.delta_profile: str = (
             get_delta_profile(self.product_name, self.device_sn)

--- a/custom_components/ecoflow_energy/ecoflow/const.py
+++ b/custom_components/ecoflow_energy/ecoflow/const.py
@@ -66,8 +66,38 @@ _SN_PREFIX_MAP = {
     "D3M1": DEVICE_TYPE_DELTA3,
     "P321": DEVICE_TYPE_DELTA3,
     "HW52": DEVICE_TYPE_SMARTPLUG,
+    # BK-series Stream devices:
+    #  - BK11: Stream Ultra
+    #  - BK31: Stream AC Pro
+    #  - BK41: Stream Max
+    #  - BK51: Stream AC
+    #  - BK61: Stream Ultra X
+    "BK11": DEVICE_TYPE_STREAM,
     "BK31": DEVICE_TYPE_STREAM,
+    "BK41": DEVICE_TYPE_STREAM,
+    "BK51": DEVICE_TYPE_STREAM,
+    "BK61": DEVICE_TYPE_STREAM,
 }
+
+_SN_PREFIX_DISPLAY_NAMES: dict[str, str] = {
+    "BK11": "Stream Ultra",
+    "BK31": "Stream AC Pro",
+    "BK41": "Stream Max",
+    "BK51": "Stream AC",
+    "BK61": "Stream Ultra X",
+}
+
+
+def get_device_name(product_name: str, sn: str = "") -> str:
+    """Return a best-effort human-friendly name for the device."""
+    if product_name:
+        return product_name
+    if sn:
+        prefix = sn[:4].upper()
+        if prefix in _SN_PREFIX_DISPLAY_NAMES:
+            return _SN_PREFIX_DISPLAY_NAMES[prefix]
+    device_type = get_device_type(product_name, sn)
+    return DEVICE_TYPE_DISPLAY_NAMES.get(device_type, "")
 
 
 def get_device_type(product_name: str, sn: str = "") -> str:

--- a/custom_components/ecoflow_energy/ecoflow/const.py
+++ b/custom_components/ecoflow_energy/ecoflow/const.py
@@ -87,40 +87,27 @@ _SN_PREFIX_DISPLAY_NAMES: dict[str, str] = {
     "BK61": "Stream Ultra X",
 }
 
-DEVICE_TYPE_DISPLAY_NAMES: dict[str, str] = {
-    DEVICE_TYPE_POWEROCEAN: "PowerOcean",
-    DEVICE_TYPE_DELTA: "Delta 2 Max",
-    DEVICE_TYPE_DELTA3: "Delta 3 Series",
-    DEVICE_TYPE_SMARTPLUG: "Smart Plug",
-    DEVICE_TYPE_STREAM: "Stream",
-}
-
-
 def get_device_name(product_name: str, sn: str = "") -> str:
-    """Return a best-effort human-friendly name for the device."""
+    """Return a human-friendly name for the device.
+
+    A serial-prefix-derived name is only provided for Stream (BK-series)
+    devices, which report an empty product name through the app API. For
+    every other device type the product name is returned when present and
+    an empty string otherwise, so callers keep their existing fallback
+    (device-type display name or bare serial).
+    """
     if product_name:
         return product_name
 
-    base_name = ""
-    if sn:
-        prefix = sn[:4].upper()
-        if prefix in _SN_PREFIX_DISPLAY_NAMES:
-            base_name = _SN_PREFIX_DISPLAY_NAMES[prefix]
-
+    if not sn:
+        return ""
+    base_name = _SN_PREFIX_DISPLAY_NAMES.get(sn[:4].upper(), "")
     if not base_name:
-        device_type = get_device_type(product_name, sn)
-        base_name = DEVICE_TYPE_DISPLAY_NAMES.get(device_type, "")
-
-    if not sn or not base_name:
-        return base_name
+        return ""
 
     serial_tail = sn[-4:]
-    if not serial_tail.isdigit():
-        serial_tail = sn[-4:]
-
-    if len(serial_tail) >= 4 and serial_tail.isdigit():
+    if len(serial_tail) == 4 and serial_tail.isdigit():
         return f"{base_name} ({serial_tail})"
-
     return base_name
 
 

--- a/custom_components/ecoflow_energy/ecoflow/const.py
+++ b/custom_components/ecoflow_energy/ecoflow/const.py
@@ -100,12 +100,28 @@ def get_device_name(product_name: str, sn: str = "") -> str:
     """Return a best-effort human-friendly name for the device."""
     if product_name:
         return product_name
+
+    base_name = ""
     if sn:
         prefix = sn[:4].upper()
         if prefix in _SN_PREFIX_DISPLAY_NAMES:
-            return _SN_PREFIX_DISPLAY_NAMES[prefix]
-    device_type = get_device_type(product_name, sn)
-    return DEVICE_TYPE_DISPLAY_NAMES.get(device_type, "")
+            base_name = _SN_PREFIX_DISPLAY_NAMES[prefix]
+
+    if not base_name:
+        device_type = get_device_type(product_name, sn)
+        base_name = DEVICE_TYPE_DISPLAY_NAMES.get(device_type, "")
+
+    if not sn or not base_name:
+        return base_name
+
+    serial_tail = sn[-4:]
+    if not serial_tail.isdigit():
+        serial_tail = sn[-4:]
+
+    if len(serial_tail) >= 4 and serial_tail.isdigit():
+        return f"{base_name} ({serial_tail})"
+
+    return base_name
 
 
 def get_device_type(product_name: str, sn: str = "") -> str:

--- a/custom_components/ecoflow_energy/ecoflow/const.py
+++ b/custom_components/ecoflow_energy/ecoflow/const.py
@@ -87,6 +87,14 @@ _SN_PREFIX_DISPLAY_NAMES: dict[str, str] = {
     "BK61": "Stream Ultra X",
 }
 
+DEVICE_TYPE_DISPLAY_NAMES: dict[str, str] = {
+    DEVICE_TYPE_POWEROCEAN: "PowerOcean",
+    DEVICE_TYPE_DELTA: "Delta 2 Max",
+    DEVICE_TYPE_DELTA3: "Delta 3 Series",
+    DEVICE_TYPE_SMARTPLUG: "Smart Plug",
+    DEVICE_TYPE_STREAM: "Stream",
+}
+
 
 def get_device_name(product_name: str, sn: str = "") -> str:
     """Return a best-effort human-friendly name for the device."""

--- a/custom_components/ecoflow_energy/ecoflow/parsers/stream_proto.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/stream_proto.py
@@ -1,9 +1,14 @@
 """Protobuf telemetry parser for EcoFlow Stream devices.
 
-Current scope targets BK31 (Stream AC Pro) in app-auth MQTT mode.
-Only fields that have been observed repeatedly in live captures are
-mapped here. The parser is intentionally conservative so we can extend
-it safely as more captures become available.
+Current scope targets BkSeries stream devices in app-auth MQTT mode.
+The parser was derived from the BK31 Stream AC Pro capture and is
+intentionally conservative: only fields observed repeatedly in live
+captures are mapped. The same parser is reused for other BK-series
+device prefixes until hardware-specific differences are identified.
+
+TODO: verify BK11 / BK41 / BK51 / BK61 field layouts against real
+hardware; the current implementation assumes the same protobuf frames
+and field numbers as BK31.
 
 Current field notes from dump analysis:
 - `grid_w` tracks the summed AC grid intake seen in the app "grid

--- a/custom_components/ecoflow_energy/manifest.json
+++ b/custom_components/ecoflow_energy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/shuette42/ecoflow-energy-ha/issues",
   "requirements": [],
-  "version": "1.15.1"
+  "version": "1.15.0"
 }

--- a/custom_components/ecoflow_energy/manifest.json
+++ b/custom_components/ecoflow_energy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/shuette42/ecoflow-energy-ha/issues",
   "requirements": [],
-  "version": "1.15.0"
+  "version": "1.15.1"
 }

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -21,6 +21,7 @@ from ecoflow_energy.const import (
     STREAM_SWITCHES,
     SMARTPLUG_SWITCHES,
     SMARTPLUG_NUMBERS,
+    get_device_name,
     get_device_type,
     get_delta_profile,
 )

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -49,6 +49,18 @@ class TestDeviceTypeRouting:
     def test_stream_detected_by_bk31_prefix(self) -> None:
         assert get_device_type("", "BK31_TEST_DEVICE") == "stream"
 
+    def test_stream_detected_by_bk11_prefix(self) -> None:
+        assert get_device_type("", "BK11TEST00000001") == "stream"
+
+    def test_stream_detected_by_bk41_prefix(self) -> None:
+        assert get_device_type("", "BK41TEST00000001") == "stream"
+
+    def test_stream_detected_by_bk51_prefix(self) -> None:
+        assert get_device_type("", "BK51TEST00000001") == "stream"
+
+    def test_stream_detected_by_bk61_prefix(self) -> None:
+        assert get_device_type("", "BK61TEST00000001") == "stream"
+
     def test_delta3_by_product_name(self) -> None:
         # "DELTA 3 Max Plus" contains "delta" but must route to delta3,
         # not the Delta 2 Max parser (root cause of the #110 report).
@@ -69,6 +81,13 @@ class TestDeviceTypeRouting:
 
     def test_delta3_classic_by_p321_sn_prefix(self) -> None:
         assert get_device_type("", "P321TEST00000001") == "delta3"
+
+    def test_stream_display_name_by_bk_prefix(self) -> None:
+        assert get_device_name("", "BK11TEST00000001") == "Stream Ultra"
+        assert get_device_name("", "BK31TEST00000001") == "Stream AC Pro"
+        assert get_device_name("", "BK41TEST00000001") == "Stream Max"
+        assert get_device_name("", "BK51TEST00000001") == "Stream AC"
+        assert get_device_name("", "BK61TEST00000001") == "Stream Ultra X"
 
     def test_delta3_keyword_wins_over_delta(self) -> None:
         # The delta3 keyword check runs before the generic delta check.

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -84,11 +84,11 @@ class TestDeviceTypeRouting:
         assert get_device_type("", "P321TEST00000001") == "delta3"
 
     def test_stream_display_name_by_bk_prefix(self) -> None:
-        assert get_device_name("", "BK11TEST00000001") == "Stream Ultra"
-        assert get_device_name("", "BK31TEST00000001") == "Stream AC Pro"
-        assert get_device_name("", "BK41TEST00000001") == "Stream Max"
-        assert get_device_name("", "BK51TEST00000001") == "Stream AC"
-        assert get_device_name("", "BK61TEST00000001") == "Stream Ultra X"
+        assert get_device_name("", "BK11TEST00000001") == "Stream Ultra (0001)"
+        assert get_device_name("", "BK31TEST00000001") == "Stream AC Pro (0001)"
+        assert get_device_name("", "BK41TEST00000001") == "Stream Max (0001)"
+        assert get_device_name("", "BK51TEST00000001") == "Stream AC (0001)"
+        assert get_device_name("", "BK61TEST00000001") == "Stream Ultra X (0001)"
 
     def test_delta3_keyword_wins_over_delta(self) -> None:
         # The delta3 keyword check runs before the generic delta check.

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -90,6 +90,23 @@ class TestDeviceTypeRouting:
         assert get_device_name("", "BK51TEST00000001") == "Stream AC (0001)"
         assert get_device_name("", "BK61TEST00000001") == "Stream Ultra X (0001)"
 
+    def test_device_name_prefers_product_name(self) -> None:
+        # A non-empty product name always wins over any prefix-derived name.
+        assert get_device_name("Stream Ultra X", "BK61TEST00000001") == "Stream Ultra X"
+
+    def test_device_name_only_for_stream_prefixes(self) -> None:
+        # The prefix-derived friendly name is Stream-only: every other device
+        # type returns an empty string so callers keep their own fallback.
+        assert get_device_name("", "R351TEST00000001") == ""
+        assert get_device_name("", "HW52FAKE00000001") == ""
+        assert get_device_name("", "J32DTEST00001234") == ""
+        assert get_device_name("", "P321TEST00005678") == ""
+        assert get_device_name("", "") == ""
+
+    def test_stream_display_name_without_numeric_tail(self) -> None:
+        # A non-numeric serial tail drops the suffix rather than guessing.
+        assert get_device_name("", "BK11ABCDXYZ") == "Stream Ultra"
+
     def test_delta3_keyword_wins_over_delta(self) -> None:
         # The delta3 keyword check runs before the generic delta check.
         assert get_device_type("Delta3", "") == "delta3"


### PR DESCRIPTION
## Related Issue

Closes # https://github.com/shuette42/ecoflow-energy-ha/issues/71

## Summary

This PR builds on the Stream AC Pro support introduced in https://github.com/shuette42/ecoflow-energy-ha/commit/8b688c635ba9580b449a2fc6554306a7916a6d71 and adds support for the remaining Stream devices that were still missing: Stream AC, Ultra, Ultra X, and Max.

It reuses the existing entities. I have two Ultra units and one Ultra X at home, and all of the previously implemented entities work as expected.


## Changes

- Add new devices at const.py and modify the way to obtain their name    
    BK-series Stream devices:
    BK11: Stream Ultra
    BK31: Stream AC Pro
    BK41: Stream Max
    BK51: Stream AC
    BK61: Stream Ultra X

## Checklist

- [x] Tests pass (`pytest`)
- [x] CHANGELOG.md updated
- [x] Version bumped in `manifest.json` (if code change)
- [x] README updated (if new sensors, features, or behavior changes)
- [x] No secrets or real device serial numbers in code

## Screenshots
- Tested on HA
<img width="1528" height="797" alt="image" src="https://github.com/user-attachments/assets/6cfa6516-ac51-443c-8f27-b9ac1be2f6b5" />
- Tests
-  
<img width="1080" height="327" alt="image" src="https://github.com/user-attachments/assets/2e798a16-08a9-4046-9af2-320c7bb866f0" />

