### PR TITLE
docs: correct supported-devices tables against actual entity definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@
 | | Sensors | Controls | Energy Sensors | Update Rate |
 |:---|:---:|:---:|:---:|:---|
 | **PowerOcean** — Home Battery | 202 | 2 numbers, 1 select (Enhanced only) | 6 (solar, grid, battery, home) | ~30 s standard / ~3 s enhanced |
-| **Delta 2 Max** — Portable Power | 94 | 7 switches, 8 numbers | 4 (solar 1+2, AC in/out) | ~30 s standard / ~2 s enhanced |
+| **Delta 2 Max** — Portable Power | 94 | 7 switches, 8 numbers | 4 (solar 1+2, AC in/out) | ~30 s standard (+ MQTT push) |
 | **Delta 3 Max Plus** — Portable Power | 20 | 7 switches, 3 numbers | - | ~30 s standard / ~2 s enhanced |
 | **Smart Plug** — Switchable Outlet | 11 | 1 switch, 2 numbers | 1 (total energy) | ~30 s standard / ~3 s enhanced |
-| **Stream** (AC Pro, Ultra, Max, AC, Ultra X) — AC-coupled Battery | 39 + 2 binary | 1 number (Enhanced only) | 2 default (battery charge/discharge), 2 optional diagnostic (solar/home) | Enhanced only / ~3 s |
+| **Stream** (AC Pro, Ultra, Max, AC, Ultra X) — AC-coupled Battery | 37 + 2 binary | 1 number (Enhanced only) | 2 default (battery charge/discharge), 2 optional diagnostic (solar/home) | Enhanced only / ~3 s |
 
 > **Tip:** Other Delta-series devices (Delta Pro, Delta 2, etc.) should work automatically with the Delta sensor set. Base Delta 3 (non-Max-Plus) uses the Delta 3 sensor set. All Stream models (Ultra, Max, AC, Ultra X) share the Stream sensor set shown above.
+>
+> **Note:** Every device additionally exposes 2 universal diagnostic sensors (connection status and active mode) that are not included in the sensor counts above.
 
 <details>
 <summary><b>PowerOcean</b> — 3-phase grid, MPPT tracking, multi-pack battery, EMS diagnostics, energy strategy controls</summary>
@@ -67,7 +69,7 @@ The integration enforces the app's `backup_reserve <= solar_surplus_threshold` c
 <details>
 <summary><b>Delta 2 Max</b> — AC/DC/12V switches, charge speed control, real-time MQTT</summary>
 
-Battery SoC/SoH · All input/output power, temperatures, voltages · **Expansion battery packs** (up to 2, disabled by default) · **Switches:** AC, DC, 12V output, beeper, X-Boost, AC auto restart, backup reserve · **Numbers:** AC charge speed (200-2400 W), max/min SoC, standby timeout, screen brightness/timeout, 12V port timeout, backup reserve level · Real-time MQTT push in Standard Mode · ~2 s updates in Enhanced Mode.
+Battery SoC/SoH · All input/output power, temperatures, voltages · **Expansion battery packs** (up to 2, disabled by default) · **Switches:** AC, DC, 12V output, beeper, X-Boost, AC auto restart, backup reserve · **Numbers:** AC charge speed (200-2400 W), max/min SoC, standby timeout, screen brightness/timeout, 12V port timeout, backup reserve level · Real-time MQTT push for faster-than-polling updates.
 
 </details>
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -12,4 +12,4 @@ Complete list of all sensors, switches, numbers, and binary sensors per device:
 - [Delta 2 Max](entities/delta-2-max.md) - 94 sensors, 4 binary sensors, 7 switches, 8 numbers
 - [Delta 3 Max Plus](entities/delta-3-max-plus.md) - 20 sensors, 7 switches, 3 numbers
 - [Smart Plug](entities/smart-plug.md) - 11 sensors, 1 binary sensor, 1 switch, 2 numbers
-- Stream (AC Pro, Ultra, Max, AC, Ultra X) - 39 sensors, 2 binary sensors, 1 number (Enhanced Mode). See the [main README](../README.md#supported-devices) for details.
+- Stream (AC Pro, Ultra, Max, AC, Ultra X) - 37 sensors, 2 binary sensors, 1 number (Enhanced Mode). See the [main README](../README.md#supported-devices) for details.

--- a/documentation/entities/delta-2-max.md
+++ b/documentation/entities/delta-2-max.md
@@ -174,8 +174,7 @@ Two expansion packs (Slave 1, Slave 2), each with 16 sensors. All disabled by de
 
 ## Notes
 
-- Both Standard Mode (~30s) and Enhanced Mode (~2s) provide all sensors
-- Enhanced Mode adds real-time MQTT push for faster updates
-- Standard Mode also receives MQTT push data alongside HTTP polling
-- All switches and numbers work in both modes
+- Standard Mode polls over HTTP (~30s) and also receives MQTT push data for faster updates
+- App-authenticated (WSS) connections receive the same MQTT push; the ~2-3s protobuf Enhanced Mode is exclusive to PowerOcean
+- All sensors, switches, and numbers work regardless of connection type
 - Delta devices with R331 serial numbers use a slightly different command protocol (detected automatically)

--- a/documentation/entities/powerocean.md
+++ b/documentation/entities/powerocean.md
@@ -4,7 +4,7 @@ Full list of all entities created for PowerOcean devices (HJ31, HJ32, J32D, and 
 
 > **Note:** PowerOcean variants with serial prefix `J32D` or `J32E` (European variants) are currently not exposed through the EcoFlow Developer API and therefore require Enhanced Mode. In Standard Mode these devices report error 1006 and all entities stay unavailable. Single-phase variants (`J32E`) report only the phases that are physically present; the remaining phase entities stay empty.
 
-**Totals:** 202 sensors, 1 number control
+**Totals:** 202 sensors, 2 numbers, 1 select
 
 > Entities marked with *disabled* are available but hidden by default. Enable them in **Settings > Devices > EcoFlow PowerOcean > Entities** (click the filter icon and show disabled entities).
 
@@ -148,11 +148,13 @@ Each battery pack creates 24 sensors (7 core + 17 diagnostic). Pack 1 core senso
 
 ---
 
-## Number Controls
+## Controls
 
-| Entity | Unit | Range | Step | Mode |
-|:---|:---:|:---:|:---:|:---|
-| Min Discharge SoC | % | 0 - 30 | 5 | Enhanced only |
+| Entity | Type | Range / Options | Mode |
+|:---|:---:|:---:|:---|
+| Backup Reserve | Number | 0 - 100 % | Enhanced only |
+| Solar Surplus Threshold | Number | 0 - 100 % | Enhanced only |
+| Work Mode | Select | Self-use / AI Schedule | Enhanced only |
 
 ---
 


### PR DESCRIPTION
Follow-up to #142. Instead of only widening the device list, this audits **every cell of every row** in the Supported Devices tables against the real entity definitions in code.

## Findings and fixes

| Device | Result | Change |
|---|---|---|
| PowerOcean | Table row 100% correct (202 sensors = 82 base + 24x5 packs) | Fixed the **entity page**: control count was `1 number control`, actually 2 numbers + 1 select; replaced the stale `Min Discharge SoC` control (removed in v1.13.0) with the current Backup Reserve / Solar Surplus Threshold / Work Mode |
| Delta 2 Max | Counts correct (94/7/8/4) | Update rate **`~2 s enhanced` was wrong** - the protobuf Enhanced Mode is gated to PowerOcean only; Delta gets MQTT push. Fixed in the table, the `<details>` block, and the entity page notes |
| Delta 3 Max Plus | Fully correct | None (the low `20` is by design - no control-mirror or BMS-pack sensors, no energy counters) |
| Smart Plug | Fully correct (`~3 s enhanced` verified via device-specific WSS handling) | None |
| Stream | `39` was a miscount | **39 -> 37**. The 2 universal diagnostic sensors (connection status, active mode) are added to *every* device and were only counted in the Stream row. Added a note explaining the +2 |

## Consistency note

The sensor counts now follow one convention across all rows and all entity-reference pages: the device-specific sensor list length, excluding the 2 universal diagnostic sensors, which are documented in a footnote instead.

Docs-only, no code touched, no version bump.