### PR TITLE
fix: stop reconnect churn on slow devices, capture raw frames in diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Delta 3 Max Plus now exposes Energy Dashboard sensors for solar, solar 2, AC input, and total output energy, integrated from the live power telemetry (the device reports no native energy counters). The four sensors were verified to register with the correct Energy Dashboard attributes on a real Delta 3 Max Plus. (beta.16)
 - Serial prefixes R371, R374 and HJ3C (PowerOcean Plus) are now recognized as PowerOcean. These higher-power 3-phase hybrid units were previously skipped with "no parser available". Like J32D/J32E they are not exposed through the EcoFlow Developer API and require Enhanced mode; the device is now routed to the PowerOcean parser so entities are created. (beta.17)
 - Diagnostics now include the raw API quota of devices that are discovered but not yet supported by a parser, so field data for new models can be captured from a standard diagnostics download. Serial numbers are redacted and developer credentials are never exposed. (beta.18)
+- Diagnostics now include the most recent raw device messages received in Enhanced mode, with the serial number masked and each message truncated. Device variants within a serial family do not always use the same telemetry layout, so this makes it possible to check a wrongly decoded device from a diagnostics download alone. (beta.19)
 
 ### Changed
 - Internal restructuring of the device coordinator into smaller, single-purpose modules; no functional or user-facing change. (beta.7)
@@ -26,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Ah battery capacity counters are disabled diagnostic entities. (beta.2)
 
 ### Fixed
+- Devices that send telemetry slowly no longer end up in a constant reconnect loop in Enhanced mode. When a connected device stayed silent, the integration dropped and rebuilt the whole session every time; it now first repeats the requests it normally sends after connecting, which wakes the device up without tearing down the connection, and only reconnects if that does not help. (beta.19)
 - Enhanced mode no longer logs a warning when a device briefly goes silent and its entities turn unavailable. This is a normal step in the graduated availability handling, so it is now logged at info level; a warning is only emitted when reconnect attempts are already failing repeatedly. The log line also reads correctly when a device has sent no data since connecting, instead of showing an infinite age. (beta.15)
 - Switches and numbers now restore their last known state after a Home Assistant restart instead of showing unknown until the first full device status arrives; live device data always replaces the restored value. (beta.10)
 - App API devices reported with an unknown device type are now classified locally using their product name or supported serial-number prefix. (beta.10)

--- a/custom_components/ecoflow_energy/const.py
+++ b/custom_components/ecoflow_energy/const.py
@@ -71,6 +71,12 @@ SMARTPLUG_SOFT_UNAVAILABLE_S = 360.0  # 6 min: SmartPlug tolerates longer gaps
 HARD_UNAVAILABLE_S = 600.0  # 10 min: entities go unavailable
 SMARTPLUG_HARD_UNAVAILABLE_S = 600.0  # 10 min: SmartPlug hard cutoff
 HTTP_FALLBACK_INTERVAL_S = 30
+
+# Raw protobuf frame capture for diagnostics (app-auth push path).
+# Enough frames to cover several push cycles of every command a device sends,
+# truncated so a single oversized frame cannot bloat a diagnostics download.
+RAW_FRAME_LOG_MAX = 24
+RAW_FRAME_MAX_BYTES = 512
 HTTP_SUPPLEMENT_INTERVAL_S = 60  # Enhanced Mode: HTTP supplement poll for detail sensors
 ENERGY_STREAM_KEEPALIVE_S = 20  # Re-send EnergyStreamSwitch every 20s
 QUOTAS_KEEPALIVE_S = 30  # latestQuotas poll interval (app-level keepalive)

--- a/custom_components/ecoflow_energy/coordinator/availability.py
+++ b/custom_components/ecoflow_energy/coordinator/availability.py
@@ -169,7 +169,13 @@ class AvailabilityMixin:
             hard_unavailable_s = self._hard_unavailable_s()
 
             if age > stale_threshold_s:
-                # Reconnect attempts: force-reconnect on connected-but-silent
+                # Connected-but-silent escalation. A full reconnect drops the
+                # WSS session and re-runs the whole subscribe handshake, which
+                # is expensive and — on devices that push slowly — happens
+                # every stale interval. Re-sending the post-connect requests
+                # achieves the same wake-up at a fraction of the cost, so it
+                # runs first; the reconnect follows only if the device stays
+                # silent through the next stale interval.
                 now = time.monotonic()
                 if (
                     mqtt_connected
@@ -178,14 +184,30 @@ class AvailabilityMixin:
                     and (now - self._last_stale_reconnect_ts) >= stale_threshold_s
                 ):
                     self._last_stale_reconnect_ts = now
-                    _LOGGER.info(
-                        "MQTT stale for %s [%s] (%.0fs) while connected - forcing reconnect",
-                        self.device_name,
-                        self.device_sn,
-                        age,
-                    )
-                    self._log_event("stale_force_reconnect", f"age={age:.0f}s")
-                    self.hass.async_add_executor_job(self._mqtt_client.force_reconnect)
+                    if not self._stale_reactivate_tried:
+                        self._stale_reactivate_tried = True
+                        _LOGGER.debug(
+                            "MQTT stale for %s [%s] (%.0fs) while connected - "
+                            "re-sending initial requests",
+                            self.device_name,
+                            self.device_sn,
+                            age,
+                        )
+                        self._log_event("stale_reactivate", f"age={age:.0f}s")
+                        self.hass.async_add_executor_job(
+                            self._mqtt_client.resend_initial_requests,
+                        )
+                    else:
+                        _LOGGER.info(
+                            "MQTT stale for %s [%s] (%.0fs) while connected - forcing reconnect",
+                            self.device_name,
+                            self.device_sn,
+                            age,
+                        )
+                        self._log_event("stale_force_reconnect", f"age={age:.0f}s")
+                        self.hass.async_add_executor_job(self._mqtt_client.force_reconnect)
+                        # Next silence starts with the cheap remedy again.
+                        self._stale_reactivate_tried = False
 
                 # Graduated availability: only mark unavailable after hard threshold
                 if self._device_available and age >= hard_unavailable_s:
@@ -241,6 +263,7 @@ class AvailabilityMixin:
                     # frame arrives, so they return from unavailable promptly.
                     self.async_update_listeners()
                 self._last_stale_reconnect_ts = 0.0
+                self._stale_reactivate_tried = False
 
         # Tier 2+3: try MQTT reconnect if disconnected
         if self._mqtt_client is not None and not mqtt_connected:

--- a/custom_components/ecoflow_energy/coordinator/core.py
+++ b/custom_components/ecoflow_energy/coordinator/core.py
@@ -45,6 +45,7 @@ from ..const import (
     HTTP_FALLBACK_INTERVAL_S,
     POWEROCEAN_ENERGY_FROM_API,
     POWEROCEAN_POWER_TO_ENERGY,
+    RAW_FRAME_LOG_MAX,
     SMARTPLUG_ENERGY_FROM_API,
     SMARTPLUG_POWER_TO_ENERGY,
     STREAM_ENERGY_FROM_API,
@@ -177,6 +178,9 @@ class EcoFlowDeviceCoordinator(
         self._consecutive_http_failures: int = 0
         self._device_available: bool = True
         self._last_stale_reconnect_ts: float = 0.0
+        # Stale escalation: the cheap remedy (re-send post-connect requests)
+        # runs before the expensive one (force reconnect).
+        self._stale_reactivate_tried: bool = False
         self._last_smartplug_get_all_ts: float = 0.0
         # Surplus auto-sync state (PowerOcean Enhanced Mode):
         # the EcoFlow app sets the slider via cmd_id=112 wire field 4 only,
@@ -205,6 +209,13 @@ class EcoFlowDeviceCoordinator(
         self._credential_obtained_ts: float = 0.0
         self._credential_refresh_unsub: asyncio.TimerHandle | None = None
         self._event_log: deque[dict[str, Any]] = deque(maxlen=50)
+        # Raw protobuf frame ring buffer (app-auth push path). A parser can
+        # only be verified against the bytes a device actually sends, and
+        # device variants sharing a serial family do not necessarily share a
+        # field layout. Frames are captured with the serial masked out and
+        # truncated, so a diagnostics download stays a safe way to report a
+        # mis-decoded device without owning the hardware.
+        self._raw_frames: deque[dict[str, Any]] = deque(maxlen=RAW_FRAME_LOG_MAX)
         # Stable SN → pack index mapping for proto heartbeats (cmd_id=7).
         # Each heartbeat contains only one pack; this map ensures the same
         # physical pack always maps to the same pack{n}_* sensor keys.
@@ -294,6 +305,11 @@ class EcoFlowDeviceCoordinator(
         """Return the MQTT client (or None if not set up)."""
         return self._mqtt_client
 
+
+    @property
+    def raw_frames(self) -> list[dict[str, Any]]:
+        """Return the captured raw protobuf frames for diagnostics export."""
+        return list(self._raw_frames)
 
     @property
     def event_log(self) -> list[dict[str, Any]]:

--- a/custom_components/ecoflow_energy/coordinator/mqtt_ingest.py
+++ b/custom_components/ecoflow_energy/coordinator/mqtt_ingest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import time
 from typing import Any
 
 from ..const import (
@@ -13,6 +14,7 @@ from ..const import (
     DEVICE_TYPE_POWEROCEAN,
     DEVICE_TYPE_SMARTPLUG,
     DEVICE_TYPE_STREAM,
+    RAW_FRAME_MAX_BYTES,
 )
 from ..ecoflow.parsers.delta import parse_delta_report
 from ..ecoflow.parsers.delta_http import parse_delta_http_quota
@@ -29,6 +31,7 @@ from ..ecoflow.parsers.powerocean_proto import (
 from ..ecoflow.parsers.powerocean import parse_powerocean_http_quota
 from ..ecoflow.parsers.smartplug import parse_smartplug_http_quota, parse_smartplug_report
 from ..ecoflow.parsers.stream_proto import parse_stream_proto_message
+from ..ecoflow.proto.decoder import decode_header_message
 from ..ecoflow.proto.runtime import decode_proto_runtime_frame
 
 _LOGGER = logging.getLogger(__name__)
@@ -109,8 +112,71 @@ class MqttIngestMixin:
         ):
             return  # Standard Mode (non-Delta/SmartPlug): ignore MQTT data
         parsed = self._parse_message(topic, payload)
+        self._capture_raw_frame(topic, payload, parsed)
         if parsed:
             self.hass.loop.call_soon_threadsafe(self._apply_data, parsed)
+
+    def _capture_raw_frame(
+        self,
+        topic: str,
+        payload: bytes,
+        parsed: dict[str, Any] | None,
+    ) -> None:
+        """Record a protobuf frame for diagnostics (Paho thread).
+
+        Captures what the device actually sent alongside what the parser made
+        of it, so a mis-decoded device variant can be diagnosed from a
+        diagnostics download alone. Only the app-auth push path is captured:
+        the HTTP quota path already exposes its keys verbatim.
+
+        The frame is truncated and the device serial is masked before storage.
+        Capture never affects ingest — any failure is swallowed.
+        """
+        if not self._enhanced_mode or b"\x0a" not in payload[:4]:
+            return
+        try:
+            entry: dict[str, Any] = {
+                "ts": time.time(),
+                "topic": "get_reply" if "get_reply" in topic else "property",
+                "size": len(payload),
+                "parsed_keys": len(parsed) if parsed else 0,
+            }
+            try:
+                headers, _ = decode_header_message(payload)
+                entry["cmds"] = [
+                    {"cmd_func": h.get("cmd_func"), "cmd_id": h.get("cmd_id")}
+                    for h in (headers or [])
+                    if isinstance(h, dict)
+                ]
+            except Exception:  # noqa: BLE001
+                entry["cmds"] = []
+            entry["hex"] = self._sanitize_frame(payload)[:RAW_FRAME_MAX_BYTES].hex()
+            self._raw_frames.append(entry)
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug("Raw frame capture failed", exc_info=True)
+
+    def _sanitize_frame(self, payload: bytes) -> bytes:
+        """Mask identifying strings inside a raw frame before it is stored.
+
+        Protobuf frames carry the device serial and, on some commands, the
+        account user id as plain ASCII. Both are replaced with a fixed filler
+        of equal length so the byte offsets a parser analysis depends on stay
+        intact.
+        """
+        sanitized = payload
+        secrets = [self.device_sn]
+        if self._mqtt_client is not None:
+            user_id = getattr(self._mqtt_client, "user_id", None)
+            if isinstance(user_id, str):
+                secrets.append(user_id)
+        for secret in secrets:
+            if not secret:
+                continue
+            for variant in {secret, secret.upper(), secret.lower()}:
+                raw = variant.encode("ascii", "ignore")
+                if raw and raw in sanitized:
+                    sanitized = sanitized.replace(raw, b"X" * len(raw))
+        return sanitized
 
     def _check_delta3_set_ack(self, payload: bytes) -> None:
         """Report a rejected Delta 3 setting (Paho thread).

--- a/custom_components/ecoflow_energy/diagnostics.py
+++ b/custom_components/ecoflow_energy/diagnostics.py
@@ -26,6 +26,7 @@ from .const import (
     DATA_SKIPPED_DEVICES,
     DEVICE_TYPE_DELTA3,
     DOMAIN,
+    RAW_FRAME_MAX_BYTES,
 )
 from .coordinator import EcoFlowDeviceCoordinator
 from .ecoflow.cloud_http import EcoFlowHTTPQuota
@@ -210,6 +211,18 @@ def _device_diagnostics(coordinator: EcoFlowDeviceCoordinator) -> dict[str, Any]
         "data_key_count": len(data_keys),
         "event_log": _format_event_log(coordinator.event_log),
     }
+
+    # Enhanced Mode: the raw push frames the device sent, with the serial
+    # masked and each frame truncated. Device variants within a serial family
+    # do not always share a field layout, so a mis-decoded variant can only be
+    # diagnosed against the bytes it actually sends.
+    raw_frames = coordinator.raw_frames
+    if raw_frames:
+        diag["raw_frames"] = {
+            "count": len(raw_frames),
+            "truncated_at_bytes": RAW_FRAME_MAX_BYTES,
+            "frames": _format_event_log(raw_frames),
+        }
 
     # Delta 3: the quota field map is community-researched but not yet
     # hardware-verified for every key. Expose the raw HTTP quota key/value

--- a/custom_components/ecoflow_energy/ecoflow/cloud_mqtt.py
+++ b/custom_components/ecoflow_energy/ecoflow/cloud_mqtt.py
@@ -506,6 +506,27 @@ class EcoFlowMQTTClient:
         payload = build_device_get_all_payload()
         return self.publish(topic, payload, qos=1)
 
+    def resend_initial_requests(self) -> bool:
+        """Re-send the post-connect request set without dropping the socket.
+
+        Some devices stop pushing telemetry while the WSS session stays up
+        (observed on PowerOcean Plus units, which only answer right after a
+        subscribe). Repeating the post-connect requests restores the data flow
+        at a fraction of the cost of a full reconnect, so the stale handler
+        tries this first and only tears the session down if it does not help.
+
+        Returns True if at least one request was published.
+        """
+        if not self._wss_mode or not self._user_id or not self.is_connected():
+            return False
+
+        sent = False
+        if self._enhanced_mode:
+            sent |= self.send_energy_stream_switch()
+        sent |= self.send_get_all()
+        sent |= self.send_latest_quotas()
+        return sent
+
     def send_ping(self) -> bool:
         """Send a ping heartbeat to the EcoFlow broker."""
         if not self.is_connected():

--- a/tests/ha/test_coordinator.py
+++ b/tests/ha/test_coordinator.py
@@ -34,6 +34,8 @@ from custom_components.ecoflow_energy.const import (
     MODE_ENHANCED,
     MODE_STANDARD,
     MQTT_HEALTH_CHECK_INTERVAL_S,
+    RAW_FRAME_LOG_MAX,
+    RAW_FRAME_MAX_BYTES,
     SMARTPLUG_GET_ALL_KEEPALIVE_S,
     SMARTPLUG_SOFT_UNAVAILABLE_S,
     SMARTPLUG_STALE_THRESHOLD_S,
@@ -2061,7 +2063,11 @@ class TestStaleDetection:
         hass: HomeAssistant,
         enhanced_config_entry: MockConfigEntry,
     ) -> None:
-        """Connected-but-stale app-auth sessions trigger a forced reconnect."""
+        """Connected-but-stale app-auth sessions trigger a forced reconnect.
+
+        Only after the cheap remedy (re-sending the post-connect requests)
+        has been tried and the device stayed silent.
+        """
         enhanced_config_entry.add_to_hass(hass)
         coordinator = EcoFlowDeviceCoordinator(
             hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
@@ -2069,14 +2075,62 @@ class TestStaleDetection:
         mock_mqtt = MagicMock()
         mock_mqtt.is_connected.return_value = True
         mock_mqtt.force_reconnect.return_value = True
+        mock_mqtt.reconnect_attempts = 0
         coordinator._mqtt_client = mock_mqtt
-        coordinator._last_mqtt_ts = time.monotonic() - STALE_THRESHOLD_S - 5
+        coordinator._last_mqtt_ts = 1000.0
         coordinator._last_stale_reconnect_ts = 0.0
+        now = 1000.0 + STALE_THRESHOLD_S + 5
+        clock = patch(
+            "custom_components.ecoflow_energy.coordinator.availability.time.monotonic",
+            return_value=now,
+        )
 
-        coordinator._check_stale()
+        # First stale check: re-activation only, session stays up.
+        with clock:
+            coordinator._check_stale()
+        self._cleanup_stale_timer(coordinator)
+        await hass.async_block_till_done()
+
+        mock_mqtt.resend_initial_requests.assert_called_once()
+        mock_mqtt.force_reconnect.assert_not_called()
+        assert coordinator._last_stale_reconnect_ts == now
+
+        # Still silent one stale interval later: escalate to reconnect.
+        coordinator._last_stale_reconnect_ts = 0.0
+        with clock:
+            coordinator._check_stale()
+        self._cleanup_stale_timer(coordinator)
+        await hass.async_block_till_done()
 
         mock_mqtt.force_reconnect.assert_called_once()
-        assert coordinator._last_stale_reconnect_ts > 0.0
+        # The next silence starts with the cheap remedy again.
+        assert coordinator._stale_reactivate_tried is False
+        self._cleanup_stale_timer(coordinator)
+
+    async def test_stale_recovery_resets_escalation(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """Recovered data flow resets the escalation state."""
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        mock_mqtt = MagicMock()
+        mock_mqtt.is_connected.return_value = True
+        coordinator._mqtt_client = mock_mqtt
+        coordinator._stale_reactivate_tried = True
+        coordinator._last_mqtt_ts = 1000.0
+
+        with patch(
+            "custom_components.ecoflow_energy.coordinator.availability.time.monotonic",
+            return_value=1000.0 + 1.0,
+        ):
+            coordinator._check_stale()
+
+        assert coordinator._stale_reactivate_tried is False
+        mock_mqtt.force_reconnect.assert_not_called()
         self._cleanup_stale_timer(coordinator)
 
     async def test_stale_triggers_reconnect(
@@ -5175,6 +5229,8 @@ class TestEventLog:
         coordinator._mqtt_client.reconnect_attempts = 0
         coordinator._last_mqtt_ts = time.monotonic() - STALE_THRESHOLD_S - 10
         coordinator._last_stale_reconnect_ts = 0.0
+        # Re-activation already tried, so this check escalates.
+        coordinator._stale_reactivate_tried = True
 
         coordinator._check_stale()
 
@@ -6379,3 +6435,131 @@ class TestMalformedProtoMessages:
             topic = f"/app/device/property/{device['sn']}"
             for payload in self._GARBAGE:
                 assert coordinator._parse_message(topic, payload) is None
+
+
+# ===========================================================================
+# Raw Frame Capture (diagnostics)
+# ===========================================================================
+
+
+class TestRawFrameCapture:
+    """A device variant can only be diagnosed against the bytes it sends."""
+
+    def _frame(self, sn: str, filler: int = 0) -> bytes:
+        """Build a protobuf-shaped frame that carries the serial in ASCII."""
+        return b"\x0a" + bytes([len(sn)]) + sn.encode() + b"\x00" * filler
+
+    async def test_enhanced_frame_is_captured(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """An Enhanced Mode protobuf frame lands in the ring buffer."""
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        payload = self._frame(coordinator.device_sn)
+
+        coordinator._on_mqtt_message(
+            f"/app/device/property/{coordinator.device_sn}", payload
+        )
+
+        frames = coordinator.raw_frames
+        assert len(frames) == 1
+        assert frames[0]["size"] == len(payload)
+        assert frames[0]["topic"] == "property"
+        assert frames[0]["parsed_keys"] == 0
+
+    async def test_serial_is_masked_in_captured_frame(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """The serial never reaches the diagnostics buffer, byte count is kept."""
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        sn = coordinator.device_sn
+
+        coordinator._on_mqtt_message(
+            f"/app/device/property/{sn}", self._frame(sn)
+        )
+
+        captured = bytes.fromhex(coordinator.raw_frames[0]["hex"])
+        assert sn.encode() not in captured
+        assert b"X" * len(sn) in captured
+
+    async def test_frame_is_truncated(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """An oversized frame cannot bloat a diagnostics download."""
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        payload = self._frame(coordinator.device_sn, filler=RAW_FRAME_MAX_BYTES * 2)
+
+        coordinator._on_mqtt_message(
+            f"/app/device/property/{coordinator.device_sn}", payload
+        )
+
+        frame = coordinator.raw_frames[0]
+        assert len(bytes.fromhex(frame["hex"])) == RAW_FRAME_MAX_BYTES
+        assert frame["size"] == len(payload)
+
+    async def test_ring_buffer_is_bounded(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """Only the most recent frames are kept."""
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        topic = f"/app/device/property/{coordinator.device_sn}"
+
+        for _ in range(RAW_FRAME_LOG_MAX + 5):
+            coordinator._on_mqtt_message(topic, self._frame(coordinator.device_sn))
+
+        assert len(coordinator.raw_frames) == RAW_FRAME_LOG_MAX
+
+    async def test_standard_mode_is_not_captured(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        """Standard Mode has an HTTP quota path, so no frames are stored."""
+        standard_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, standard_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+
+        coordinator._on_mqtt_message(
+            f"/app/device/property/{coordinator.device_sn}",
+            self._frame(coordinator.device_sn),
+        )
+
+        assert coordinator.raw_frames == []
+
+    async def test_json_payload_is_not_captured(
+        self,
+        hass: HomeAssistant,
+        enhanced_config_entry: MockConfigEntry,
+    ) -> None:
+        """JSON pushes expose their keys already and are left out."""
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+
+        coordinator._on_mqtt_message(
+            f"/app/device/property/{coordinator.device_sn}",
+            b'{"params": {"bpSoc": 50}}',
+        )
+
+        assert coordinator.raw_frames == []

--- a/tests/ha/test_diagnostics.py
+++ b/tests/ha/test_diagnostics.py
@@ -618,3 +618,44 @@ class TestSkippedDeviceRawQuotaDiagnostics:
         serialized = json.dumps(result)
         assert secret_detail not in serialized
         assert self.SKIPPED_SN not in serialized
+
+
+class TestRawFrameDiagnostics:
+    async def test_no_frames_omits_section(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        """A device without captured frames has no raw_frames section."""
+        standard_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, standard_config_entry, MOCK_DELTA_DEVICE
+        )
+        assert "raw_frames" not in _device_diagnostics(coordinator)
+
+    async def test_captured_frames_exposed_with_iso_timestamps(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        """Captured frames reach diagnostics with readable timestamps."""
+        standard_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, standard_config_entry, MOCK_DELTA_DEVICE
+        )
+        coordinator._raw_frames.append({
+            "ts": 1784973604.0,
+            "topic": "property",
+            "size": 42,
+            "parsed_keys": 5,
+            "cmds": [{"cmd_func": 96, "cmd_id": 33}],
+            "hex": "0a02ffff",
+        })
+
+        result = _device_diagnostics(coordinator)
+
+        assert result["raw_frames"]["count"] == 1
+        frame = result["raw_frames"]["frames"][0]
+        assert frame["hex"] == "0a02ffff"
+        assert frame["cmds"] == [{"cmd_func": 96, "cmd_id": 33}]
+        assert frame["ts_iso"].startswith("2026-")

--- a/tests/test_cloud_mqtt.py
+++ b/tests/test_cloud_mqtt.py
@@ -576,3 +576,47 @@ class TestUpdateCredentials:
         client.client = None
         client.update_credentials("new_account", "new_password")  # must not raise
         assert client._cert_account == "new_account"
+
+
+class TestResendInitialRequests:
+    """The cheap remedy for a connected-but-silent session."""
+
+    def _connected_client(self, **kwargs):
+        client = _make_client(wss_mode=True, user_id="user123", **kwargs)
+        client.client = MagicMock()
+        client.client.is_connected.return_value = True
+        client.client.publish.return_value = MagicMock(rc=0)
+        client.connected = True
+        return client
+
+    def test_enhanced_resends_stream_switch_and_requests(self):
+        client = self._connected_client(enhanced_mode=True)
+
+        assert client.resend_initial_requests() is True
+
+        topics = [call.args[0] for call in client.client.publish.call_args_list]
+        assert any(topic.endswith("/thing/property/set") for topic in topics)
+        assert sum(topic.endswith("/thing/property/get") for topic in topics) == 2
+
+    def test_non_enhanced_skips_stream_switch(self):
+        client = self._connected_client(enhanced_mode=False)
+
+        assert client.resend_initial_requests() is True
+
+        topics = [call.args[0] for call in client.client.publish.call_args_list]
+        assert all(not topic.endswith("/thing/property/set") for topic in topics)
+
+    def test_disconnected_client_sends_nothing(self):
+        client = self._connected_client(enhanced_mode=True)
+        client.connected = False
+
+        assert client.resend_initial_requests() is False
+        client.client.publish.assert_not_called()
+
+    def test_tcp_mode_sends_nothing(self):
+        client = _make_client(wss_mode=False, enhanced_mode=True)
+        client.client = MagicMock()
+        client.connected = True
+
+        assert client.resend_initial_requests() is False
+        client.client.publish.assert_not_called()


### PR DESCRIPTION
Groundwork for #88 (PowerOcean Plus / R374).

A beta.18 test on real R374 hardware showed two problems: the session was
force-reconnecting roughly every 40 s while the device only pushed data every
60-80 s, and the parsed telemetry contained impossible values (power jumping
between 0 W and 1.4e28 W, energy counters around 1e24 kWh) with no MPPT or
phase keys at all.

The second problem cannot be fixed without seeing the bytes the device
actually sends, so this PR covers the two things that can be done now.

## Changes

- **Stale escalation.** A connected-but-silent session first gets the
  post-connect requests re-sent (EnergyStreamSwitch, get-all, latestQuotas)
  and is only torn down and rebuilt if the device stays silent through the
  next stale interval. On the R374 the reconnect was the only thing producing
  data, so raising the threshold instead would have made it worse.
- **Raw frame capture.** A bounded ring buffer (24 frames, 512 bytes each)
  records the raw Enhanced-mode protobuf frames together with their command
  ids and how many keys the parser made of them. The device serial and the
  account user id are masked with a filler of equal length, so byte offsets
  stay usable for analysis while nothing identifying is exposed.

## Verification

Full suite green (1416 tests), including new coverage for the escalation
order, the recovery reset, frame masking, truncation and ring-buffer bounds.

Ref #88