### PR TITLE
fix: say what the two unmapped ES22 power fields actually are

### DIFF
--- a/custom_components/ecoflow_energy/const.py
+++ b/custom_components/ecoflow_energy/const.py
@@ -841,9 +841,10 @@ STREAMAC5000_SENSORS: list[EcoFlowSensorDef] = [
     EcoFlowSensorDef("max_charge_soc_pct", "Charge Limit", "%", None, "measurement", "mdi:battery-charging-high", "diagnostic", suggested_display_precision=0),
     EcoFlowSensorDef("min_discharge_soc_pct", "Discharge Limit", "%", None, "measurement", "mdi:battery-arrow-down", "diagnostic", suggested_display_precision=0),
     EcoFlowSensorDef("backup_reserve_pct", "Backup Reserve", "%", None, "measurement", "mdi:battery-lock", "diagnostic", suggested_display_precision=0),
-    # The two account-level limits, named as the app names them. Raising the
-    # output limit needs a request to EcoFlow; the input limit is settable in
-    # the app. A task power above either is accepted and then clamped.
+    # The two power limits, named as the app names them. The output limit is
+    # an account-level ceiling and raising it needs a request to EcoFlow; the
+    # input limit is an ordinary setting in the app. A task power above either
+    # is accepted and then clamped.
     EcoFlowSensorDef("max_grid_output_power_w", "Max Grid-tied Output Power", "W", "power", "measurement", "mdi:transmission-tower-export", "diagnostic", suggested_display_precision=0),
     EcoFlowSensorDef("max_grid_input_power_w", "Max Grid Input Power", "W", "power", "measurement", "mdi:transmission-tower-import", "diagnostic", suggested_display_precision=0),
     EcoFlowSensorDef("scheduled_discharge_power_w", "Scheduled Discharge Power", "W", "power", "measurement", "mdi:calendar-clock", "diagnostic", suggested_display_precision=0),

--- a/custom_components/ecoflow_energy/ecoflow/parsers/stream_ac5000_proto.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/stream_ac5000_proto.py
@@ -126,6 +126,10 @@ _ES22_FIELD_MAP: dict[tuple[int, int], dict[str, tuple[str, str, float]]] = {
         "30.1": ("_backup_reserve_enabled_raw", _TYPE_INT, 1),
         "30.2": ("backup_reserve_pct", _TYPE_INT, 1),
         "33.6": ("soc_precise_pct", _TYPE_FLOAT, 1),
+        # `f33.7` and `f33.8` are a third copy of the SoC limits, reading 90
+        # and 20 in the same get-all that carries them on `32/2` and on `f29`.
+        # Deliberately unmapped: `32/2` is the source, and this file has
+        # already had the limits taken from the wrong one of three.
         # --- scheduled task readback ---
         # One task per frame, and the device rotates through them, so these
         # land as per-kind keys that merge across frames rather than as a list

--- a/custom_components/ecoflow_energy/ecoflow/parsers/stream_ac5000_proto.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/stream_ac5000_proto.py
@@ -112,7 +112,12 @@ _ES22_FIELD_MAP: dict[tuple[int, int], dict[str, tuple[str, str, float]]] = {
         # --- configuration readback ---
         # The two power limits the app calls "Max grid-tied output power" and
         # "Max grid input power". `.5` and `.6` hold values that look like
-        # these and are not: both track the account ceiling, not the setting.
+        # these and are not, for different reasons: `.6` behaves like a
+        # ceiling, having moved once across four days of captures, when the
+        # account limit went from 600 to 2500, and through neither user
+        # change. `.5` is simply unexplained, 600 at that ceiling and 800
+        # after it rose, matching no setting visible in the app. Both stay
+        # unmapped.
         "10.1": ("max_grid_output_power_w", _TYPE_INT, 1),
         "10.2": ("max_grid_input_power_w", _TYPE_INT, 1),
         "25": ("_work_mode_raw", _TYPE_INT, 1),
@@ -149,9 +154,11 @@ _ES22_FIELD_MAP: dict[tuple[int, int], dict[str, tuple[str, str, float]]] = {
     # the account limit was raised to 2500 W, while the output limit was set
     # to 2400 W, and while the discharge task ran at 1400 W. They are neither
     # the limits nor the task powers, so their meaning is unknown.
-    # Same field numbers as the Delta 3 CMS heartbeat, where these two stay
-    # unmapped because their meaning was never seen away from the default. On
-    # an ES22 they follow the app, so here they are the SoC limits.
+    #
+    # `32/2 f1.7` and `f1.21` carry the same field numbers as the Delta 3 CMS
+    # heartbeat, where that pair stays unmapped because its meaning was never
+    # seen away from the default. On an ES22 both follow the app, so here they
+    # are the SoC limits.
     (32, 2): {
         "1.7": ("max_charge_soc_pct", _TYPE_INT, 1),
         "1.21": ("min_discharge_soc_pct", _TYPE_INT, 1),

--- a/tests/test_stream_ac5000_parser.py
+++ b/tests/test_stream_ac5000_parser.py
@@ -301,12 +301,14 @@ class TestDerivedValues:
         assert result["max_grid_input_power_w"] == 1200
 
     def test_the_ceiling_fields_are_not_a_user_limit(self) -> None:
-        """f10.5 and f10.6 track the account ceiling, not a setting.
+        """Neither f10.5 nor f10.6 is a user setting, for different reasons.
 
         `.6` sat at the same 2500 as the input limit for as long as nobody
         touched the setting, which is what made it look like the source. It
         did not follow that limit to 1200 and back, and it has moved only
-        once ever, when the ceiling was raised from 600.
+        once ever, when the ceiling was raised from 600, so it behaves like
+        that ceiling. `.5` is unexplained: 600 at the old ceiling and 800
+        after, matching no setting visible in the app.
         """
         inner = _sub(10, encode_field_varint(5, 800) + encode_field_varint(6, 2500))
         assert parse_stream_ac5000_message(_build_frame(254, 39, bytes(inner))) is None
@@ -518,7 +520,24 @@ class TestCaptureReplay:
             )
         assert len(empty_cmds) < len(frames) / 2
         for cmds in empty_cmds:
-            assert cmds in (((32, 2),), ((254, 40),), ((254, 39),)), cmds
+            assert cmds in (((254, 40),), ((254, 39),)), cmds
+
+    def test_every_battery_heartbeat_frame_yields_the_soc_limits(self) -> None:
+        """A 32/2 frame is the fast source, so none of them may parse empty.
+
+        The allowance above used to cover 32/2 because nothing in it was
+        mapped. Now that both SoC limits ride there, a frame carrying it has
+        to produce them, and this fails if the mapping is ever dropped again.
+        """
+        seen = 0
+        for frame in _load(PUSHES):
+            if [(c["cmd_func"], c["cmd_id"]) for c in frame["cmds"]] != [(32, 2)]:
+                continue
+            seen += 1
+            parsed = parse_stream_ac5000_message(bytes.fromhex(frame["hex"])) or {}
+            assert "max_charge_soc_pct" in parsed
+            assert "min_discharge_soc_pct" in parsed
+        assert seen >= 1
 
     def test_no_solar_entity_data_on_a_unit_without_pv(self) -> None:
         """Most frames must not carry solar, or the gating never holds off."""


### PR DESCRIPTION
Review pass on top of #210, which is already merged.

## The correction brought its own overclaim

A comment introduced with the input-limit fix called both `f10.5` and `f10.6` account ceilings. Only `f10.6` behaves that way: it moved once across four days of captures, when the account limit went from 600 to 2500, and through neither user change. `f10.5` went from 600 to 800 at that same moment and matches no setting visible anywhere in the app, which the measurement session says plainly. It is unexplained, and a change whose whole purpose is retiring overclaims should not introduce one.

## The input limit is not account-level

The sensor comment still described it that way. Only the output limit is a ceiling that needs a request to EcoFlow; the input limit is an ordinary setting in the app. That was the point of the fix.

## A test that could no longer fail

`test_push_frames_parse_or_carry_nothing_we_map` still permitted a `32/2` frame to parse to nothing. That was correct while nothing in that frame was mapped. Now that both SoC limits ride there, the allowance is a hole: the mapping could be dropped again and the test would stay green. It is gone, and a new test asserts every `32/2` frame in the capture yields both limits.

## The third copy

The get-all carries the SoC limits three times: on `32/2`, on `254/39 f29`, and again on `254/39 f33.7`/`f33.8`, all reading 90 and 20 in the same bundle. Two of the three are now known to be the slow ones, and this file has already had the limits taken from the wrong source once. A note at the third copy costs one comment and stops the next reader adding a fourth path to two entities.

## Tests

2164 pass.

Ref #177