### PR TITLE
feat: recognize PowerOcean Plus serial prefixes (R371, R374, HJ3C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Serial prefix J32E (PowerOcean Single Phase) is now recognized as PowerOcean. Like J32D, this European variant reports an empty product name through the app API and is not exposed by the EcoFlow Developer API (error 1006), so it requires Enhanced mode. Verified on real hardware with full live telemetry. Single-phase units report only the phases that are physically present. (beta.12)
 - Additional Stream-family models are now recognized in Enhanced Mode and shown with their model names: Stream Ultra (BK11), Stream Max (BK41), Stream AC (BK51), and Stream Ultra X (BK61), alongside the existing Stream AC Pro (BK31). (beta.13)
 - Delta 3 Max Plus now exposes Energy Dashboard sensors for solar, solar 2, AC input, and total output energy, integrated from the live power telemetry (the device reports no native energy counters). The four sensors were verified to register with the correct Energy Dashboard attributes on a real Delta 3 Max Plus. (beta.16)
+- Serial prefixes R371, R374 and HJ3C (PowerOcean Plus) are now recognized as PowerOcean. These higher-power 3-phase hybrid units were previously skipped with "no parser available". Like J32D/J32E they are not exposed through the EcoFlow Developer API and require Enhanced mode; the device is now routed to the PowerOcean parser so entities are created. (beta.17)
 
 ### Changed
 - Internal restructuring of the device coordinator into smaller, single-purpose modules; no functional or user-facing change. (beta.7)

--- a/custom_components/ecoflow_energy/ecoflow/const.py
+++ b/custom_components/ecoflow_energy/ecoflow/const.py
@@ -61,6 +61,14 @@ _SN_PREFIX_MAP = {
     # diagnostics in Enhanced mode - live data across grid/battery/MPPT;
     # single-phase unit, so only grid phases A and B carry values.
     "J32E": DEVICE_TYPE_POWEROCEAN,
+    # PowerOcean Plus variants (#88): higher-power 3-phase hybrid units
+    # (e.g. P3-S1, ~25-30 kW). Not exposed through the Developer API, so
+    # Enhanced mode only - same situation as J32D/J32E. Routed to the
+    # PowerOcean parser so entities are created; field layout to be
+    # confirmed via reporter diagnostics on a Plus unit.
+    "R371": DEVICE_TYPE_POWEROCEAN,
+    "R374": DEVICE_TYPE_POWEROCEAN,
+    "HJ3C": DEVICE_TYPE_POWEROCEAN,
     "R351": DEVICE_TYPE_DELTA,
     "R331": DEVICE_TYPE_DELTA,
     "D3M1": DEVICE_TYPE_DELTA3,

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -79,6 +79,13 @@ class TestDeviceTypeRouting:
         # product_name behavior as J32D, classified via SN prefix.
         assert get_device_type("", "J32ETEST00000001") == "powerocean"
 
+    def test_powerocean_plus_by_sn_prefix(self) -> None:
+        # PowerOcean Plus variants (#88): higher-power 3-phase hybrid units,
+        # Enhanced mode only, classified via SN prefix like J32D/J32E.
+        assert get_device_type("", "R371TEST00000001") == "powerocean"
+        assert get_device_type("", "R374TEST00000001") == "powerocean"
+        assert get_device_type("", "HJ3CTEST00000001") == "powerocean"
+
     def test_delta3_by_sn_prefix(self) -> None:
         assert get_device_type("", "D3M1TEST00000001") == "delta3"
 


### PR DESCRIPTION
Routes the PowerOcean Plus serial prefixes R371, R374 and HJ3C to the PowerOcean parser so these Enhanced-mode units are no longer skipped with "no parser available". Field layout to be confirmed via reporter diagnostics on a Plus unit.

Ref #88