### PR TITLE
Assert the whole capture verdict instead of a hostname substring

### DIFF
--- a/tests/ha/test_device_probe.py
+++ b/tests/ha/test_device_probe.py
@@ -657,9 +657,11 @@ class TestConnectionReport:
         report = probe.connection
         assert report["refusals"] == 1
         assert report["last_refusal_rc"] == 5
-        assert "Auth failed" in report["last_refusal_reason"]
-        assert "refused the login" in report["verdict"]
-        assert "mqtt-e.ecoflow.com:8084" in report["verdict"]
+        assert report["last_refusal_reason"] == "Auth failed (credentials expired?)"
+        assert report["verdict"] == (
+            "never connected - mqtt-e.ecoflow.com:8084 refused the login "
+            "(rc=5, Auth failed (credentials expired?))"
+        )
         # The drop counters stay honest alongside it.
         assert report["disconnects"] == 50
         assert report["last_rc"] == 128


### PR DESCRIPTION
Follow-up to #227. Code scanning flagged `"mqtt-e.ecoflow.com:8084" in report["verdict"]` as incomplete URL sanitization. In a test the security reading does not apply, but the point stands: the assertion held for any verdict that merely contained the address. It now checks the whole sentence, which is stricter.

Ref #184