### PR TITLE
docs: complete the Delta 3 control counts and date the release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.16.0] - 2026-07-31
+## [1.16.0] - 2026-08-06
 
 ### Fixed
 - A Stream could reset its two lifetime battery capacity readings and make the long-term statistics count the standing total a second time. The battery management system reports how much charge has passed through the pack since the beginning, and it reports a zero when there is nothing to report yet, which is what a factory-new pack sends and what a pack whose management system has been reset sends. The protocol declares those two fields in a way that puts the zero on the wire rather than leaving it out, so the zero arrived and was published on a reading that only ever counts up. Home Assistant reads a value of zero on such a reading as a meter change and adds the old total to everything that follows. Both readings are diagnostic and switched off by default, so this only reaches installations that turned them on. A zero is now treated as what it means, nothing to report, and the reading stays empty until the pack has something to say.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 | **PowerOcean** - Home Battery | `HJ31` `HJ32` `HJ35` `J32B` `J32D`\* `J32E`\* | 222 + 5 binary | 2 numbers, 1 select (Enhanced only) | 6 (solar, grid import/export, battery charge/discharge, home) | ~30 s standard / ~3 s enhanced |
 | **PowerOcean Plus** - 3-phase Hybrid | `R371`\* `R374`\* `HJ3C`\* | 222 + 5 binary | 2 numbers, 1 select (Enhanced only) | 6 (solar, grid import/export, battery charge/discharge, home) | ~3 s enhanced |
 | **Delta 2 Max** - Portable Power | `R351` `R331` | 94 + 4 binary | 7 switches, 8 numbers | 4 (solar 1+2, AC in/out) | ~30 s standard (+ MQTT push) |
-| **Delta 3** - Portable Power | `D3M1` `P321` `P231` | 47 | 7 switches, 4 numbers, 5 selects (selects and 1 number Enhanced only) | 4 (solar 1+2, AC in, output) | ~30 s standard / ~2 s enhanced |
+| **Delta 3** - Portable Power | `D3M1` `P321` `P231` | 47 | 7 switches, 4 numbers, 5 selects (selects and 1 number Enhanced only); `D3M` serials add 3 switches, 3 numbers and 1 binary sensor for port priority | 4 (solar 1+2, AC in, output) | ~30 s standard / ~2 s enhanced |
 | **Smart Plug** - Switchable Outlet | `HW52` | 11 + 1 binary | 1 switch, 2 numbers | 1 (total energy) | ~30 s standard / ~3 s enhanced |
 | **Stream** - AC-coupled Battery | `BK31` `BK11` `BK41` `BK51` `BK61` | 54 + 2 binary | 1 number (Enhanced only) | 2 default (battery charge/discharge), 6 optional diagnostic (solar/home, PV 1-4) | ~30 s standard / ~3 s enhanced |
 | **Stream Micro** - Grid-tie Inverter | `BK01`\* | 21 | - | 4 optional diagnostic (PV 1-4) | ~3 s enhanced |


### PR DESCRIPTION
The device table on the front page listed 7 switches and 4 numbers for a Delta 3. That is what a P321 or P231 gets. A D3M serial also gets the port priority set, three switches, three numbers and a binary sensor, and the table said nothing about it. The per-device page had it right all along, so only the front page was wrong, and that is the page HACS shows.

Also dates the 1.16.0 changelog block to the day it is released rather than the day it was opened.

Counts verified against const.py at runtime: PowerOcean 222 sensors, Delta 2 Max 94, Delta 3 47, Smart Plug 11, Stream 54, Stream Micro 21. Every other row was already correct.