### PR TITLE
feat: add Delta 3 Max Plus Energy Dashboard sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Serial prefix J32D is now recognized as PowerOcean. This European PowerOcean variant reports an empty product name through the app API, so it was previously skipped with "no parser available". Live telemetry was verified against the EcoFlow app on real hardware. Note that this variant currently works in Enhanced mode only, as the EcoFlow Developer API does not expose it (error 1006). (beta.11)
 - Serial prefix J32E (PowerOcean Single Phase) is now recognized as PowerOcean. Like J32D, this European variant reports an empty product name through the app API and is not exposed by the EcoFlow Developer API (error 1006), so it requires Enhanced mode. Verified on real hardware with full live telemetry. Single-phase units report only the phases that are physically present. (beta.12)
 - Additional Stream-family models are now recognized in Enhanced Mode and shown with their model names: Stream Ultra (BK11), Stream Max (BK41), Stream AC (BK51), and Stream Ultra X (BK61), alongside the existing Stream AC Pro (BK31). (beta.13)
+- Delta 3 Max Plus now exposes Energy Dashboard sensors for solar, solar 2, AC input, and total output energy, integrated from the live power telemetry (the device reports no native energy counters). The four sensors were verified to register with the correct Energy Dashboard attributes on a real Delta 3 Max Plus. (beta.16)
 
 ### Changed
 - Internal restructuring of the device coordinator into smaller, single-purpose modules; no functional or user-facing change. (beta.7)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 |:---|:---:|:---:|:---:|:---|
 | **PowerOcean** — Home Battery | 202 | 2 numbers, 1 select (Enhanced only) | 6 (solar, grid, battery, home) | ~30 s standard / ~3 s enhanced |
 | **Delta 2 Max** — Portable Power | 94 | 7 switches, 8 numbers | 4 (solar 1+2, AC in/out) | ~30 s standard (+ MQTT push) |
-| **Delta 3 Max Plus** — Portable Power | 20 | 7 switches, 3 numbers | - | ~30 s standard / ~2 s enhanced |
+| **Delta 3 Max Plus** — Portable Power | 24 | 7 switches, 3 numbers | 4 (solar 1+2, AC in, output) | ~30 s standard / ~2 s enhanced |
 | **Smart Plug** — Switchable Outlet | 11 | 1 switch, 2 numbers | 1 (total energy) | ~30 s standard / ~3 s enhanced |
 | **Stream** (AC Pro, Ultra, Max, AC, Ultra X) — AC-coupled Battery | 37 + 2 binary | 1 number (Enhanced only) | 2 default (battery charge/discharge), 2 optional diagnostic (solar/home) | Enhanced only / ~3 s |
 

--- a/custom_components/ecoflow_energy/const.py
+++ b/custom_components/ecoflow_energy/const.py
@@ -603,9 +603,10 @@ STREAM_SENSORS: list[EcoFlowSensorDef] = [
 # Telemetry arrives via HTTP quota (Standard mode) or protobuf push
 # (Enhanced mode); both paths produce identical sensor keys. Switches and
 # numbers are defined further below and require Standard mode, because the
-# SET commands go through the official HTTP endpoint. No energy (kWh)
-# sensors yet - the quota exposes no native energy counters (see the
-# delta3_http.py docstring).
+# SET commands go through the official HTTP endpoint. The quota exposes no
+# native energy counters, so the kWh Energy Dashboard sensors are derived
+# from the live power keys via Riemann-sum integration (see
+# DELTA3_POWER_TO_ENERGY and the delta3_http.py docstring).
 
 DELTA3_SENSORS: list[EcoFlowSensorDef] = [
     # --- Battery / SoC ---
@@ -625,6 +626,11 @@ DELTA3_SENSORS: list[EcoFlowSensorDef] = [
     EcoFlowSensorDef("typec3_w", "Type-C 3", "W", "power", "measurement", "mdi:usb-c-port", suggested_display_precision=0),
     EcoFlowSensorDef("usb_qc1_w", "USB QC 1", "W", "power", "measurement", "mdi:usb", suggested_display_precision=0),
     EcoFlowSensorDef("usb_qc2_w", "USB QC 2", "W", "power", "measurement", "mdi:usb", suggested_display_precision=0),
+    # --- Energy Dashboard (total_increasing, kWh; derived via Riemann integration) ---
+    EcoFlowSensorDef("solar_energy_kwh", "Solar Energy", "kWh", "energy", "total_increasing", "mdi:solar-power", suggested_display_precision=2),
+    EcoFlowSensorDef("solar2_energy_kwh", "Solar 2 Energy", "kWh", "energy", "total_increasing", "mdi:solar-power", suggested_display_precision=2),
+    EcoFlowSensorDef("ac_in_energy_kwh", "AC Input Energy", "kWh", "energy", "total_increasing", "mdi:power-plug", suggested_display_precision=2),
+    EcoFlowSensorDef("out_energy_kwh", "Output Energy", "kWh", "energy", "total_increasing", "mdi:power-plug-outline", suggested_display_precision=2),
     # --- Duration (minutes; can exceed 12000, no cap) ---
     EcoFlowSensorDef("chg_remain_time_min", "Charge Time Remaining", "min", "duration", "measurement", "mdi:battery-clock", suggested_display_precision=0),
     EcoFlowSensorDef("dsg_remain_time_min", "Discharge Time Remaining", "min", "duration", "measurement", "mdi:battery-clock-outline", suggested_display_precision=0),
@@ -687,6 +693,18 @@ DELTA_POWER_TO_ENERGY: dict[str, str] = {
 }
 
 DELTA_ENERGY_FROM_API: list[tuple[str, str]] = []
+
+# The Delta 3 HTTP quota exposes no native energy counters, so these kWh
+# sensors are integrated from the live power keys. pow_out_sum_w is the
+# aggregate output (AC + DC + USB), giving one clean "output energy" total.
+DELTA3_POWER_TO_ENERGY: dict[str, str] = {
+    "pv1_in_w": "solar_energy_kwh",
+    "pv2_in_w": "solar2_energy_kwh",
+    "ac_in_w": "ac_in_energy_kwh",
+    "pow_out_sum_w": "out_energy_kwh",
+}
+
+DELTA3_ENERGY_FROM_API: list[tuple[str, str]] = []
 
 SMARTPLUG_POWER_TO_ENERGY: dict[str, str] = {
     "power_w": "energy_kwh",

--- a/custom_components/ecoflow_energy/coordinator/core.py
+++ b/custom_components/ecoflow_energy/coordinator/core.py
@@ -30,9 +30,12 @@ from ..const import (
     AUTH_METHOD_APP,
     AUTH_METHOD_DEVELOPER,
     CONF_AUTH_METHOD,
+    DELTA3_ENERGY_FROM_API,
+    DELTA3_POWER_TO_ENERGY,
     DELTA_ENERGY_FROM_API,
     DELTA_POWER_TO_ENERGY,
     DEVICE_TYPE_DELTA,
+    DEVICE_TYPE_DELTA3,
     DEVICE_TYPE_POWEROCEAN,
     DEVICE_TYPE_DISPLAY_NAMES,
     DEVICE_TYPE_SMARTPLUG,
@@ -230,6 +233,9 @@ class EcoFlowDeviceCoordinator(
         elif self.device_type == DEVICE_TYPE_DELTA:
             self._power_to_energy = DELTA_POWER_TO_ENERGY
             self._energy_from_api = DELTA_ENERGY_FROM_API
+        elif self.device_type == DEVICE_TYPE_DELTA3:
+            self._power_to_energy = DELTA3_POWER_TO_ENERGY
+            self._energy_from_api = DELTA3_ENERGY_FROM_API
         elif self.device_type == DEVICE_TYPE_SMARTPLUG:
             self._power_to_energy = SMARTPLUG_POWER_TO_ENERGY
             self._energy_from_api = SMARTPLUG_ENERGY_FROM_API

--- a/custom_components/ecoflow_energy/ecoflow/parsers/delta3_http.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/delta3_http.py
@@ -12,9 +12,10 @@ and min - there is no deciwatt anywhere in this generation. Values are
 rounded to clean integers (the HTTP quota subset carries no voltage,
 current or temperature fields that would need decimals).
 
-No native energy (Wh/kWh) counters exist in the HTTP quota, so Energy
-Dashboard integration is deferred until the power keys are validated on
-real hardware.
+No native energy (Wh/kWh) counters exist in the HTTP quota. The power
+keys have been validated on real hardware, so the Energy Dashboard
+sensors are derived from them via Riemann-sum integration (see
+DELTA3_POWER_TO_ENERGY in const.py).
 
 Remaining-time quirk: the device keeps both `cmsChgRemTime` and
 `cmsDsgRemTime` populated at all times and parks the direction that is

--- a/custom_components/ecoflow_energy/strings.json
+++ b/custom_components/ecoflow_energy/strings.json
@@ -567,6 +567,9 @@
       "ac_out_energy_kwh": {
         "name": "AC Output Energy"
       },
+      "out_energy_kwh": {
+        "name": "Output Energy"
+      },
       "batt_max_cell_vol_mv": {
         "name": "Cell Voltage (Max)"
       },

--- a/custom_components/ecoflow_energy/translations/de.json
+++ b/custom_components/ecoflow_energy/translations/de.json
@@ -618,6 +618,9 @@
       "ac_out_energy_kwh": {
         "name": "AC-Ausgangsenergie"
       },
+      "out_energy_kwh": {
+        "name": "Ausgangsenergie"
+      },
       "batt_max_cell_vol_mv": {
         "name": "Zellspannung (max.)"
       },

--- a/custom_components/ecoflow_energy/translations/en.json
+++ b/custom_components/ecoflow_energy/translations/en.json
@@ -618,6 +618,9 @@
       "ac_out_energy_kwh": {
         "name": "AC Output Energy"
       },
+      "out_energy_kwh": {
+        "name": "Output Energy"
+      },
       "batt_max_cell_vol_mv": {
         "name": "Cell Voltage (Max)"
       },

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -10,6 +10,6 @@ Complete list of all sensors, switches, numbers, and binary sensors per device:
 
 - [PowerOcean](entities/powerocean.md) - 202 sensors, 1 number control
 - [Delta 2 Max](entities/delta-2-max.md) - 94 sensors, 4 binary sensors, 7 switches, 8 numbers
-- [Delta 3 Max Plus](entities/delta-3-max-plus.md) - 20 sensors, 7 switches, 3 numbers
+- [Delta 3 Max Plus](entities/delta-3-max-plus.md) - 24 sensors, 7 switches, 3 numbers
 - [Smart Plug](entities/smart-plug.md) - 11 sensors, 1 binary sensor, 1 switch, 2 numbers
 - Stream (AC Pro, Ultra, Max, AC, Ultra X) - 37 sensors, 2 binary sensors, 1 number (Enhanced Mode). See the [main README](../README.md#supported-devices) for details.

--- a/documentation/entities/delta-3-max-plus.md
+++ b/documentation/entities/delta-3-max-plus.md
@@ -2,7 +2,7 @@
 
 Full list of all entities created for Delta 3 Max Plus devices (D3M1 series).
 
-**Totals:** 20 sensors, 7 switches, 3 numbers
+**Totals:** 24 sensors, 7 switches, 3 numbers
 
 > Entities marked with *diagnostic* appear in the diagnostics section of the device page.
 
@@ -37,6 +37,17 @@ Full list of all entities created for Delta 3 Max Plus devices (D3M1 series).
 | Type-C 1 / Type-C 2 / Type-C 3 | W | USB-C ports |
 | USB QC 1 / USB QC 2 | W | USB Quick Charge ports |
 
+## Sensors - Energy Dashboard
+
+Integrated from the live power telemetry (the device exposes no native energy counters), so these accumulate over time and can be added to the Home Assistant Energy Dashboard.
+
+| Entity | Unit | Description |
+|:---|:---:|:---|
+| Solar Energy | kWh | Cumulative solar input 1 |
+| Solar 2 Energy | kWh | Cumulative solar input 2 |
+| AC Input Energy | kWh | Cumulative AC charging |
+| Output Energy | kWh | Cumulative total output (AC + DC + USB) |
+
 ---
 
 ## Switches
@@ -67,5 +78,5 @@ Full list of all entities created for Delta 3 Max Plus devices (D3M1 series).
 
 - **Standard Mode (~30 s)** delivers all sensors and controls. Commands go through the official HTTP endpoint.
 - **Enhanced Mode (~2 s)** delivers the same sensors with the same entity IDs, so switching modes keeps history and dashboards intact. Switches and numbers work here as well: commands travel on the live device connection instead of the HTTP endpoint, and the device confirms each one.
-- No energy (kWh) sensors. The device exposes no native energy counters, so nothing is published to the Energy Dashboard.
+- Energy Dashboard sensors (solar, solar 2, AC input, total output) are integrated from the live power telemetry, since the device exposes no native energy counters. Values accumulate over time and start at 0 on a fresh install.
 - Remaining charge and discharge times are only reported while the battery is actually charging or discharging. The device keeps both values populated at all times and parks the inactive one on a placeholder, which would otherwise show a runtime of several hundred hours on an idle unit.

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -10,6 +10,8 @@ from ecoflow_energy.const import (
     DELTA_PROFILE_R351,
     POWEROCEAN_SENSORS,
     DELTA2MAX_SENSORS,
+    DELTA3_SENSORS,
+    DELTA3_POWER_TO_ENERGY,
     SMARTPLUG_SENSORS,
     STREAM_SENSORS,
     STREAM_NUMBERS,
@@ -419,6 +421,38 @@ class TestStreamEntities:
                 assert s.device_class != "battery", (
                     f"{s.key} has device_class='battery' but is not the primary SoC"
                 )
+
+
+class TestDelta3Energy:
+    """Delta 3 Energy Dashboard sensors are integrated from live power keys."""
+
+    ENERGY_KEYS = (
+        "solar_energy_kwh",
+        "solar2_energy_kwh",
+        "ac_in_energy_kwh",
+        "out_energy_kwh",
+    )
+
+    def test_energy_dashboard_sensors_exist(self) -> None:
+        sensors = {s.key: s for s in DELTA3_SENSORS}
+        for key in self.ENERGY_KEYS:
+            assert key in sensors, f"Missing Delta 3 energy sensor: {key}"
+            s = sensors[key]
+            assert s.device_class == "energy", f"{key} must be device_class=energy"
+            assert s.state_class == "total_increasing", f"{key} must be total_increasing"
+            assert s.unit == "kWh", f"{key} must be kWh"
+
+    def test_power_to_energy_mapping(self) -> None:
+        assert DELTA3_POWER_TO_ENERGY == {
+            "pv1_in_w": "solar_energy_kwh",
+            "pv2_in_w": "solar2_energy_kwh",
+            "ac_in_w": "ac_in_energy_kwh",
+            "pow_out_sum_w": "out_energy_kwh",
+        }
+        sensor_keys = {s.key for s in DELTA3_SENSORS}
+        for power_key, energy_key in DELTA3_POWER_TO_ENERGY.items():
+            assert power_key in sensor_keys, f"Source power sensor missing: {power_key}"
+            assert energy_key in sensor_keys, f"Target energy sensor missing: {energy_key}"
 
 
 class TestBatteryDeviceClassSingleton:


### PR DESCRIPTION
Delta 3 Max Plus now feeds the Home Assistant Energy Dashboard. Previously it exposed only instantaneous power (W); this adds cumulative kWh energy sensors.

## Approach

Probing a real Delta 3 confirmed the HTTP quota has **no native energy counters** (all 27 quota keys are instantaneous watts or flags). The four kWh sensors are therefore derived via Riemann-sum integration from the live power keys, the same mechanism used for Delta 2 Max:

| Power key | Energy sensor |
|---|---|
| `pv1_in_w` | Solar Energy |
| `pv2_in_w` | Solar 2 Energy |
| `ac_in_w` | AC Input Energy |
| `pow_out_sum_w` | Output Energy (total: AC + DC + USB) |

The parser had explicitly deferred this "until the power keys are validated on real hardware" - that precondition is now met.

## Verification

- 1395 unit tests pass, including a new `TestDelta3Energy` class (attribute contract + mapping-key existence).
- Deployed to Docker Desktop HA on a real Delta 3 Max Plus: all four entities register, enabled, with the correct Energy Dashboard attributes (`device_class=energy`, `state_class=total_increasing`, `kWh`). Integration loads clean, no new error/warning logs.
- The device was idle during verification, so values read 0.0. Non-zero accumulation will show once the device charges/discharges.

## Changes

- `const.py`: 4 energy `SensorEntityDescription` in `DELTA3_SENSORS`, plus `DELTA3_POWER_TO_ENERGY` / `DELTA3_ENERGY_FROM_API`
- `coordinator/core.py`: `DEVICE_TYPE_DELTA3` dispatch branch (mirrors the Delta branch)
- translations: new `out_energy_kwh` key (en/de/strings)
- docs: Delta 3 sensor count 20 → 24, energy column populated, entity reference updated
- CHANGELOG: entry under [1.15.0] (beta.16)