### PR TITLE
chore: pin the PowerOcean phase container contract

### DIFF
--- a/custom_components/ecoflow_energy/ecoflow/parsers/powerocean_proto.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/powerocean_proto.py
@@ -265,6 +265,9 @@ def flatten_heartbeat(raw: dict[str, Any]) -> dict[str, Any]:
     values are treated as zero because a heartbeat is a full snapshot; this
     prevents a previous non-zero power/voltage/current value from staying stale
     when the device sends an explicit zero that MessageToDict omits.
+
+    The grid phases are the one exception: two containers describe them and a
+    scalar is only zeroed when neither reported it. See the comment there.
     """
     result: dict[str, Any] = {}
 
@@ -324,14 +327,35 @@ def flatten_heartbeat(raw: dict[str, Any]) -> dict[str, Any]:
     # zero-filled when no container reported it, which keeps a phase that drops
     # to zero from holding a stale reading. On an HJ31 pcs_load_info carries no
     # current and no power at all, so filling those from it reported 0 W while
-    # the device was exporting over 200 W on a phase.
+    # the device was exporting over 200 W on a phase. Both fields exist in the
+    # schema, so an omitted one is indistinguishable from a transmitted zero,
+    # which is why absence must not be read as a measurement.
+    #
+    # On a conflict pcs_a/b/c_phase wins, because it is collected second. That
+    # container is the one that models a phase electrically, so it is the
+    # authoritative source for these sensors. Pinned by
+    # test_phase_container_wins_over_load_info_on_conflict.
+    #
+    # The positional mapping of pcs_load_info entries to A, B and C is an
+    # assumption. The schema carries no phase identifier there. It holds on the
+    # observed hardware and is currently unobservable anyway, because the phase
+    # container overwrites every key the load container can contribute.
     reported_vols: list[float] = []
     collected: dict[str, dict[str, float]] = {}
 
-    def _collect(label: str, phase: dict[str, Any], fields: tuple[tuple[str, str], ...]) -> None:
+    def _collect(
+        label: str,
+        phase: dict[str, Any],
+        fields: tuple[tuple[str, str], ...],
+    ) -> None:
         vol = phase.get("vol")
         if isinstance(vol, (int, float)) and not isinstance(vol, bool):
             reported_vols.append(float(vol))
+        # Created unconditionally, before any field is read. A container that
+        # arrives with every scalar at its proto3 default carries no fields at
+        # all, and that is exactly the dead-grid case whose zeros must still be
+        # written. Moving this into the loop below would silently reintroduce
+        # stale readings.
         target = collected.setdefault(label, {})
         for field, suffix in fields:
             value = phase.get(field)
@@ -346,7 +370,11 @@ def flatten_heartbeat(raw: dict[str, Any]) -> dict[str, Any]:
                 _collect(
                     phase_names[idx],
                     phase,
-                    (("vol", "voltage_v"), ("amp", "current_a"), ("pwr", "active_power_w")),
+                    (
+                        ("vol", "voltage_v"),
+                        ("amp", "current_a"),
+                        ("pwr", "active_power_w"),
+                    ),
                 )
 
     for phase_key, label in (

--- a/tests/test_powerocean_bundled_frames.py
+++ b/tests/test_powerocean_bundled_frames.py
@@ -281,6 +281,55 @@ def test_load_info_only_phase_reports_zero_and_no_extended_power() -> None:
     assert "grid_phase_a_apparent_power_va" not in result
 
 
+def test_phase_container_wins_over_load_info_on_conflict() -> None:
+    """pcs_a/b/c_phase is authoritative when both containers report a scalar.
+
+    Only the phase container models a phase electrically, so it decides. The
+    observed hardware never sends a conflict, which is why this has to be
+    pinned by a test rather than left to the field order.
+    """
+    raw = {
+        "pcs_load_info": [{"vol": 230.0, "amp": 9.9, "freq": 50.0, "pwr": 2200.0}],
+        "pcs_a_phase": {"vol": 231.0, "amp": 1.1, "act_pwr": -207.0},
+    }
+
+    result = flatten_heartbeat(raw)
+
+    assert result["grid_phase_a_voltage_v"] == pytest.approx(231.0)
+    assert result["grid_phase_a_current_a"] == pytest.approx(1.1)
+    assert result["grid_phase_a_active_power_w"] == pytest.approx(-207.0)
+
+
+def test_container_without_any_scalar_still_clears_the_phase() -> None:
+    """A container whose scalars are all at their proto3 default writes zeros.
+
+    This is the dead-grid case. The phase entry is created before any field is
+    read, so an empty container still clears instead of leaving a stale value.
+    """
+    from_phase = flatten_heartbeat({"pcs_a_phase": {}})
+    assert from_phase["grid_phase_a_voltage_v"] == 0.0
+    assert from_phase["grid_phase_a_current_a"] == 0.0
+    assert from_phase["grid_phase_a_active_power_w"] == 0.0
+    assert from_phase["grid_phase_a_reactive_power_var"] == 0.0
+    assert from_phase["grid_phase_a_apparent_power_va"] == 0.0
+    assert "grid_status" not in from_phase
+
+    from_load = flatten_heartbeat({"pcs_load_info": [{}]})
+    assert from_load["grid_phase_a_voltage_v"] == 0.0
+    assert from_load["grid_phase_a_current_a"] == 0.0
+    assert from_load["grid_phase_a_active_power_w"] == 0.0
+    assert "grid_phase_a_reactive_power_var" not in from_load
+
+
+def test_non_numeric_phase_scalar_is_rejected() -> None:
+    """MessageToDict can render a float as "NaN"; it must not reach a sensor."""
+    result = flatten_heartbeat({"pcs_a_phase": {"vol": "NaN", "amp": 1.2}})
+
+    assert result["grid_phase_a_voltage_v"] == 0.0
+    assert result["grid_phase_a_current_a"] == pytest.approx(1.2)
+    assert "grid_status" not in result
+
+
 def test_multi_header_frame_with_outer_payload_still_decodes() -> None:
     """Several headers plus one outer payload field keep the typed decode.
 


### PR DESCRIPTION
Review follow-up on the phase zero-fill fix in beta.23. Comments and tests only, no behaviour change.

## Why

The zero-fill fix flipped the precedence between the two containers that describe a grid phase. `pcs_a/b/c_phase` now wins a conflict where `pcs_load_info` used to. That is the right way round, because only the phase container models a phase electrically, but nothing in the code recorded the decision and no test held it. On the observed hardware the two never conflict, so the next tidy-up would have silently reverted it.

The same applies to the phase entry being created before any field is read. That is what makes a container arriving with every scalar at its proto3 default still clear a dead grid instead of leaving a stale reading. Moving that line into the field loop looks like an obvious simplification and would reintroduce the exact problem the zero-fill exists to prevent.

## What

- comment stating that `pcs_a/b/c_phase` is authoritative on conflict, and why
- comment on why the phase entry is created unconditionally
- docstring corrected: the blanket "missing scalars are treated as zero" is no longer true for the phase branch
- recorded that the positional mapping of `pcs_load_info` entries to phases A, B and C is an assumption the schema does not support, and that it is currently unobservable because the phase container overwrites every key the load container can contribute

Three tests for cases the observed hardware does not produce:

- `test_phase_container_wins_over_load_info_on_conflict`
- `test_container_without_any_scalar_still_clears_the_phase`
- `test_non_numeric_phase_scalar_is_rejected`

Suite 1509 to 1512.

No CHANGELOG entry: nothing here is observable to a user, and the next release is the full 1.15.0.

Ref #88