### PR TITLE
fix: redact serials in diagnostics key names, not only values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [1.16.0] - 2026-07-31
 
+### Fixed
+- Diagnostics no longer leak a device serial through a key name. Serial numbers were replaced inside values but not inside the key itself, and the PowerOcean quota addresses battery packs by serial in the key (`bp_addr.<serial>`). Anyone attaching a diagnostics download to a public issue would have published that serial. Keys are now redacted the same way values are.
+
 ### Added
 - PowerOcean: water temperature, target power and target temperature for an attached PowerGlow heating rod, alongside the power reading. All four are read-only, disabled by default, and stay empty on systems without the accessory. The heating rod does not report the same field names on every system, so each reading is looked up under every name the accessory is known to use.
 - PowerOcean diagnostics now include the raw API quota, the same section Delta 3 and Stream already had. Accessories report through the PowerOcean rather than as devices of their own, and their field names are documented nowhere, so a diagnostics download from an owner is the only way to learn what an accessory actually contributes.

--- a/custom_components/ecoflow_energy/diagnostics.py
+++ b/custom_components/ecoflow_energy/diagnostics.py
@@ -52,11 +52,19 @@ def _redact_serials(value: Any) -> Any:
     ``powGetAcOutList``) cannot smuggle a serial past redaction. Over-redaction
     of long alphanumeric tokens is accepted by design: a diagnostics dump must
     never leak a device serial.
+
+    Dictionary **keys** are redacted as well. The PowerOcean quota addresses
+    battery packs by serial in the key itself (``bp_addr.<SN>``), so redacting
+    values alone would still publish a serial in a dump users are asked to
+    attach to a public issue.
     """
     if isinstance(value, str):
         return _SERIAL_RE.sub(REDACTED, value)
     if isinstance(value, dict):
-        return {key: _redact_serials(item) for key, item in value.items()}
+        return {
+            _redact_serials(key): _redact_serials(item)
+            for key, item in value.items()
+        }
     if isinstance(value, list):
         return [_redact_serials(item) for item in value]
     return value
@@ -277,7 +285,7 @@ def _device_diagnostics(coordinator: EcoFlowDeviceCoordinator) -> dict[str, Any]
             "age_s": raw_age_s,
             "key_count": len(raw_quota),
             "values": {
-                key: _redact_serials(value)
+                _redact_serials(key): _redact_serials(value)
                 for key, value in sorted(raw_quota.items())
             },
         }

--- a/tests/ha/test_diagnostics.py
+++ b/tests/ha/test_diagnostics.py
@@ -416,6 +416,34 @@ class TestDeltaThreeRawQuotaDiagnostics:
         )
         assert result["raw_quota"]["values"]["bpSoc"] == 74
 
+    async def test_powerocean_raw_quota_redacts_serials_in_keys(
+        self,
+        hass: HomeAssistant,
+        standard_config_entry: MockConfigEntry,
+    ) -> None:
+        """A serial in the key name must not survive into the dump.
+
+        The PowerOcean quota addresses battery packs by serial in the key
+        itself. Redacting values alone would still publish that serial in a
+        dump users are asked to attach to a public issue.
+        """
+        standard_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, standard_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        coordinator._raw_quota = {"bp_addr.HJ31TESTSERIAL01": {"bpSoc": 74}}
+        coordinator._raw_quota_captured_at = 1000.0
+
+        with patch(
+            "custom_components.ecoflow_energy.diagnostics.time.monotonic",
+            return_value=1001.0,
+        ):
+            result = _device_diagnostics(coordinator)
+
+        keys = list(result["raw_quota"]["values"])
+        assert keys == ["bp_addr.**REDACTED**"]
+        assert "HJ31TESTSERIAL01" not in json.dumps(result)
+
     async def test_delta3_raw_quota_redacts_serials(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
Follow-up to #172, which exposed the PowerOcean raw quota in diagnostics.

## The problem

Redaction ran over values only. The PowerOcean quota addresses battery packs by serial in the **key** (`bp_addr.<serial>`), so a dump would have carried a real serial, in the one section users are explicitly asked to attach to a public issue.

```
bp_addr.HJ31ZDH4ZF7H0170  ->  bp_addr.**REDACTED**   (after this change)
```

## Changes

- The recursive redaction helper now redacts dictionary keys as well as values
- The raw quota section applies it to both
- A test pins it with a serial-shaped key and asserts the serial does not survive anywhere in the serialised output

## Verification

Full suite green, 1559 passed.