### PR TITLE
feat: capture raw quota of unsupported devices in diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Additional Stream-family models are now recognized in Enhanced Mode and shown with their model names: Stream Ultra (BK11), Stream Max (BK41), Stream AC (BK51), and Stream Ultra X (BK61), alongside the existing Stream AC Pro (BK31). (beta.13)
 - Delta 3 Max Plus now exposes Energy Dashboard sensors for solar, solar 2, AC input, and total output energy, integrated from the live power telemetry (the device reports no native energy counters). The four sensors were verified to register with the correct Energy Dashboard attributes on a real Delta 3 Max Plus. (beta.16)
 - Serial prefixes R371, R374 and HJ3C (PowerOcean Plus) are now recognized as PowerOcean. These higher-power 3-phase hybrid units were previously skipped with "no parser available". Like J32D/J32E they are not exposed through the EcoFlow Developer API and require Enhanced mode; the device is now routed to the PowerOcean parser so entities are created. (beta.17)
+- Diagnostics now include the raw API quota of devices that are discovered but not yet supported by a parser, so field data for new models can be captured from a standard diagnostics download. Serial numbers are redacted and developer credentials are never exposed. (beta.18)
 
 ### Changed
 - Internal restructuring of the device coordinator into smaller, single-purpose modules; no functional or user-facing change. (beta.7)

--- a/custom_components/ecoflow_energy/__init__.py
+++ b/custom_components/ecoflow_energy/__init__.py
@@ -110,6 +110,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: EcoFlowConfigEntry) -> b
             )
             skipped_devices.append({
                 "sn_prefix": sn[:4],
+                # Full SN is carried in-memory only so diagnostics can fetch
+                # this device's raw quota to help add parser support. It is
+                # never persisted and never included in diagnostics output
+                # (only the prefix is exposed there).
+                "sn": sn,
                 "product_name": product_name,
                 "reason": "no parser available for this device type",
             })

--- a/custom_components/ecoflow_energy/diagnostics.py
+++ b/custom_components/ecoflow_energy/diagnostics.py
@@ -6,6 +6,7 @@ NEVER exposes credentials (access_key, secret_key, email, password, certificates
 
 from __future__ import annotations
 
+import logging
 import re
 import time
 from datetime import datetime, timezone
@@ -13,17 +14,23 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     AUTH_METHOD_DEVELOPER,
+    CONF_ACCESS_KEY,
     CONF_AUTH_METHOD,
     CONF_DEVICES,
     CONF_MODE,
+    CONF_SECRET_KEY,
     DATA_SKIPPED_DEVICES,
     DEVICE_TYPE_DELTA3,
     DOMAIN,
 )
 from .coordinator import EcoFlowDeviceCoordinator
+from .ecoflow.cloud_http import EcoFlowHTTPQuota
+
+_LOGGER = logging.getLogger(__name__)
 
 REDACTED = "**REDACTED**"
 
@@ -77,8 +84,73 @@ async def async_get_config_entry_diagnostics(
             "password": REDACTED,
         },
         "devices": devices_diag,
-        "skipped_devices": [dict(item) for item in skipped_devices],
+        "skipped_devices": await _skipped_devices_diagnostics(
+            hass, entry, skipped_devices
+        ),
     }
+
+
+async def _skipped_devices_diagnostics(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    skipped_devices: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Build diagnostics for unsupported/skipped devices.
+
+    For a device we do not yet parse, capture its raw HTTP quota so a parser
+    can be built from real API fields without owning the hardware. The full
+    serial is used only to sign the read-only quota request and is never
+    included in the output — only the SN prefix is exposed. Serial-looking
+    values inside the quota are redacted.
+
+    Requires developer credentials (access key + secret key). In enhanced /
+    app-auth mode those are absent, so the quota is omitted with a note.
+    """
+    access_key = entry.data.get(CONF_ACCESS_KEY)
+    secret_key = entry.data.get(CONF_SECRET_KEY)
+    has_dev_creds = bool(access_key and secret_key)
+    session = async_get_clientsession(hass) if has_dev_creds else None
+
+    result: list[dict[str, Any]] = []
+    for item in skipped_devices:
+        out: dict[str, Any] = {
+            "sn_prefix": item.get("sn_prefix"),
+            "product_name": item.get("product_name"),
+            "reason": item.get("reason"),
+        }
+
+        if not has_dev_creds:
+            out["quota_note"] = (
+                "developer credentials required to capture raw quota "
+                "(device is in enhanced/app-auth mode)"
+            )
+            result.append(out)
+            continue
+
+        sn = item.get("sn")
+        response: dict | None = None
+        if sn:
+            try:
+                client = EcoFlowHTTPQuota(session, access_key, secret_key, sn)
+                response = await client.get_quota_all()
+            except Exception:  # noqa: BLE001
+                # A skipped-device quota fetch failing is expected and not
+                # actionable (unsupported model, transient API error), so it
+                # stays at debug level and never breaks the download. The SN
+                # and any exception detail are deliberately kept out of logs.
+                _LOGGER.debug("Skipped-device quota fetch failed")
+                response = None
+
+        if response is None:
+            out["quota_note"] = "quota fetch unavailable"
+        else:
+            # get_quota_all() already returns the flat quota dict (the client
+            # unwraps the API envelope), so redact and expose it directly.
+            out["raw_quota"] = _redact_serials(response)
+
+        result.append(out)
+
+    return result
 
 
 def _device_diagnostics(coordinator: EcoFlowDeviceCoordinator) -> dict[str, Any]:

--- a/custom_components/ecoflow_energy/ecoflow/cloud_http.py
+++ b/custom_components/ecoflow_energy/ecoflow/cloud_http.py
@@ -53,6 +53,11 @@ class EcoFlowHTTPQuota:
         self.last_error_code: str | None = None
         self._logged_1006: bool = False
 
+    @property
+    def _sn_display(self) -> str:
+        """SN prefix only for logs — never leak a full serial to HA logs."""
+        return self._device_sn[:4] + "..."
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -197,7 +202,7 @@ class EcoFlowHTTPQuota:
                 await asyncio.sleep(HTTP_RETRY_BACKOFF_S)
 
         self.last_error_code = "network"
-        _LOGGER.error("HTTP: all %d attempts failed for %s", HTTP_RETRIES, self._device_sn)
+        _LOGGER.error("HTTP: all %d attempts failed for %s", HTTP_RETRIES, self._sn_display)
         return None
 
     async def _handle_response(self, resp: aiohttp.ClientResponse) -> dict | None:
@@ -206,14 +211,14 @@ class EcoFlowHTTPQuota:
         code = str(data.get("code"))
 
         if resp.ok and code == "0":
-            _LOGGER.debug("HTTP: quota OK for %s", self._device_sn)
+            _LOGGER.debug("HTTP: quota OK for %s", self._sn_display)
             self.last_error_code = None
             self._logged_1006 = False
             return data.get("data") or {}
 
         # EcoFlow error 8521 is a transient server-side error — retry
         if code == "8521":
-            _LOGGER.debug("HTTP: transient error 8521 for %s — will retry", self._device_sn)
+            _LOGGER.debug("HTTP: transient error 8521 for %s — will retry", self._sn_display)
             raise self._RetryableAPIError(f"code={code}")
 
         # Error 1006: device not linked to API key — not an auth failure (#2)
@@ -223,14 +228,14 @@ class EcoFlowHTTPQuota:
                 _LOGGER.warning(
                     "HTTP: device %s not linked to API key — "
                     "verify device binding at developer.ecoflow.com (code=1006)",
-                    self._device_sn,
+                    self._sn_display,
                 )
                 self._logged_1006 = True
             else:
-                _LOGGER.debug("HTTP: device %s still returns 1006", self._device_sn)
+                _LOGGER.debug("HTTP: device %s still returns 1006", self._sn_display)
             return None
 
         self.last_error_code = code
-        _LOGGER.warning("HTTP: quota code=%s msg=%s (sn=%s)", code, data.get("message"), self._device_sn)
+        _LOGGER.warning("HTTP: quota code=%s msg=%s (sn=%s)", code, data.get("message"), self._sn_display)
         return None
 

--- a/tests/ha/test_diagnostics.py
+++ b/tests/ha/test_diagnostics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -492,3 +493,128 @@ class TestDeltaThreeRawQuotaCapture:
         assert coordinator.raw_quota_captured_at > 0
         # Field map still empty → no mapped keys leak into device data
         assert result == {}
+
+
+class TestSkippedDeviceRawQuotaDiagnostics:
+    """Raw quota capture for unsupported/skipped devices (issue #135)."""
+
+    DIAG_QUOTA_PATH = (
+        "custom_components.ecoflow_energy.diagnostics.EcoFlowHTTPQuota"
+    )
+    # Fictional Smart Meter serial: a device we do not yet parse.
+    SKIPPED_SN = "SM3ATEST00000001"
+    # A 16-char alphanumeric quota value that looks like a serial and must
+    # be redacted, alongside numeric fields that must be preserved.
+    FAKE_SERIAL_FIELD = "ABCDEFGH12345678"
+
+    def _register_skipped(self, hass: HomeAssistant, entry: MockConfigEntry) -> None:
+        hass.data.setdefault(DATA_SKIPPED_DEVICES, {})[entry.entry_id] = [
+            {
+                "sn_prefix": self.SKIPPED_SN[:4],
+                "sn": self.SKIPPED_SN,
+                "product_name": "Smart Meter",
+                "reason": "no parser available for this device type",
+            }
+        ]
+
+    def _standard_entry(self) -> MockConfigEntry:
+        return MockConfigEntry(
+            domain=DOMAIN,
+            title="EcoFlow Energy",
+            data={
+                CONF_ACCESS_KEY: "test_access_key",
+                CONF_SECRET_KEY: "test_secret_key",
+                CONF_MODE: MODE_STANDARD,
+                CONF_DEVICES: [],
+            },
+            unique_id="test_access_key",
+        )
+
+    async def test_with_dev_keys_captures_redacted_quota(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """With developer keys: quota captured, serial redacted, SN hidden."""
+        entry = self._standard_entry()
+        entry.add_to_hass(hass)
+        self._register_skipped(hass, entry)
+
+        # get_quota_all() returns the already-unwrapped flat quota dict —
+        # no code/data envelope. Match the real client contract.
+        quota_response = {
+            "meterSn": self.FAKE_SERIAL_FIELD,
+            "gridWatts": 1234,
+            "gridVol": 230.5,
+        }
+
+        with patch(self.DIAG_QUOTA_PATH) as quota_cls:
+            quota_cls.return_value.get_quota_all = AsyncMock(
+                return_value=quota_response
+            )
+            result = await async_get_config_entry_diagnostics(hass, entry)
+
+        device = result["skipped_devices"][0]
+        assert device["sn_prefix"] == "SM3A"
+        assert "sn" not in device
+        assert "raw_quota" in device
+
+        raw = device["raw_quota"]
+        assert raw["meterSn"] == REDACTED
+        assert raw["gridWatts"] == 1234
+        assert raw["gridVol"] == 230.5
+
+        # Full SN and credential values must never appear in the output.
+        serialized = json.dumps(result)
+        assert self.SKIPPED_SN not in serialized
+        assert "SM3A" in serialized
+        assert "test_access_key" not in serialized
+        assert "test_secret_key" not in serialized
+
+    async def test_without_dev_keys_omits_quota(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """App-auth mode (no dev keys): quota omitted with a note, no crash."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="EcoFlow Energy",
+            data={
+                CONF_MODE: MODE_STANDARD,
+                CONF_DEVICES: [],
+            },
+            unique_id="app_auth_entry",
+        )
+        entry.add_to_hass(hass)
+        self._register_skipped(hass, entry)
+
+        result = await async_get_config_entry_diagnostics(hass, entry)
+
+        device = result["skipped_devices"][0]
+        assert device["sn_prefix"] == "SM3A"
+        assert "raw_quota" not in device
+        assert "developer credentials required" in device["quota_note"]
+
+    async def test_fetch_exception_is_swallowed(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """A quota fetch raising yields a note, no crash, no leaked detail."""
+        entry = self._standard_entry()
+        entry.add_to_hass(hass)
+        self._register_skipped(hass, entry)
+
+        secret_detail = "boom-secret-detail"
+
+        with patch(self.DIAG_QUOTA_PATH) as quota_cls:
+            quota_cls.return_value.get_quota_all = AsyncMock(
+                side_effect=RuntimeError(secret_detail)
+            )
+            result = await async_get_config_entry_diagnostics(hass, entry)
+
+        device = result["skipped_devices"][0]
+        assert "raw_quota" not in device
+        assert device["quota_note"] == "quota fetch unavailable"
+
+        serialized = json.dumps(result)
+        assert secret_detail not in serialized
+        assert self.SKIPPED_SN not in serialized

--- a/tests/test_cloud_http.py
+++ b/tests/test_cloud_http.py
@@ -421,6 +421,114 @@ class TestError1006Handling:
         assert client._logged_1006 is False
 
 
+class TestFullSerialNeverLogged:
+    """A full device serial must never reach the HA logs (only the prefix).
+
+    Unsupported devices commonly return 1006, and the diagnostics feature
+    exists to make users attach their HA log to a GitHub issue — so a full
+    serial in the logs would leak. Every error/status log path is checked.
+    """
+
+    FULL_SN = "SM3ATEST00000001"
+    PREFIX = "SM3A"
+
+    def _make_client(self, session):
+        return EcoFlowHTTPQuota(
+            session=session,
+            access_key="ak",
+            secret_key="sk",
+            device_sn=self.FULL_SN,
+            min_interval=0,
+        )
+
+    def _response(self, payload):
+        resp = AsyncMock()
+        resp.ok = True
+        resp.json = AsyncMock(return_value=payload)
+        return resp
+
+    def _assert_no_full_sn(self, caplog):
+        for record in caplog.records:
+            assert self.FULL_SN not in record.getMessage(), (
+                "full serial leaked into logs: " + record.getMessage()
+            )
+
+    @pytest.mark.asyncio
+    async def test_1006_does_not_log_full_sn(self, caplog):
+        import logging
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(
+            return_value=AsyncContextManager(
+                self._response({
+                    "code": "1006",
+                    "message": "current device is not allowed to get device info",
+                })
+            )
+        )
+        client = self._make_client(mock_session)
+
+        with caplog.at_level(logging.DEBUG, logger="ecoflow_energy.ecoflow.cloud_http"):
+            await client.get_quota_all()
+
+        self._assert_no_full_sn(caplog)
+        # The prefix is allowed and expected in the warning.
+        assert any(self.PREFIX in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_generic_error_code_does_not_log_full_sn(self, caplog):
+        import logging
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(
+            return_value=AsyncContextManager(
+                self._response({"code": "1", "message": "invalid param"})
+            )
+        )
+        client = self._make_client(mock_session)
+
+        with caplog.at_level(logging.DEBUG, logger="ecoflow_energy.ecoflow.cloud_http"):
+            await client.get_quota_all()
+
+        self._assert_no_full_sn(caplog)
+
+    @pytest.mark.asyncio
+    async def test_all_attempts_failed_does_not_log_full_sn(self, caplog):
+        import logging
+
+        mock_session = MagicMock()
+        # A network error on every attempt drives the "all attempts failed"
+        # ERROR line.
+        mock_session.get = MagicMock(side_effect=TimeoutError("boom"))
+        client = self._make_client(mock_session)
+
+        with (
+            caplog.at_level(logging.DEBUG, logger="ecoflow_energy.ecoflow.cloud_http"),
+            patch("ecoflow_energy.ecoflow.cloud_http.asyncio.sleep", new=AsyncMock()),
+        ):
+            result = await client.get_quota_all()
+
+        assert result is None
+        self._assert_no_full_sn(caplog)
+
+    @pytest.mark.asyncio
+    async def test_success_does_not_log_full_sn(self, caplog):
+        import logging
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(
+            return_value=AsyncContextManager(
+                self._response({"code": "0", "data": {"soc": 85}})
+            )
+        )
+        client = self._make_client(mock_session)
+
+        with caplog.at_level(logging.DEBUG, logger="ecoflow_energy.ecoflow.cloud_http"):
+            await client.get_quota_all()
+
+        self._assert_no_full_sn(caplog)
+
+
 class TestDeadCodeRemoved:
     def test_no_powerocean_quota_keys(self):
         """POWEROCEAN_QUOTA_KEYS was dead code and must be removed."""

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -17,22 +17,25 @@ def test_diagnostics_redacts_credentials():
         pattern = rf'"{key}":\s*REDACTED'
         assert re.search(pattern, source), f'"{key}" not REDACTED in diagnostics.py'
 
-    # The module must never import or reference CONF_ACCESS_KEY etc.
-    # (except in the REDACTED context)
-    for conf_name in ("CONF_ACCESS_KEY", "CONF_SECRET_KEY", "CONF_EMAIL", "CONF_PASSWORD"):
+    # Email/password are never needed by diagnostics and must never be
+    # referenced. Access/secret key ARE read (read-only) to sign the raw
+    # quota request for unsupported devices, so they are allowed here — the
+    # runtime tests prove their values never reach the output.
+    for conf_name in ("CONF_EMAIL", "CONF_PASSWORD"):
         assert conf_name not in source, f"{conf_name} must not appear in diagnostics.py"
 
 
-def test_diagnostics_no_credential_values_in_output():
-    """Static analysis: diagnostics must never do entry.data[CONF_ACCESS_KEY] etc."""
+def test_diagnostics_no_password_values_in_output():
+    """Static analysis: diagnostics must never read email/password from entry.data."""
     with open(REPO_ROOT / "custom_components/ecoflow_energy/diagnostics.py") as f:
         source = f.read()
 
-    # Must not access raw credential data from entry.data
+    # Must not access email/password from entry.data. Access/secret key are
+    # read for the read-only quota client (see runtime output-guard tests).
     dangerous_patterns = [
-        r'entry\.data\[.*(ACCESS|SECRET|EMAIL|PASSWORD)',
-        r'entry\.data\.get\(.*(access_key|secret_key|email|password)',
+        r'entry\.data\[.*(EMAIL|PASSWORD)',
+        r'entry\.data\.get\(.*(email|password)',
     ]
     for pattern in dangerous_patterns:
         assert not re.search(pattern, source, re.IGNORECASE), \
-            f"diagnostics.py must not access raw credentials: {pattern}"
+            f"diagnostics.py must not access email/password: {pattern}"


### PR DESCRIPTION
Devices that are discovered but have no parser yet (e.g. the EcoFlow Smart Meter, SN prefix `SM3A`) are skipped without creating entities. Their raw HTTP quota is now captured in the config entry diagnostics, so field data for new models can be mapped from a standard diagnostics download without needing the hardware on hand.

## What changed
- Skipped/unsupported devices now include their raw API quota in the diagnostics download.
- The full serial is used only to sign the read-only quota request and is never written to the output. Only the serial prefix is exposed, and serial-looking values inside the quota are redacted.
- In enhanced/app-auth mode (no developer credentials) the quota is omitted with a note; a fetch failure never breaks the download.
- The HTTP quota client now truncates the serial to its prefix in its log lines, so an attached debug log cannot leak a full serial.

## Tests
Full suite: 1403 passing (+4 log-leak regression tests, updated diagnostics tests).

Ref #135