### PR TITLE
fix: log graduated-availability transition at info level for transient silence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Ah battery capacity counters are disabled diagnostic entities. (beta.2)
 
 ### Fixed
+- Enhanced mode no longer logs a warning when a device briefly goes silent and its entities turn unavailable. This is a normal step in the graduated availability handling, so it is now logged at info level; a warning is only emitted when reconnect attempts are already failing repeatedly. The log line also reads correctly when a device has sent no data since connecting, instead of showing an infinite age. (beta.15)
 - Switches and numbers now restore their last known state after a Home Assistant restart instead of showing unknown until the first full device status arrives; live device data always replaces the restored value. (beta.10)
 - App API devices reported with an unknown device type are now classified locally using their product name or supported serial-number prefix. (beta.10)
 - Entities no longer stay unavailable indefinitely after a Home Assistant restart that happens while their device is between transmissions. When a device (for example an idle Delta 3) was silent during startup, its entities were written as unavailable and the later recovery was filtered out by the state-write deduplication if the sensor value had not changed, so they never came back without a manual reload. (beta.9)

--- a/custom_components/ecoflow_energy/coordinator/availability.py
+++ b/custom_components/ecoflow_energy/coordinator/availability.py
@@ -194,15 +194,30 @@ class AvailabilityMixin:
                         if self._mqtt_client is not None
                         else 0
                     )
-                    _LOGGER.warning(
-                        "MQTT stream interrupted for %s [%s] (%.0fs, reconnect_attempts=%d) - "
-                        "marking device unavailable",
+                    # Mirror the MQTT layer's escalation (see the cloud_mqtt
+                    # disconnect handler): a first interruption with no pending
+                    # reconnects is normal broker/device silence and stays at
+                    # INFO, symmetric with the recovery log below. Only a
+                    # sustained failure, where reconnects are already being
+                    # attempted, is a degraded state worth a WARNING. This keeps
+                    # healthy operation free of WARNING noise.
+                    age_str = (
+                        "no data since connect"
+                        if self._last_mqtt_ts <= 0
+                        else f"{age:.0f}s"
+                    )
+                    log = _LOGGER.warning if reconnect_attempts > 0 else _LOGGER.info
+                    log(
+                        "Device %s [%s] became unavailable (%s, reconnect_attempts=%d)",
                         self.device_name,
                         self.device_sn,
-                        age,
+                        age_str,
                         reconnect_attempts,
                     )
-                    self._log_event("stale_unavailable", f"age={age:.0f}s, attempts={reconnect_attempts}")
+                    self._log_event(
+                        "stale_unavailable",
+                        f"age={age_str}, attempts={reconnect_attempts}",
+                    )
                     self._device_available = False
                     self._snapshot = DeviceSnapshot(
                         data={},

--- a/tests/ha/test_coordinator.py
+++ b/tests/ha/test_coordinator.py
@@ -1915,7 +1915,10 @@ class TestStaleDetection:
         enhanced_config_entry: MockConfigEntry,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """App-auth marks unavailable only after hard unavailable threshold (10 min)."""
+        """App-auth marks unavailable only after hard unavailable threshold (10 min).
+
+        A sustained failure (reconnect attempts already pending) logs a WARNING.
+        """
         enhanced_config_entry.add_to_hass(hass)
         coordinator = EcoFlowDeviceCoordinator(
             hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
@@ -1923,6 +1926,8 @@ class TestStaleDetection:
         coordinator._mqtt_client = MagicMock()
         coordinator._mqtt_client.is_connected.return_value = False
         coordinator._mqtt_client.try_reconnect.return_value = False
+        # Sustained failure: reconnects already being attempted -> WARNING
+        coordinator._mqtt_client.reconnect_attempts = 5
 
         now = 10_000.0
         with patch(
@@ -1936,7 +1941,52 @@ class TestStaleDetection:
 
             assert coordinator.device_available is False
             assert coordinator.availability_stage == "unavailable"
-        assert "marking device unavailable" in caplog.text
+        assert "became unavailable" in caplog.text
+        assert "reconnect_attempts=5" in caplog.text
+        self._cleanup_stale_timer(coordinator)
+
+    async def test_app_auth_transient_unavailable_logs_info_not_warning(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A transient interruption (no pending reconnects) must not WARN.
+
+        Reproduces a device that connected but has not pushed a frame yet
+        (age is infinite, reconnect_attempts=0). Marking it unavailable is a
+        normal graduated-availability transition and must stay at INFO so the
+        HA log stays free of WARNING noise (zero-noise-logging policy).
+        """
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        coordinator._mqtt_client = MagicMock()
+        coordinator._mqtt_client.is_connected.return_value = True
+        coordinator._mqtt_client.reconnect_attempts = 0
+
+        now = 10_000.0
+        with patch(
+            "custom_components.ecoflow_energy.coordinator.time.monotonic",
+            return_value=now,
+        ):
+            # Never received data -> age is infinite, past the hard threshold
+            coordinator._last_mqtt_ts = 0.0
+            with caplog.at_level("INFO"):
+                coordinator._check_stale()
+
+            assert coordinator.device_available is False
+            assert coordinator.availability_stage == "unavailable"
+
+        assert "became unavailable" in caplog.text
+        assert "no data since connect" in caplog.text
+        # The transition must not be logged at WARNING or above
+        assert not [
+            r for r in caplog.records
+            if r.levelname in ("WARNING", "ERROR", "CRITICAL")
+            and "became unavailable" in r.getMessage()
+        ]
         self._cleanup_stale_timer(coordinator)
 
     async def test_availability_stage_transitions(
@@ -5258,6 +5308,7 @@ class TestAppAuthMode:
         coordinator._mqtt_client = MagicMock()
         coordinator._mqtt_client.is_connected.return_value = False
         coordinator._mqtt_client.try_reconnect.return_value = None
+        coordinator._mqtt_client.reconnect_attempts = 0
 
         # Simulate stale MQTT (no data received)
         coordinator._last_mqtt_ts = 0.0


### PR DESCRIPTION
A device that briefly goes silent and turns unavailable is a normal step in the graduated availability handling, but it was logged at warning level on every occurrence, including the common transient case where no reconnect attempts are pending. That produced a warning in the Home Assistant log during otherwise healthy operation.

The availability layer now mirrors the MQTT layer's escalation: a first interruption with no pending reconnects is logged at info level, and a warning is only emitted when reconnect attempts are already failing repeatedly. An infinite data age (a device that has not sent any data since connecting) now reads as "no data since connect" instead of an infinite number, and the misleading "stream interrupted" wording is dropped when the connection is up but the device is quiet.

Full suite green (1393 tests), including a new test that reproduces the transient case and asserts it is not logged at warning level.