### PR TITLE
docs: list all recognized device models in supported-devices tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@
 | **Delta 2 Max** — Portable Power | 94 | 7 switches, 8 numbers | 4 (solar 1+2, AC in/out) | ~30 s standard / ~2 s enhanced |
 | **Delta 3 Max Plus** — Portable Power | 20 | 7 switches, 3 numbers | - | ~30 s standard / ~2 s enhanced |
 | **Smart Plug** — Switchable Outlet | 11 | 1 switch, 2 numbers | 1 (total energy) | ~30 s standard / ~3 s enhanced |
-| **Stream AC Pro** — AC-coupled Battery | 39 + 2 binary | 1 number (Enhanced only) | 2 default (battery charge/discharge), 2 optional diagnostic (solar/home) | Enhanced only / ~3 s |
+| **Stream** (AC Pro, Ultra, Max, AC, Ultra X) — AC-coupled Battery | 39 + 2 binary | 1 number (Enhanced only) | 2 default (battery charge/discharge), 2 optional diagnostic (solar/home) | Enhanced only / ~3 s |
 
-> **Tip:** Other Delta-series devices (Delta Pro, Delta 2, etc.) should work automatically with the Delta sensor set.
+> **Tip:** Other Delta-series devices (Delta Pro, Delta 2, etc.) should work automatically with the Delta sensor set. Base Delta 3 (non-Max-Plus) uses the Delta 3 sensor set. All Stream models (Ultra, Max, AC, Ultra X) share the Stream sensor set shown above.
 
 <details>
 <summary><b>PowerOcean</b> — 3-phase grid, MPPT tracking, multi-pack battery, EMS diagnostics, energy strategy controls</summary>

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -10,4 +10,6 @@ Complete list of all sensors, switches, numbers, and binary sensors per device:
 
 - [PowerOcean](entities/powerocean.md) - 202 sensors, 1 number control
 - [Delta 2 Max](entities/delta-2-max.md) - 94 sensors, 4 binary sensors, 7 switches, 8 numbers
+- [Delta 3 Max Plus](entities/delta-3-max-plus.md) - 20 sensors, 7 switches, 3 numbers
 - [Smart Plug](entities/smart-plug.md) - 11 sensors, 1 binary sensor, 1 switch, 2 numbers
+- Stream (AC Pro, Ultra, Max, AC, Ultra X) - 39 sensors, 2 binary sensors, 1 number (Enhanced Mode). See the [main README](../README.md#supported-devices) for details.


### PR DESCRIPTION
The device-recognition code accepts more serial prefixes than the docs exposed. This syncs the public device documentation with what the integration actually recognizes.

## What changed

- **README.md** supported-devices table: the single `Stream AC Pro` row is now a `Stream` family row covering AC Pro, Ultra, Max, AC, and Ultra X (BK31/BK11/BK41/BK51/BK61 all share the same sensor set).
- **README.md** tip: extended to note that base Delta 3 (non-Max-Plus, P321) uses the Delta 3 sensor set and that all Stream models share the Stream set.
- **documentation/README.md** entity reference: added Delta 3 Max Plus (links the existing but previously unlinked entity page) and a Stream family entry.

## Why

The most recently added models were only recognized in code, not reflected in the public tables:
- Stream Ultra/Max/AC/Ultra X (only Stream AC Pro was listed)
- base Delta 3 (only Delta 3 Max Plus was listed)
- J32D/J32E EU PowerOcean variants (folded into the PowerOcean row, still covered)

Docs-only, no code under `custom_components/` touched, no version bump.