### PR TITLE
chore: write asides with a plain hyphen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to this project will be documented in this file.
 - A diagnostics download now contains the whole of the message a device sends when it is asked for its full state. Every captured message was kept only up to its first 512 bytes. That was enough for the small updates a device pushes as things change, but not for the one message that carries everything at once: on a STREAM AC 5000 that message is around 1440 bytes and holds six parts, so two thirds of it, including several settings, never reached the download. Nothing in the file said it had been shortened either, and that is what turned a size limit into wrong answers: settings the device does report were read as settings it does not have, and the owner was asked to confirm something the download had thrown away. How much of a message is kept now depends on what the message carries, so a full state arrives whole while an ordinary update costs no more space than before, and anything that still had to be shortened now says so. This changes nothing about your devices or your entities, only what a support download is worth. (Ref #177)
 - A charge or discharge limit changed in the EcoFlow app took minutes to reach Home Assistant instead of seconds. The device reports both limits on two different messages, and the one being read only appears in the full state dump it sends when asked, which happens on connect and seldom after that. The other message carries them continuously. Measured on hardware over one thirteen-minute window: the continuous message carried the limits 83 times, the state dump 4, and a limit changed in the app showed up 4 minutes 27 seconds later than it needed to. The limits are now taken from the message that actually carries them, and the state dump stays unmapped, so there is still exactly one source for the value. (Ref #177)
 
+### Changed
+
+- Log messages write an aside with a plain hyphen instead of a long dash. Purely cosmetic, and noted only because these lines are written into your Home Assistant log rather than kept here. Nothing about what is logged, when, or at which level changes, and no text you see in the interface is affected.
+
 ## [1.16.0] - 2026-08-06
 
 ### Added
@@ -174,7 +178,7 @@ All notable changes to this project will be documented in this file.
 - PowerOcean `number.solar_surplus_threshold` value not applied in the EcoFlow app. The fix in beta.2 wrote the surplus percentage only to wire field 3 (`sys_bat_backup_ratio`), which the device's EMS reads. The EcoFlow app, however, reads the value from a separate cloud-quota key (`socDev` / `dev_soc`, wire field 4). The two fields are independent views of the same logical slider and must be written together; otherwise the app and the device drift apart. The payload now writes both wire fields in a single `SysBatChgDsgSet`, keeping HA, the device EMS, and the EcoFlow app aligned. Verified against live cloud quota: writing surplus=33 propagates `sys_bat_backup_ratio=33`, `socDev=33`, and `dev_soc=33` simultaneously. (beta.4)
 - PowerOcean `number.solar_surplus_threshold` did not reflect changes made in the EcoFlow app. The app sends `cmd_id=112` over MQTT but only includes wire field 4 (`dev_soc`), which leaves the EMS-side `sys_bat_backup_ratio` (wire field 3) on the previous threshold; HA observes the EMS field and stayed out of sync. The device does mirror the app's value back via `cmd_id=13` `EmsParamChangeReport` field 10. The proto decoder now handles `cmd_id=13` (`JTS1EmsParamChangeReport`) and exposes `dev_soc` as `ems_app_surplus_pct`. Whenever this differs from `ems_backup_ratio_pct`, the coordinator pushes a corrective both-field SET so the EMS catches up to whatever the app set, keeping HA, app, and device aligned. The auto-sync respects a 30 s throttle and a 5 s grace period after a user-initiated SET so it does not race the device echo. (beta.4)
 - PowerOcean SoC sliders (`number.solar_surplus_threshold` and `number.backup_reserve`) sent one MQTT SET per 5 %-step while the user dragged the slider in HA, producing 5-10 SETs in <1 s. The PowerOcean firmware cannot keep wire field 3 (EMS) and field 4 (App-Layer) in sync at that cadence, so the two fields drifted apart and HA, the EcoFlow app, and the device EMS ended up showing different values for the same slider. SET delivery is now coalesced through a 300 ms debouncer in the coordinator: every Number-Entity call updates the pending (backup, solar) pair and resets a timer, so only the final value reaches the device. The optimistic UI value is still applied immediately, so the slider feels responsive. (beta.5)
-- PowerOcean `number.solar_surplus_threshold` slider was pulled back to a previous value about 30 s after the user set a new value in HA. The auto-sync from beta.4 reissued a both-field SET whenever the cached `ems_app_surplus_pct` (from `EmsParamChangeReport`) differed from `ems_backup_ratio_pct`, but it did not check whether the ParamChange frame that produced the cached app value was actually fresh. After a drag-race left the device's app-layer field stuck on a stale value, the auto-sync would dutifully reissue that obsolete value, dragging HA back to it. The auto-sync now records the timestamp of every incoming ParamChange and only fires when that timestamp is more recent than the last user SET — so genuine app-side changes still trigger a sync, but a stale frame can no longer override the user's HA SET. (beta.6)
+- PowerOcean `number.solar_surplus_threshold` slider was pulled back to a previous value about 30 s after the user set a new value in HA. The auto-sync from beta.4 reissued a both-field SET whenever the cached `ems_app_surplus_pct` (from `EmsParamChangeReport`) differed from `ems_backup_ratio_pct`, but it did not check whether the ParamChange frame that produced the cached app value was actually fresh. After a drag-race left the device's app-layer field stuck on a stale value, the auto-sync would dutifully reissue that obsolete value, dragging HA back to it. The auto-sync now records the timestamp of every incoming ParamChange and only fires when that timestamp is more recent than the last user SET - so genuine app-side changes still trigger a sync, but a stale frame can no longer override the user's HA SET. (beta.6)
 - PowerOcean `number.solar_surplus_threshold` showed 90 instead of 100 when the user set 100 in either HA or the EcoFlow app. Live diagnosis revealed that the two cmd_id=112 wire fields are semantically different: `dev_soc` (field 4 / cloud-quota `socDev`) is the user-facing slider value the EcoFlow app reads and writes, while `sys_bat_backup_ratio` (field 3) is a derived EMS status that the device internally clamps at edge cases (notably 100 %, where it caps at 90). HA was reading the EMS-side value and therefore showed the clamped state instead of the user's intent. The slider now sources from `ems_app_surplus_pct` (the user-side mirror), matching what the EcoFlow app shows. The SET still writes both fields so the EMS follows the user value where it can; at the 0 %/100 % edges the auto-sync no longer schedules futile reissues since the EMS-side divergence is by design at those boundaries. (beta.7)
 
 ### Removed
@@ -310,20 +314,20 @@ All notable changes to this project will be documented in this file.
 ## [1.8.3] - 2026-03-31
 
 ### Fixed
-- HTTP error 1006 ("device not linked to API key") no longer triggers false re-authentication — classified as a configuration issue with an actionable log message instead of counting toward the auth failure threshold (#2)
+- HTTP error 1006 ("device not linked to API key") no longer triggers false re-authentication - classified as a configuration issue with an actionable log message instead of counting toward the auth failure threshold (#2)
 - Enhanced Mode: HTTP fallback failures no longer trigger re-authentication when MQTT is actively delivering data (#2)
 - Error 1006 logged once per device with clear guidance instead of repeating every 30 seconds
 
 ## [1.8.2] - 2026-03-31
 
 ### Fixed
-- PowerOcean Enhanced Mode: stable per-pack sensor numbering via battery serial number — each physical pack now consistently maps to the same `pack{n}_*` sensors across heartbeats, fixing Pack 2 sensors not updating (#10)
+- PowerOcean Enhanced Mode: stable per-pack sensor numbering via battery serial number - each physical pack now consistently maps to the same `pack{n}_*` sensors across heartbeats, fixing Pack 2 sensors not updating (#10)
 
 ## [1.8.1] - 2026-03-31
 
 ### Fixed
-- PowerOcean Enhanced Mode: idle battery packs no longer falsely filtered as phantoms — replaced numeric non-zero check with identity key presence check (bp_soc, bp_design_cap, bp_sn, etc.) so packs with zero power/SoC are still recognized (#10)
-- PowerOcean Enhanced Mode: aggregate `bp_remain_watth` now computed from accumulated device data instead of per-message — partial heartbeats (single pack reporting) no longer cause the total to revert to one pack's value (#10)
+- PowerOcean Enhanced Mode: idle battery packs no longer falsely filtered as phantoms - replaced numeric non-zero check with identity key presence check (bp_soc, bp_design_cap, bp_sn, etc.) so packs with zero power/SoC are still recognized (#10)
+- PowerOcean Enhanced Mode: aggregate `bp_remain_watth` now computed from accumulated device data instead of per-message - partial heartbeats (single pack reporting) no longer cause the total to revert to one pack's value (#10)
 
 ## [1.8.0] - 2026-03-31
 
@@ -333,7 +337,7 @@ All notable changes to this project will be documented in this file.
 - Optimistic writes (switch, number) now sync dedup state to prevent one redundant write on the next coordinator tick
 
 ### Fixed
-- MQTT fallback logging reduced from WARNING to INFO: transient stale/recovery transitions are self-healing and no longer clutter the HA log — both "switching to HTTP fallback" and "MQTT recovered" now log at INFO level as a matched pair
+- MQTT fallback logging reduced from WARNING to INFO: transient stale/recovery transitions are self-healing and no longer clutter the HA log - both "switching to HTTP fallback" and "MQTT recovered" now log at INFO level as a matched pair
 
 ## [1.7.1] - 2026-03-31
 
@@ -345,16 +349,16 @@ All notable changes to this project will be documented in this file.
 ## [1.7.0] - 2026-03-31
 
 ### Fixed
-- PowerOcean: SoC limit 0% now correctly synced in both directions — `optional` proto3 field presence on `sys_bat_dsg_down_limit` and `sys_bat_chg_up_limit` ensures `MessageToDict` includes zero values instead of silently omitting them
-- PowerOcean: "Battery Remaining Capacity" (`bp_remain_watth`) now shows total capacity across all battery packs instead of only Pack 1 — affects both Standard Mode (HTTP) and Enhanced Mode (Protobuf) (#10)
+- PowerOcean: SoC limit 0% now correctly synced in both directions - `optional` proto3 field presence on `sys_bat_dsg_down_limit` and `sys_bat_chg_up_limit` ensures `MessageToDict` includes zero values instead of silently omitting them
+- PowerOcean: "Battery Remaining Capacity" (`bp_remain_watth`) now shows total capacity across all battery packs instead of only Pack 1 - affects both Standard Mode (HTTP) and Enhanced Mode (Protobuf) (#10)
 
 ### Removed
-- Temporary workarounds from v1.6.5–v1.6.8 (proto3 global flag, optimistic lock, zero-fill, HTTP sync loop) — all replaced by proper `optional` field presence
+- Temporary workarounds from v1.6.5–v1.6.8 (proto3 global flag, optimistic lock, zero-fill, HTTP sync loop) - all replaced by proper `optional` field presence
 
 ## [1.6.7] - 2026-03-31
 
 ### Fixed
-- PowerOcean: Min Discharge SoC 0% now persists permanently — optimistic value is written to `_device_data` so it survives coordinator refresh cycles (proto3 omits zero-valued fields from MQTT readback, but the merge no longer overwrites the SET value)
+- PowerOcean: Min Discharge SoC 0% now persists permanently - optimistic value is written to `_device_data` so it survives coordinator refresh cycles (proto3 omits zero-valued fields from MQTT readback, but the merge no longer overwrites the SET value)
 
 ### Removed
 - Temporary 10-second optimistic lock from v1.6.6 (no longer needed)
@@ -362,25 +366,25 @@ All notable changes to this project will be documented in this file.
 ## [1.6.6] - 2026-03-31
 
 ### Fixed
-- Revert `always_print_fields_with_no_presence` from v1.6.5 — it flooded all proto fields with default 0, overwriting real sensor values
+- Revert `always_print_fields_with_no_presence` from v1.6.5 - it flooded all proto fields with default 0, overwriting real sensor values
 - PowerOcean: number entities now use a 10-second optimistic lock after SET commands to prevent proto3 zero-omission readback from reverting the displayed value
 
 ## [1.6.5] - 2026-03-31
 
 ### Fixed
-- Proto3 zero-value readback: `MessageToDict` now includes fields with value 0 — previously, setting Min Discharge SoC to 0% was accepted by the device but HA reverted to the previous value because the proto3 decoder omitted zero-valued fields
+- Proto3 zero-value readback: `MessageToDict` now includes fields with value 0 - previously, setting Min Discharge SoC to 0% was accepted by the device but HA reverted to the previous value because the proto3 decoder omitted zero-valued fields
 
 ## [1.6.4] - 2026-03-31
 
 ### Fixed
-- PowerOcean: revert to 2-field SysBatChgDsgSet payload (charge upper + discharge lower only) — the 4-field version from v1.6.1 caused the device to reject discharge lower limit value 0
-- Proto3 zero-value readback: `MessageToDict` now includes fields with value 0 — previously, setting Min Discharge SoC to 0% was accepted by the device but HA reverted to the previous value because the proto3 decoder omitted zero-valued fields
+- PowerOcean: revert to 2-field SysBatChgDsgSet payload (charge upper + discharge lower only) - the 4-field version from v1.6.1 caused the device to reject discharge lower limit value 0
+- Proto3 zero-value readback: `MessageToDict` now includes fields with value 0 - previously, setting Min Discharge SoC to 0% was accepted by the device but HA reverted to the previous value because the proto3 decoder omitted zero-valued fields
 
 ## [1.6.3] - 2026-03-31
 
 ### Fixed
-- PowerOcean: revert proto field swap from v1.6.2 — both values were broken after swap
-- PowerOcean: remove Max Charge SoC number entity — device firmware does not reliably accept charge upper limit via SysBatChgDsgSet (requires portal traffic capture for further investigation)
+- PowerOcean: revert proto field swap from v1.6.2 - both values were broken after swap
+- PowerOcean: remove Max Charge SoC number entity - device firmware does not reliably accept charge upper limit via SysBatChgDsgSet (requires portal traffic capture for further investigation)
 
 ### Changed
 - PowerOcean: SoC control reduced to Min Discharge SoC only (Enhanced Mode) until charge limit SET protocol is verified
@@ -389,17 +393,17 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - PowerOcean: swap proto field order in SysBatChgDsgSet - device reads field 1 as discharge lower and field 2 as charge upper (opposite of proto definition labels)
-- PowerOcean: fix dev_soc lookup in SET payload — was reading unmapped key, now uses coordinator-mapped `soc_pct`
+- PowerOcean: fix dev_soc lookup in SET payload - was reading unmapped key, now uses coordinator-mapped `soc_pct`
 
 ## [1.6.1] - 2026-03-31
 
 ### Fixed
-- PowerOcean: Max Charge SoC SET now includes all 4 required protobuf fields (charge upper, discharge lower, backup ratio, device SoC) — previously only 2 fields were sent, causing the device to silently reject the charge limit change
+- PowerOcean: Max Charge SoC SET now includes all 4 required protobuf fields (charge upper, discharge lower, backup ratio, device SoC) - previously only 2 fields were sent, causing the device to silently reject the charge limit change
 
 ## [1.6.0] - 2026-03-30
 
 ### Added
-- PowerOcean: battery SoC limit control — Max Charge SoC (50–100%) and Min Discharge SoC (0–30%) as number entities (Enhanced Mode only)
+- PowerOcean: battery SoC limit control - Max Charge SoC (50–100%) and Min Discharge SoC (0–30%) as number entities (Enhanced Mode only)
 - PowerOcean: SysBatChgDsgSet protobuf SET command (cmd_func=96, cmd_id=112) for real-time SoC limit adjustment via WSS
 
 ### Changed
@@ -414,7 +418,7 @@ All notable changes to this project will be documented in this file.
 ## [1.5.2] - 2026-03-30
 
 ### Fixed
-- Sensor precision: `native_value` now rounds numeric values based on `suggested_display_precision` — power sensors show integers (e.g. "2347 W"), energy sensors show 2 decimal places (e.g. "15.23 kWh")
+- Sensor precision: `native_value` now rounds numeric values based on `suggested_display_precision` - power sensors show integers (e.g. "2347 W"), energy sensors show 2 decimal places (e.g. "15.23 kWh")
 
 ### Changed
 - Diagnostics: event log capacity increased from 20 to 50 entries for better support troubleshooting
@@ -422,9 +426,9 @@ All notable changes to this project will be documented in this file.
 ## [1.5.1] - 2026-03-30
 
 ### Fixed
-- PowerOcean: battery pack numbering now starts at "Pack 1" instead of "Pack 2" — phantom/empty API entries (EMS module) are skipped before numbering (#5)
+- PowerOcean: battery pack numbering now starts at "Pack 1" instead of "Pack 2" - phantom/empty API entries (EMS module) are skipped before numbering (#5)
 - PowerOcean: aggregate battery sensors (bp_*) now correctly select the first real battery pack, not a phantom entry
-- PowerOcean: Enhanced Mode (Protobuf) now delivers multi-pack data correctly — previously silently discarded by internal key filter
+- PowerOcean: Enhanced Mode (Protobuf) now delivers multi-pack data correctly - previously silently discarded by internal key filter
 - Config flow: narrowed exception handling with OSError coverage for SSL/socket errors
 
 ### Note for multi-pack users
@@ -448,7 +452,7 @@ All notable changes to this project will be documented in this file.
 ## [1.5.0] - 2026-03-30
 
 ### Added
-- PowerOcean: multi-battery-pack support — per-pack sensors for up to 5 BP5000 packs (120 new sensors, 7 enabled for Pack 1)
+- PowerOcean: multi-battery-pack support - per-pack sensors for up to 5 BP5000 packs (120 new sensors, 7 enabled for Pack 1)
 - PowerOcean: 19 additional EMS/system diagnostic sensors (SoC limits, fault codes, connectivity, system capabilities)
 - PowerOcean: lifetime energy counters per battery pack (accumulated charge/discharge kWh)
 - PowerOcean: multi-pack data in Enhanced Mode (Protobuf heartbeat extracts all packs)
@@ -458,7 +462,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Delta 2 Max: beeper, X-Boost, AC auto restart, backup reserve switches (4 new)
 - Delta 2 Max: screen brightness, screen timeout, 12V port timeout, backup reserve level numbers (4 new)
-- Delta 2 Max: expansion battery pack support — 32 sensors for up to 2 slave packs (disabled by default)
+- Delta 2 Max: expansion battery pack support - 32 sensors for up to 2 slave packs (disabled by default)
 
 ### Changed
 - Delta 2 Max: X-Boost promoted from read-only binary sensor to controllable switch
@@ -493,13 +497,13 @@ All notable changes to this project will be documented in this file.
 ## [1.3.1] - 2026-03-29
 
 ### Added
-- Reconfigure flow — update API credentials via Settings > Integrations > EcoFlow Energy > Reconfigure
-- Entity availability tracking — entities show "unavailable" when device is unreachable
+- Reconfigure flow - update API credentials via Settings > Integrations > EcoFlow Energy > Reconfigure
+- Entity availability tracking - entities show "unavailable" when device is unreachable
 - Optimistic state update for number entities (charge speed, SoC limits)
-- `suggested_display_precision` for all sensors — cleaner UI values
-- `disabled_by_default` for diagnostic sensors — less overwhelming for new users
+- `suggested_display_precision` for all sensors - cleaner UI values
+- `disabled_by_default` for diagnostic sensors - less overwhelming for new users
 - Entity categories for diagnostic binary sensors
-- `configuration_url` in device info — clickable link on device page
+- `configuration_url` in device info - clickable link on device page
 - German translations for re-authentication and reconfigure flows
 
 ### Fixed
@@ -517,13 +521,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Modernized OptionsFlow to use current Home Assistant pattern
 - Modernize type hints: `Optional[X]` → `X | None`, `Dict`/`List`/`Tuple` → builtins across all source files
-- Centralize `_safe_float()` into shared parser module — removes 3 duplicate definitions
+- Centralize `_safe_float()` into shared parser module - removes 3 duplicate definitions
 - Add missing return type hints to MQTT client and proto decoder methods
 - Replace bare `except Exception` with specific exception types in proto decoder and runtime
 - Unify parser return types to `dict[str, Any]` for consistency
 
 ### Fixed
-- Downgrade MQTT auth error (rc=5) log from ERROR to WARNING — auto-recovery follows
+- Downgrade MQTT auth error (rc=5) log from ERROR to WARNING - auto-recovery follows
 - Downgrade transient MQTT message handler and connection errors to appropriate log levels
 - Remove unused typing imports
 
@@ -536,12 +540,12 @@ All notable changes to this project will be documented in this file.
 ## [1.2.7] - 2026-03-28
 
 ### Fixed
-- Remove license badge from README — renders as "?" in HACS due to image proxy limitations
+- Remove license badge from README - renders as "?" in HACS due to image proxy limitations
 
 ## [1.2.6] - 2026-03-28
 
 ### Fixed
-- Revert homeassistant field in manifest — not allowed for custom integrations (hassfest rejects it)
+- Revert homeassistant field in manifest - not allowed for custom integrations (hassfest rejects it)
 
 ## [1.2.4] - 2026-03-28
 
@@ -556,18 +560,18 @@ All notable changes to this project will be documented in this file.
 ## [1.2.2] - 2026-03-28
 
 ### Fixed
-- README uses pure markdown only — no HTML tables or emoji shortcodes that HACS cannot render
+- README uses pure markdown only - no HTML tables or emoji shortcodes that HACS cannot render
 
 ## [1.2.1] - 2026-03-28
 
 ### Changed
-- README redesigned for HACS store rendering — hero screenshots, feature grid, compact structure, standard markdown for full compatibility
+- README redesigned for HACS store rendering - hero screenshots, feature grid, compact structure, standard markdown for full compatibility
 
 ## [1.2.0] - 2026-03-28
 
 ### Added
-- Energy Dashboard support for Delta 2 Max — 4 kWh sensors (solar, solar 2, AC input, AC output) via Riemann sum integration
-- Energy Dashboard support for Smart Plug — 1 kWh energy sensor via Riemann sum integration
+- Energy Dashboard support for Delta 2 Max - 4 kWh sensors (solar, solar 2, AC input, AC output) via Riemann sum integration
+- Energy Dashboard support for Smart Plug - 1 kWh energy sensor via Riemann sum integration
 - Entity translations for all 135 entities (English + German) using HA translation_key system
 - Firmware version display in HA device page (extracted from API response)
 
@@ -580,7 +584,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Smart Plug: `watts` unit corrected from raw to deciWatt (/10) per API spec "0.1 W"
-- Delta 2 Max: MPPT fields scaling corrected per API spec — `outWatts`, `carOutWatts`, `pv2InWatts` (/10), `dcdc12vWatts`, `pv2InAmp` (/100), `dcdc12vVol`, `pv2MpptTemp` (/10)
+- Delta 2 Max: MPPT fields scaling corrected per API spec - `outWatts`, `carOutWatts`, `pv2InWatts` (/10), `dcdc12vWatts`, `pv2InAmp` (/100), `dcdc12vVol`, `pv2MpptTemp` (/10)
 
 ### Added
 - Smart Plug: `maxCur` field parsed (deciAmpere → Ampere)
@@ -590,17 +594,17 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - HTTP API nonce format corrected to 6-digit numeric per EcoFlow API spec (was 16-char alphanumeric, causing intermittent signature errors on some backend servers)
-- MQTT keepalive reduced from 120s to 60s — prevents broker disconnect due to ~200s inactivity timeout with insufficient PINGREQ frequency
+- MQTT keepalive reduced from 120s to 60s - prevents broker disconnect due to ~200s inactivity timeout with insufficient PINGREQ frequency
 
 ## [1.1.0] - 2026-03-27
 
 ### Added
-- **Delta 2 Max MQTT push** — real-time data via IoT MQTT subscription alongside HTTP polling (dual-source)
+- **Delta 2 Max MQTT push** - real-time data via IoT MQTT subscription alongside HTTP polling (dual-source)
 - MQTT credential refresh on AUTH error (rc=5) with rate-limited retry
 
 ### Fixed
-- HTTP API nonce collision causing `code=8521 signature is wrong` — nonce upgraded from 6-digit numeric to 16-char alphanumeric (matching IoT API client)
-- HA Recorder warnings for `total_increasing` sensors (battery cycles, energy totals) — monotonic filter drops micro-regressions from API
+- HTTP API nonce collision causing `code=8521 signature is wrong` - nonce upgraded from 6-digit numeric to 16-char alphanumeric (matching IoT API client)
+- HA Recorder warnings for `total_increasing` sensors (battery cycles, energy totals) - monotonic filter drops micro-regressions from API
 
 ### Changed
 - Delta devices now subscribe to `/open/.../quota` MQTT topic for event-driven updates (~1–30 s)
@@ -612,8 +616,8 @@ All notable changes to this project will be documented in this file.
 - **PowerOcean** support with 57 sensors and Energy Dashboard integration (6 energy sensors)
 - **Delta 2 Max** support with 58 sensors, 5 binary sensors, 3 switches, 4 number entities
 - **Smart Plug** support with 9 sensors, 1 binary sensor, 1 switch
-- **Standard Mode** — official IoT Developer API, HTTP polling every ~30 s
-- **Enhanced Mode** — unofficial WSS MQTT push with ~3 s real-time updates (PowerOcean only)
+- **Standard Mode** - official IoT Developer API, HTTP polling every ~30 s
+- **Enhanced Mode** - unofficial WSS MQTT push with ~3 s real-time updates (PowerOcean only)
 - Auto-discovery of all devices bound to EcoFlow account
 - Energy Dashboard ready sensors (`total_increasing` for solar, grid, battery, home)
 - Riemann-sum energy integration with persistent state and gap/jump detection

--- a/custom_components/ecoflow_energy/__init__.py
+++ b/custom_components/ecoflow_energy/__init__.py
@@ -248,7 +248,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: EcoFlowConfigEntry) -> b
         device_info = {**device_info, "device_type": device_type}
         coordinator = EcoFlowDeviceCoordinator(hass, entry, device_info)
         await coordinator.async_setup()
-        # First refresh — raises ConfigEntryNotReady on failure so HA retries.
+        # First refresh - raises ConfigEntryNotReady on failure so HA retries.
         # Partial-setup cleanup is handled by HA core: the coordinator
         # registers async_shutdown as an entry on_unload callback, and HA
         # processes those callbacks when setup fails, so coordinators
@@ -313,7 +313,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: EcoFlowConfigEntry) -> b
 
 async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload the integration when the config entry is updated."""
-    _LOGGER.debug("Config entry updated — reloading EcoFlow Energy")
+    _LOGGER.debug("Config entry updated - reloading EcoFlow Energy")
     await hass.config_entries.async_reload(entry.entry_id)
 
 

--- a/custom_components/ecoflow_energy/config_flow_options.py
+++ b/custom_components/ecoflow_energy/config_flow_options.py
@@ -65,7 +65,7 @@ class OptionsFlowMixin:
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Main options step — change mode and device selection."""
+        """Main options step - change mode and device selection."""
         errors: dict[str, str] = {}
 
         current_mode = self.config_entry.data.get(CONF_MODE, MODE_STANDARD)

--- a/custom_components/ecoflow_energy/config_flow_reauth.py
+++ b/custom_components/ecoflow_energy/config_flow_reauth.py
@@ -64,13 +64,13 @@ class ReauthFlowMixin:
                 if creds is None:
                     errors["base"] = "invalid_auth"
                 else:
-                    # Credentials valid — check if Enhanced Mode needs second step
+                    # Credentials valid - check if Enhanced Mode needs second step
                     if reauth_entry.data.get(CONF_MODE) == MODE_ENHANCED:
                         self._access_key = access_key
                         self._secret_key = secret_key
                         return await self.async_step_reauth_enhanced()
 
-                    # Standard Mode — update entry and finish
+                    # Standard Mode - update entry and finish
                     new_data = dict(reauth_entry.data)
                     new_data[CONF_ACCESS_KEY] = access_key
                     new_data[CONF_SECRET_KEY] = secret_key

--- a/custom_components/ecoflow_energy/coordinator/availability.py
+++ b/custom_components/ecoflow_energy/coordinator/availability.py
@@ -171,7 +171,7 @@ class AvailabilityMixin:
             if age > stale_threshold_s:
                 # Connected-but-silent escalation. A full reconnect drops the
                 # WSS session and re-runs the whole subscribe handshake, which
-                # is expensive and — on devices that push slowly — happens
+                # is expensive and - on devices that push slowly - happens
                 # every stale interval. Re-sending the post-connect requests
                 # achieves the same wake-up at a fraction of the cost, so it
                 # runs first; the reconnect follows only if the device stays

--- a/custom_components/ecoflow_energy/coordinator/core.py
+++ b/custom_components/ecoflow_energy/coordinator/core.py
@@ -144,7 +144,7 @@ class EcoFlowDeviceCoordinator(
         enhanced_mode = entry.data.get(CONF_AUTH_METHOD) == AUTH_METHOD_APP
 
         # Standard Mode: HTTP polling every 30s (primary data source)
-        # Enhanced Mode: MQTT push only — protobuf carries all sensor data
+        # Enhanced Mode: MQTT push only - protobuf carries all sensor data
         #   (power, battery, MPPT, grid phases, EMS state).
         #   HTTP fallback activates only when MQTT is stale (>35s).
         poll_interval = (
@@ -205,7 +205,7 @@ class EcoFlowDeviceCoordinator(
         self._last_user_surplus_set_ts: float = 0.0
         # Timestamp of the most recent EmsParamChangeReport (cmd_id=13) that
         # carried a `dev_soc` field. The auto-sync only acts on frames newer
-        # than the last user SET — stale ParamChange frames (e.g. an EMS
+        # than the last user SET - stale ParamChange frames (e.g. an EMS
         # echo of a value the user has since superseded in HA) would
         # otherwise pull HA back to the obsolete app-side value.
         self._last_ems_param_change_ts: float = 0.0

--- a/custom_components/ecoflow_energy/coordinator/http_poll.py
+++ b/custom_components/ecoflow_energy/coordinator/http_poll.py
@@ -31,7 +31,7 @@ class HttpPollMixin:
     # ------------------------------------------------------------------
 
     async def _async_update_data(self) -> dict[str, Any]:
-        """HTTP polling — primary source in Standard Mode, fallback in Enhanced.
+        """HTTP polling - primary source in Standard Mode, fallback in Enhanced.
 
         PowerOcean: POST /iot-open/sign/device/quota (with quotas array)
         Delta:      GET  /iot-open/sign/device/quota/all?sn=...
@@ -41,12 +41,12 @@ class HttpPollMixin:
         if self._http_client is None:
             return self._device_data
 
-        # All device types use GET /quota/all — returns the most complete data
+        # All device types use GET /quota/all - returns the most complete data
         raw = await self._http_client.get_quota_all()
         if not raw:
             error_code = self._http_client.last_error_code
 
-            # Error 1006 = device not linked to API key — config issue, not auth (#2)
+            # Error 1006 = device not linked to API key - config issue, not auth (#2)
             if error_code == "1006":
                 self._log_event("http_1006", "device not linked to API key")
                 return dict(self._device_data)
@@ -67,7 +67,7 @@ class HttpPollMixin:
             mqtt_active = self._enhanced_mode and self._last_mqtt_ts > 0.0
             if self._consecutive_http_failures == 5 and not mqtt_active:
                 _LOGGER.warning(
-                    "HTTP quota failed %d consecutive times for %s — triggering re-authentication",
+                    "HTTP quota failed %d consecutive times for %s - triggering re-authentication",
                     self._consecutive_http_failures, self.device_sn[:4],
                 )
                 self._entry.async_start_reauth(self.hass)

--- a/custom_components/ecoflow_energy/coordinator/keepalive.py
+++ b/custom_components/ecoflow_energy/coordinator/keepalive.py
@@ -48,7 +48,7 @@ class KeepaliveMixin:
             )
 
     # ------------------------------------------------------------------
-    # latestQuotas poll (Enhanced Mode — app-level keepalive, every 30s)
+    # latestQuotas poll (Enhanced Mode - app-level keepalive, every 30s)
     # ------------------------------------------------------------------
 
     def _schedule_quotas_poll(self) -> None:
@@ -84,7 +84,7 @@ class KeepaliveMixin:
             )
 
     # ------------------------------------------------------------------
-    # Ping heartbeat (Enhanced Mode — MQTT-level keepalive, every 60s)
+    # Ping heartbeat (Enhanced Mode - MQTT-level keepalive, every 60s)
     # ------------------------------------------------------------------
 
     def _schedule_ping(self) -> None:

--- a/custom_components/ecoflow_energy/coordinator/mqtt_ingest.py
+++ b/custom_components/ecoflow_energy/coordinator/mqtt_ingest.py
@@ -112,7 +112,7 @@ class MqttIngestMixin:
     def _on_mqtt_message(self, topic: str, payload: bytes) -> None:
         """Handle an incoming MQTT message (Paho thread).
 
-        In Standard Mode, MQTT is only used for SET commands — data updates
+        In Standard Mode, MQTT is only used for SET commands - data updates
         come from HTTP polling. Exception: Delta and Smart Plug subscribe
         to MQTT push for real-time data alongside HTTP polling (dual-source).
         In Enhanced Mode, MQTT is the primary source.
@@ -171,7 +171,7 @@ class MqttIngestMixin:
         the HTTP quota path already exposes its keys verbatim.
 
         The frame is truncated and the device serial is masked before storage.
-        Capture never affects ingest — any failure is swallowed.
+        Capture never affects ingest - any failure is swallowed.
         """
         if not self._enhanced_mode or not is_proto_frame(payload):
             return

--- a/custom_components/ecoflow_energy/coordinator/state_apply.py
+++ b/custom_components/ecoflow_energy/coordinator/state_apply.py
@@ -25,7 +25,7 @@ class StateApplyMixin:
         now = time.monotonic()
         self._last_mqtt_ts = now
         self._device_available = True
-        # MQTT data proves credentials are valid — prevent false reauth (#2)
+        # MQTT data proves credentials are valid - prevent false reauth (#2)
         self._consecutive_http_failures = 0
         # Rate-limited event log: at most once per 60s to avoid flooding the deque
         if now - self._last_mqtt_event_ts > 60:
@@ -321,10 +321,10 @@ class StateApplyMixin:
         # API totals: prefer over Riemann sum (more accurate when available)
         for power_key, energy_key in self._energy_from_api:
             if energy_key in parsed:
-                # API provided a total — use it (already set by parser)
+                # API provided a total - use it (already set by parser)
                 self._energy_integrator.set_total(energy_key, parsed[energy_key])
             else:
-                # No API total — integrate from power
+                # No API total - integrate from power
                 power_w = parsed.get(power_key)
                 if power_w is not None:
                     total = self._energy_integrator.integrate(energy_key, abs(power_w))

--- a/custom_components/ecoflow_energy/diagnostics.py
+++ b/custom_components/ecoflow_energy/diagnostics.py
@@ -194,7 +194,7 @@ async def _skipped_devices_diagnostics(
     For a device we do not yet parse, capture its raw HTTP quota so a parser
     can be built from real API fields without owning the hardware. The full
     serial is used only to sign the read-only quota request and is never
-    included in the output — only the SN prefix is exposed. Serial-looking
+    included in the output - only the SN prefix is exposed. Serial-looking
     values inside the quota are redacted by the single pass on the way out
     of ``async_get_config_entry_diagnostics``.
 
@@ -336,7 +336,7 @@ def _energy_integrator_diagnostics(
 
 
 def _device_diagnostics(coordinator: EcoFlowDeviceCoordinator) -> dict[str, Any]:
-    """Build diagnostics dict for one device — no credentials."""
+    """Build diagnostics dict for one device - no credentials."""
     now = time.monotonic()
 
     mqtt_client = coordinator.mqtt_client

--- a/custom_components/ecoflow_energy/ecoflow/__init__.py
+++ b/custom_components/ecoflow_energy/ecoflow/__init__.py
@@ -1,4 +1,4 @@
-# EcoFlow core library — ported from EcoCharge.
+# EcoFlow core library - ported from EcoCharge.
 #
 # Phase 1: transport, protobuf, parsers.
-# No HA dependencies — used by the integration coordinator in Phase 2.
+# No HA dependencies - used by the integration coordinator in Phase 2.

--- a/custom_components/ecoflow_energy/ecoflow/clientid.py
+++ b/custom_components/ecoflow_energy/ecoflow/clientid.py
@@ -1,7 +1,7 @@
 """EcoFlow Portal WSS MQTT ClientID Generator.
 
 Generates MQTT client IDs for the WSS connection to the EcoFlow broker (port 8084).
-Must be called on every connect/reconnect — old client IDs are rejected after disconnect.
+Must be called on every connect/reconnect - old client IDs are rejected after disconnect.
 
 Reverse-engineered from: main.9d3dab6f.js (ef-device-user-jt_v2.7.9)
 """
@@ -54,7 +54,7 @@ BT = [
 def generate_client_id(user_id: str) -> str:
     """Generate a valid MQTT ClientID for EcoFlow Portal WSS (port 8084).
 
-    A new ClientID is required on every connect/reconnect — the broker
+    A new ClientID is required on every connect/reconnect - the broker
     rejects old ClientIDs after disconnect.
 
     Args:

--- a/custom_components/ecoflow_energy/ecoflow/cloud_http.py
+++ b/custom_components/ecoflow_energy/ecoflow/cloud_http.py
@@ -55,7 +55,7 @@ class EcoFlowHTTPQuota:
 
     @property
     def _sn_display(self) -> str:
-        """SN prefix only for logs — never leak a full serial to HA logs."""
+        """SN prefix only for logs - never leak a full serial to HA logs."""
         return self._device_sn[:4] + "..."
 
     # ------------------------------------------------------------------
@@ -65,7 +65,7 @@ class EcoFlowHTTPQuota:
     async def get_quota_all(self) -> dict | None:
         """Fetch all quotas via GET /iot-open/sign/device/quota/all?sn=...
 
-        No request body — SN is passed as query parameter.
+        No request body - SN is passed as query parameter.
         Response: {"code": "0", "data": {"pd.soc": 83, "inv.outputWatts": 0, ...}}
         """
         if not self._check_rate_limit():
@@ -216,17 +216,17 @@ class EcoFlowHTTPQuota:
             self._logged_1006 = False
             return data.get("data") or {}
 
-        # EcoFlow error 8521 is a transient server-side error — retry
+        # EcoFlow error 8521 is a transient server-side error - retry
         if code == "8521":
-            _LOGGER.debug("HTTP: transient error 8521 for %s — will retry", self._sn_display)
+            _LOGGER.debug("HTTP: transient error 8521 for %s - will retry", self._sn_display)
             raise self._RetryableAPIError(f"code={code}")
 
-        # Error 1006: device not linked to API key — not an auth failure (#2)
+        # Error 1006: device not linked to API key - not an auth failure (#2)
         if code == "1006":
             self.last_error_code = "1006"
             if not self._logged_1006:
                 _LOGGER.warning(
-                    "HTTP: device %s not linked to API key — "
+                    "HTTP: device %s not linked to API key - "
                     "verify device binding at developer.ecoflow.com (code=1006)",
                     self._sn_display,
                 )

--- a/custom_components/ecoflow_energy/ecoflow/cloud_mqtt.py
+++ b/custom_components/ecoflow_energy/ecoflow/cloud_mqtt.py
@@ -1,7 +1,7 @@
 """EcoFlow Cloud MQTT client (Paho-based).
 
 Manages WSS (port 8084) and TCP (port 8883) connections to the EcoFlow broker.
-Configuration via constructor — no global config imports.
+Configuration via constructor - no global config imports.
 
 Threading note: Paho runs its own network thread.  In HA, bridge callbacks
 to the event loop with ``hass.loop.call_soon_threadsafe()``.
@@ -320,7 +320,7 @@ class EcoFlowMQTTClient:
                 if not self._notified_connected:
                     self._notified_connected = True
                     _LOGGER.debug(
-                    "MQTT connected — data topics: %s | %s | set_reply",
+                    "MQTT connected - data topics: %s | %s | set_reply",
                     self.mask_topic(topic_json),
                     self.mask_topic(topic_pb),
                 )
@@ -328,7 +328,7 @@ class EcoFlowMQTTClient:
                 # Standard Mode: no data subscriptions, MQTT is for SET commands only
                 if not self._notified_connected:
                     self._notified_connected = True
-                    _LOGGER.debug("MQTT connected — SET-only mode (set_reply subscribed)")
+                    _LOGGER.debug("MQTT connected - SET-only mode (set_reply subscribed)")
 
             self.last_connect_time = time.monotonic()
             self.connected = True
@@ -378,7 +378,7 @@ class EcoFlowMQTTClient:
             reason = CONNECT_REASONS.get(rc_val, "unknown error")
             auth_failure = rc_val in (4, 5, 134, 135)
             if auth_failure:
-                self._log_issue("warning", "MQTT connect failed: rc=%s (%s) — scheduling credential refresh", rc_val, reason)
+                self._log_issue("warning", "MQTT connect failed: rc=%s (%s) - scheduling credential refresh", rc_val, reason)
             else:
                 self._log_issue("error", "MQTT connect failed: rc=%s (%s)", rc_val, reason)
             self.connected = False
@@ -395,7 +395,7 @@ class EcoFlowMQTTClient:
         """Callback on MQTT disconnect.
 
         ``reason_code`` is a ReasonCode object under paho-mqtt 2.x VERSION2
-        callbacks — normalize to int before any comparison.
+        callbacks - normalize to int before any comparison.
         """
         rc_val = reason_code.value if hasattr(reason_code, "value") else reason_code
         was_connected = self.connected
@@ -432,7 +432,7 @@ class EcoFlowMQTTClient:
             if (current_time - self._last_counter_reset_time) >= self._counter_reset_interval:
                 self._last_counter_reset_time = current_time
                 self.reconnect_attempts = 0
-                _LOGGER.debug("MQTT: counter reset after %ds — starting new cycle", self._counter_reset_interval)
+                _LOGGER.debug("MQTT: counter reset after %ds - starting new cycle", self._counter_reset_interval)
             else:
                 return False
 
@@ -458,10 +458,10 @@ class EcoFlowMQTTClient:
 
     def _schedule_reconnect(self):
         """Signal that a reconnect is needed."""
-        _LOGGER.debug("MQTT: reconnect scheduled — attempts: %d/%d", self.reconnect_attempts, self.max_reconnect_attempts)
+        _LOGGER.debug("MQTT: reconnect scheduled - attempts: %d/%d", self.reconnect_attempts, self.max_reconnect_attempts)
 
     # send_ping publishes JSON to the same /app/device/property/{sn} topic the
-    # client subscribes to — the broker echoes it back. Marker covers both
+    # client subscribes to - the broker echoes it back. Marker covers both
     # compact and default json.dumps spellings.
     _PING_ECHO_MARKERS = (b'{"command":"ping"', b'{"command": "ping"')
 
@@ -471,7 +471,7 @@ class EcoFlowMQTTClient:
             msg.topic == f"/app/device/property/{self._device_sn}"
             and msg.payload.startswith(self._PING_ECHO_MARKERS)
         ):
-            # Broker echo of our own keepalive ping — not device data
+            # Broker echo of our own keepalive ping - not device data
             return
         _LOGGER.debug(
             "MQTT msg: %s (%d bytes) for %s",
@@ -526,7 +526,7 @@ class EcoFlowMQTTClient:
         """Force disconnect + reconnect with new ClientID (WSS).
 
         Recreates the Paho client instead of manipulating private attributes.
-        No blocking sleep — the old connection is torn down synchronously.
+        No blocking sleep - the old connection is torn down synchronously.
 
         Guarded by a non-blocking lock: overlapping calls (watchdog +
         credential refresh run in separate executor threads) would orphan
@@ -534,7 +534,7 @@ class EcoFlowMQTTClient:
         caller skips instead.
         """
         if not self._client_lock.acquire(blocking=False):
-            _LOGGER.debug("Force-reconnect: skipped — another reconnect already in flight")
+            _LOGGER.debug("Force-reconnect: skipped - another reconnect already in flight")
             return False
         try:
             _LOGGER.debug("Force-reconnect: disconnecting and recreating client...")

--- a/custom_components/ecoflow_energy/ecoflow/energy_integrator.py
+++ b/custom_components/ecoflow_energy/ecoflow/energy_integrator.py
@@ -78,7 +78,7 @@ class EnergyIntegrator:
         """Load persisted state from disk (blocking I/O).
 
         Call from an executor job to avoid blocking the HA event loop.
-        Safe to call multiple times — only loads once.
+        Safe to call multiple times - only loads once.
         """
         if self._loaded:
             return
@@ -183,7 +183,7 @@ class EnergyIntegrator:
         return new_total_kwh
 
     def set_total(self, metric: str, total_kwh: float) -> None:
-        """Set total directly from API (monotonic — only if higher)."""
+        """Set total directly from API (monotonic - only if higher)."""
         if not self._loaded:
             self.load_state()
 

--- a/custom_components/ecoflow_energy/ecoflow/energy_stream.py
+++ b/custom_components/ecoflow_energy/ecoflow/energy_stream.py
@@ -31,7 +31,7 @@ def build_energy_stream_activate_payload(seq: int = 0) -> bytes:
     # EnergyStreamSwitch: field 1 = true (emsOpenEnergyStream)
     switch_bytes = encode_field_varint(1, 1)
 
-    # Header — portal-exact field order:
+    # Header - portal-exact field order:
     header = bytearray()
     header.extend(encode_field_bytes(1, switch_bytes))   # pdata as field 1 (nested)
     header.extend(encode_field_varint(2, 32))            # src = 32 (Client/App)
@@ -147,13 +147,13 @@ def build_soc_limit_set_payload(
         seq = int(time.time() * 1000) & 0x7FFFFFFF
 
     # SysBatChgDsgSet: field 1 = sys_bat_chg_up_limit, field 2 = sys_bat_dsg_down_limit
-    # Only 2 fields — firmware does not reliably accept the payload with 4 fields.
+    # Only 2 fields - firmware does not reliably accept the payload with 4 fields.
     payload_bytes = (
         encode_field_varint(1, max_charge_soc)
         + encode_field_varint(2, min_discharge_soc)
     )
 
-    # Header — portal-exact field order (same as EnergyStreamSwitch, cmd_id=112):
+    # Header - portal-exact field order (same as EnergyStreamSwitch, cmd_id=112):
     header = bytearray()
     header.extend(encode_field_bytes(1, payload_bytes))          # pdata
     header.extend(encode_field_varint(2, 32))                    # src = 32 (Client/App)

--- a/custom_components/ecoflow_energy/ecoflow/enhanced_auth.py
+++ b/custom_components/ecoflow_energy/ecoflow/enhanced_auth.py
@@ -1,4 +1,4 @@
-"""Enhanced Mode authentication — login + optional AES-CFB credential decryption.
+"""Enhanced Mode authentication - login + optional AES-CFB credential decryption.
 
 Primary path: IoT Developer API provides MQTT credentials directly.
 Fallback path: Portal login → JWT → AES-encrypted credentials → decrypt.
@@ -32,7 +32,7 @@ _ENHANCED_CERT_PATH = "/iot-auth/enterprise-development/user/certification"
 # Constant IV extracted from EcoFlow Portal JS bundle (module 78829)
 _AES_IV = b"ojsajkqjwk1w2dfg"
 
-# EcoFlow has regional API endpoints — try EU first, then global fallback
+# EcoFlow has regional API endpoints - try EU first, then global fallback
 _AUTH_BASE_URLS = [
     IOT_API_BASE,                  # https://api-e.ecoflow.com (EU)
     "https://api.ecoflow.com",     # global fallback
@@ -96,7 +96,7 @@ async def get_enhanced_credentials(
 ) -> dict[str, Any] | None:
     """Fetch and decrypt Enhanced Mode MQTT credentials (Portal path).
 
-    This is a fallback — the primary path uses IoT Developer API credentials.
+    This is a fallback - the primary path uses IoT Developer API credentials.
 
     Returns:
         dict with ``certificateAccount``, ``certificatePassword``, etc.

--- a/custom_components/ecoflow_energy/ecoflow/iot_api.py
+++ b/custom_components/ecoflow_energy/ecoflow/iot_api.py
@@ -2,7 +2,7 @@
 
 Provides MQTT credentials via /iot-open/sign/certification
 and device listing via /iot-open/sign/device/list.
-Uses aiohttp for async HTTP — HA provides the ClientSession.
+Uses aiohttp for async HTTP - HA provides the ClientSession.
 """
 
 from __future__ import annotations
@@ -24,7 +24,7 @@ _Credentials = dict[str, Any]
 
 
 class IoTApiClient:
-    """IoT Developer API — HMAC-SHA256 signed async client.
+    """IoT Developer API - HMAC-SHA256 signed async client.
 
     Uses /iot-open/sign/certification to fetch MQTT credentials.
     Memory cache with rate-limit guard (max 1 fetch / 60 s).
@@ -50,7 +50,7 @@ class IoTApiClient:
 
         Returns:
             dict with certificateAccount, certificatePassword,
-            url, port, protocol — or None on error.
+            url, port, protocol - or None on error.
         """
         if self._cached is not None:
             return self._cached
@@ -59,7 +59,7 @@ class IoTApiClient:
     async def refresh_credentials(self) -> _Credentials | None:
         """Force a new fetch (e.g. after AUTH error rc=5).
 
-        Bypasses the rate-limit guard — forced refreshes only happen on
+        Bypasses the rate-limit guard - forced refreshes only happen on
         auth failure or age-based rotation, both rare. The previous cache
         is kept until a fetch succeeds, so a failed refresh does not
         destroy working credentials.
@@ -80,12 +80,12 @@ class IoTApiClient:
                 body = await resp.json()
                 data = body.get("data")
                 if data is None:
-                    _LOGGER.warning("IoT API device list: empty response — code=%s", body.get("code"))
+                    _LOGGER.warning("IoT API device list: empty response - code=%s", body.get("code"))
                     return None
                 # data == [] is a legitimate account with no bound devices
                 return data
         except (aiohttp.ClientError, TimeoutError) as exc:
-            _LOGGER.warning("IoT API device list failed — %s", exc)
+            _LOGGER.warning("IoT API device list failed - %s", exc)
             return None
 
     @staticmethod
@@ -124,7 +124,7 @@ class IoTApiClient:
         now = time.monotonic()
         if not force and (now - self._last_fetch_ts) < IOT_MIN_FETCH_INTERVAL_S:
             _LOGGER.debug(
-                "IoT API: rate-limited — next fetch in %.0f s",
+                "IoT API: rate-limited - next fetch in %.0f s",
                 IOT_MIN_FETCH_INTERVAL_S - (now - self._last_fetch_ts),
             )
             return self._cached
@@ -143,7 +143,7 @@ class IoTApiClient:
                 body = await resp.json()
                 data = body.get("data")
                 if not data:
-                    _LOGGER.warning("IoT API: empty response — code=%s", body.get("code"))
+                    _LOGGER.warning("IoT API: empty response - code=%s", body.get("code"))
                     return None
                 self._cached = data
                 _LOGGER.debug(
@@ -153,5 +153,5 @@ class IoTApiClient:
                 )
                 return data
         except (aiohttp.ClientError, TimeoutError) as exc:
-            _LOGGER.warning("IoT API: fetch failed — %s", exc)
+            _LOGGER.warning("IoT API: fetch failed - %s", exc)
             return None

--- a/custom_components/ecoflow_energy/ecoflow/parsers/delta_http.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/delta_http.py
@@ -6,7 +6,7 @@ flat sensor keys matching DELTA2MAX_SENSORS in const.py.
 The HTTP API returns keys in "module.field" format (e.g. "pd.soc"),
 different from MQTT which uses "typeCode" format (e.g. "pdStatus").
 
-Reference: EcoFlow IoT Developer Platform — DELTA 2 MAX section.
+Reference: EcoFlow IoT Developer Platform - DELTA 2 MAX section.
 """
 
 from __future__ import annotations

--- a/custom_components/ecoflow_energy/ecoflow/parsers/powerocean.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/powerocean.py
@@ -9,7 +9,7 @@ The /quota/all response contains 300+ keys including:
 - EMS data: emsBpAliveNum, ems_change_report.*, energy_stream.*
 - PV data: mpptHeartBeat[].mpptPv[]
 
-Reference: EcoFlow IoT Developer Platform — PowerOcean section.
+Reference: EcoFlow IoT Developer Platform - PowerOcean section.
 """
 
 from __future__ import annotations
@@ -468,7 +468,7 @@ def _extract_all_battery_packs(quota_data: dict) -> dict[str, Any]:
     """Extract per-pack battery data from all bp_addr.{SN} keys.
 
     Maps each pack to pack{n}_* sensor keys (n = 1..5).
-    Existing bp_* sensors are NOT affected — this produces separate keys.
+    Existing bp_* sensors are NOT affected - this produces separate keys.
     Phantom/empty entries (no core battery fields) are skipped so that
     numbering starts at 1 for the first real battery pack.
     """
@@ -503,7 +503,7 @@ def _extract_all_battery_packs(quota_data: dict) -> dict[str, Any]:
 
         prefix = f"pack{pack_num}"
 
-        # Core + diagnostic fields (no scaling needed — verified from probe data)
+        # Core + diagnostic fields (no scaling needed - verified from probe data)
         _field_map = {
             "bpSoc": f"{prefix}_soc",
             "bpPwr": f"{prefix}_power_w",

--- a/custom_components/ecoflow_energy/ecoflow/parsers/smartplug.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/smartplug.py
@@ -42,7 +42,7 @@ def parse_smartplug_http_quota(quota_data: dict) -> dict[str, Any]:
     # --- Core measurements ---
     _prefix = "2_1."
 
-    # Power (deci-W → W) — API returns value in 0.1 W units
+    # Power (deci-W → W) - API returns value in 0.1 W units
     if f"{_prefix}watts" in quota_data:
         v = _safe_float(quota_data[f"{_prefix}watts"])
         if v is not None:
@@ -91,7 +91,7 @@ def parse_smartplug_http_quota(quota_data: dict) -> dict[str, Any]:
         if v is not None:
             result["max_power_w"] = v
 
-    # Max current (deci-A → A) — API returns value in 0.1 A units
+    # Max current (deci-A → A) - API returns value in 0.1 A units
     if f"{_prefix}maxCur" in quota_data:
         v = _safe_float(quota_data[f"{_prefix}maxCur"])
         if v is not None:
@@ -116,7 +116,7 @@ def parse_smartplug_http_quota(quota_data: dict) -> dict[str, Any]:
 #   current: mA → A      (/1000)
 #   volt:    V → V        (1)
 #   maxCur:  deci-A → A   (/10)
-#   maxWatts: W → W       (1)  — no scaling in HTTP parser
+#   maxWatts: W → W       (1) - no scaling in HTTP parser
 _MQTT_FIELD_MAP: dict[str, tuple[str, float]] = {
     "watts": ("power_w", 0.1),
     "current": ("current_a", 0.001),
@@ -225,8 +225,8 @@ def parse_smartplug_report(data: dict[str, Any]) -> dict[str, Any]:
     """Parse a Smart Plug MQTT report message.
 
     MQTT reports may arrive in different envelope formats:
-    1. {"params": {"2_1.watts": 150, ...}} — same keys as HTTP quota
-    2. {"param": {"watts": 150, ...}} — direct field names (cmdId/cmdFunc format)
+    1. {"params": {"2_1.watts": 150, ...}} - same keys as HTTP quota
+    2. {"param": {"watts": 150, ...}} - direct field names (cmdId/cmdFunc format)
     3. Direct dict with field names
     """
     # Extract inner payload from envelope
@@ -239,7 +239,7 @@ def parse_smartplug_report(data: dict[str, Any]) -> dict[str, Any]:
     if any(k.startswith("2_1.") for k in params):
         return parse_smartplug_http_quota(params)
 
-    # Direct field names — apply same scaling as HTTP parser
+    # Direct field names - apply same scaling as HTTP parser
     result: dict[str, Any] = {}
 
     for api_key, (sensor_key, scale) in _MQTT_FIELD_MAP.items():

--- a/custom_components/ecoflow_energy/ecoflow/proto/ecocharge.proto
+++ b/custom_components/ecoflow_energy/ecoflow/proto/ecocharge.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-// ecocharge — Canonical Protobuf schema for EcoFlow PowerOcean telemetry.
+// ecocharge - Canonical Protobuf schema for EcoFlow PowerOcean telemetry.
 // Envelope (HeaderMessage/Header) + JT-S1 PowerOcean messages in one file.
 // Source: Protocol analysis of EcoFlow Portal web client, validated against live MQTT.
 

--- a/custom_components/ecoflow_energy/ecoflow/proto/runtime.py
+++ b/custom_components/ecoflow_energy/ecoflow/proto/runtime.py
@@ -67,7 +67,7 @@ def _build_cmd_registry() -> dict[tuple[int, int], CmdConfig]:
     try:
         from . import ecocharge_pb2 as pb2
     except ImportError:
-        _LOGGER.warning("Failed to import protobuf module — Enhanced Mode will not work")
+        _LOGGER.warning("Failed to import protobuf module - Enhanced Mode will not work")
         return {}
 
     return {

--- a/info.md
+++ b/info.md
@@ -9,13 +9,13 @@ Energy Dashboard ready. Two modes: official API or real-time app connection.
 
 ## What you get
 
-- **Up to 200 sensors per device** — power, energy, battery packs, temperature, diagnostics
-- **Energy Dashboard ready** — local Riemann-sum kWh with gap detection
-- **Real-time updates** — Enhanced Mode pushes data every 2-4 seconds
-- **Full PowerOcean control** — Backup Reserve, Solar Surplus Threshold, Work Mode, all verified against the official EcoFlow app
-- **Delta switches & numbers** — AC/DC output, charge speed, backup reserve, screen settings
-- **Smart Plug** — power monitoring, on/off switch, max power limit
-- **Auto-discovery** — picks up every device bound to your EcoFlow account
+- **Up to 200 sensors per device** - power, energy, battery packs, temperature, diagnostics
+- **Energy Dashboard ready** - local Riemann-sum kWh with gap detection
+- **Real-time updates** - Enhanced Mode pushes data every 2-4 seconds
+- **Full PowerOcean control** - Backup Reserve, Solar Surplus Threshold, Work Mode, all verified against the official EcoFlow app
+- **Delta switches & numbers** - AC/DC output, charge speed, backup reserve, screen settings
+- **Smart Plug** - power monitoring, on/off switch, max power limit
+- **Auto-discovery** - picks up every device bound to your EcoFlow account
 
 ## Supported devices
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 The ecoflow/ sub-package (core library) has no HA dependencies and can be
 tested standalone.  We add its parent to sys.path so tests can import
-``ecoflow_energy.ecoflow.*`` — but the HA integration modules
+``ecoflow_energy.ecoflow.*`` - but the HA integration modules
 (coordinator, config_flow, sensor, …) are NOT importable here because
 they require homeassistant.
 

--- a/tests/ha/test_coordinator.py
+++ b/tests/ha/test_coordinator.py
@@ -1,4 +1,4 @@
-"""Tests for EcoFlowDeviceCoordinator — setup, data flow, stale detection, shutdown."""
+"""Tests for EcoFlowDeviceCoordinator - setup, data flow, stale detection, shutdown."""
 
 from __future__ import annotations
 
@@ -2210,7 +2210,7 @@ class TestStaleDetection:
         coordinator = EcoFlowDeviceCoordinator(
             hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
         )
-        # Don't call async_setup — just set up a mock MQTT client directly
+        # Don't call async_setup - just set up a mock MQTT client directly
         mock_mqtt = MagicMock()
         mock_mqtt.is_connected.return_value = False
         mock_mqtt.try_reconnect.return_value = False
@@ -2577,7 +2577,7 @@ class TestApplyData:
         coordinator._consecutive_http_failures = 4
         coordinator._device_available = False
 
-        # MQTT data arrives — proves credentials are valid
+        # MQTT data arrives - proves credentials are valid
         coordinator._apply_data({"soc": 85})
 
         assert coordinator._consecutive_http_failures == 0
@@ -2618,7 +2618,7 @@ class TestApplyData:
         # First call: sets baseline (no energy yet)
         coordinator._apply_data({"solar_w": 3000, "home_w": 1500})
         # Backdate the integrator's internal timestamp to simulate elapsed time
-        # (same pattern as tests/test_energy_integrator.py — manipulate _state directly)
+        # (same pattern as tests/test_energy_integrator.py - manipulate _state directly)
         for metric in ("solar_energy_kwh", "home_energy_kwh"):
             if metric in coordinator._energy_integrator._state:
                 total, _ts, power = coordinator._energy_integrator._state[metric]
@@ -3126,7 +3126,7 @@ class TestApplyData:
 
 
 # ===========================================================================
-# Protobuf Key Remapping (_remap_proto_keys) — F-001
+# Protobuf Key Remapping (_remap_proto_keys) - F-001
 # ===========================================================================
 
 
@@ -3230,7 +3230,7 @@ class TestProtoKeyRemapping:
 
 
 # ===========================================================================
-# Heartbeat Nested Extraction (_flatten_heartbeat) — MPPT, Grid Phases
+# Heartbeat Nested Extraction (_flatten_heartbeat) - MPPT, Grid Phases
 # ===========================================================================
 
 
@@ -3578,7 +3578,7 @@ class TestBpRemapping:
         }
         result = remap_bp_keys(raw, coordinator._bp_sn_to_index, coordinator.device_sn)
 
-        # Phantom skipped — real packs are pack1 and pack2
+        # Phantom skipped - real packs are pack1 and pack2
         assert result["pack1_soc"] == 76.0
         assert result["pack1_power_w"] == 2486.48
         assert result["pack2_soc"] == 74.0
@@ -3590,7 +3590,7 @@ class TestBpRemapping:
         hass: HomeAssistant,
         enhanced_config_entry: MockConfigEntry,
     ) -> None:
-        """All packs are empty dicts (EMS module placeholders) — no pack sensors produced."""
+        """All packs are empty dicts (EMS module placeholders) - no pack sensors produced."""
         enhanced_config_entry.add_to_hass(hass)
         coordinator = EcoFlowDeviceCoordinator(
             hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
@@ -3626,7 +3626,7 @@ class TestBpRemapping:
         # Per-pack values extracted by _remap_bp_keys
         assert parsed["pack1_remain_watth"] == 2400.0
         assert parsed["pack2_remain_watth"] == 2600.0
-        # Aggregate is NOT in _remap_bp_keys output — it's computed in _apply_data
+        # Aggregate is NOT in _remap_bp_keys output - it's computed in _apply_data
         assert "bp_remain_watth" not in parsed
 
         # _apply_data computes the aggregate from accumulated device_data
@@ -3698,7 +3698,7 @@ class TestBpRemapping:
                 {"bp_soc": 76, "bp_pwr": 2486.48, "bp_vol": 54.671,
                  "bp_design_cap": 100000, "bp_full_cap": 100000,
                  "bp_remain_watth": 3891.2},
-                # Pack 2: idle — proto3 omits bp_soc=0, bp_pwr=0.0 but
+                # Pack 2: idle - proto3 omits bp_soc=0, bp_pwr=0.0 but
                 # bp_design_cap/bp_full_cap are >0 so they survive MessageToDict
                 {"bp_design_cap": 100000, "bp_full_cap": 100000,
                  "bp_remain_watth": 2000.0},
@@ -3706,7 +3706,7 @@ class TestBpRemapping:
         }
         parsed = remap_bp_keys(raw, coordinator._bp_sn_to_index, coordinator.device_sn)
 
-        # Both packs recognized — idle pack is NOT filtered
+        # Both packs recognized - idle pack is NOT filtered
         assert parsed["pack1_soc"] == 76.0
         assert parsed["pack1_remain_watth"] == pytest.approx(3891.2)
         assert parsed["pack2_remain_watth"] == 2000.0
@@ -3738,7 +3738,7 @@ class TestBpRemapping:
         coordinator._apply_data(msg1)
         assert coordinator.device_data["pack1_remain_watth"] == 2400.0
 
-        # Second heartbeat: Pack B reports (SN=BBB) — different SN → pack2
+        # Second heartbeat: Pack B reports (SN=BBB) - different SN → pack2
         msg2 = remap_bp_keys({
             "all_packs": [
                 {"bp_sn": "BBB", "bp_soc": 74, "bp_pwr": 2529,
@@ -3856,7 +3856,7 @@ class TestBpRemapping:
 
 
 # ===========================================================================
-# Monotonic Filter (_enforce_monotonic) — total_increasing regression guard
+# Monotonic Filter (_enforce_monotonic) - total_increasing regression guard
 # ===========================================================================
 
 

--- a/tests/ha/test_diagnostics.py
+++ b/tests/ha/test_diagnostics.py
@@ -1,4 +1,4 @@
-"""Functional tests for diagnostics — runtime output verification."""
+"""Functional tests for diagnostics - runtime output verification."""
 
 from __future__ import annotations
 
@@ -103,7 +103,7 @@ class TestConfigEntryDiagnostics:
     ) -> None:
         """Diagnostics handles missing coordinators gracefully."""
         standard_config_entry.add_to_hass(hass)
-        # Don't set up the integration — no coordinators in hass.data
+        # Don't set up the integration - no coordinators in hass.data
         result = await async_get_config_entry_diagnostics(hass, standard_config_entry)
         assert result["devices"] == []
         assert result["skipped_devices"] == []
@@ -253,7 +253,7 @@ class TestDeviceDiagnostics:
         hass: HomeAssistant,
         standard_config_entry: MockConfigEntry,
     ) -> None:
-        """Standard Mode is not a fallback — http_fallback_active is False."""
+        """Standard Mode is not a fallback - http_fallback_active is False."""
         standard_config_entry.add_to_hass(hass)
         coordinator = EcoFlowDeviceCoordinator(
             hass, standard_config_entry, MOCK_DELTA_DEVICE
@@ -992,7 +992,7 @@ class TestSkippedDeviceRawQuotaDiagnostics:
         entry.add_to_hass(hass)
         self._register_skipped(hass, entry)
 
-        # get_quota_all() returns the already-unwrapped flat quota dict —
+        # get_quota_all() returns the already-unwrapped flat quota dict -
         # no code/data envelope. Match the real client contract.
         quota_response = {
             "meterSn": self.FAKE_SERIAL_FIELD,

--- a/tests/ha/test_entities.py
+++ b/tests/ha/test_entities.py
@@ -1,4 +1,4 @@
-"""Tests for EcoFlow entity platforms — sensor, binary_sensor, switch, number."""
+"""Tests for EcoFlow entity platforms - sensor, binary_sensor, switch, number."""
 
 from __future__ import annotations
 

--- a/tests/ha/test_init.py
+++ b/tests/ha/test_init.py
@@ -529,7 +529,7 @@ class TestUnsupportedDeviceSkip:
             if r.levelno == logging.WARNING and "Skipping unsupported" in r.message
         ]
         assert len(warnings) == 1
-        # SN prefix only (privacy) — full serial must not leak
+        # SN prefix only (privacy) - full serial must not leak
         assert "BK21" in warnings[0].getMessage()
         assert "BK21TEST00000001" not in warnings[0].getMessage()
 

--- a/tests/ha/test_powerocean_number.py
+++ b/tests/ha/test_powerocean_number.py
@@ -1,4 +1,4 @@
-"""Tests for PowerOcean number entities — SoC limit SET via Enhanced Mode."""
+"""Tests for PowerOcean number entities - SoC limit SET via Enhanced Mode."""
 
 from __future__ import annotations
 
@@ -186,7 +186,7 @@ class TestPowerOceanNumberBasic:
             await entity.async_set_native_value(50.0)
 
         coordinator.async_set_powerocean_soc_debounced.assert_called_once_with(50, 100)
-        # No optimistic update — original value retained
+        # No optimistic update - original value retained
         assert coordinator.data["ems_discharge_lower_limit_pct"] == 0
 
     async def test_native_value_reads_state_key(
@@ -541,7 +541,7 @@ class TestPowerOceanAppSurplusAutoSync:
         enhanced_config_entry: MockConfigEntry,
     ) -> None:
         """If the most recent EmsParamChangeReport arrived BEFORE the user
-        pushed a new value in HA, the auto-sync must not fire — the
+        pushed a new value in HA, the auto-sync must not fire - the
         ParamChange's dev_soc value is the obsolete app-side mirror that
         the user has already superseded."""
         coordinator = self._make_coordinator(hass, enhanced_config_entry)
@@ -684,7 +684,7 @@ class TestPowerOceanAppSurplusAutoSync:
     ) -> None:
         """Frames that do not carry `ems_app_surplus_pct` (e.g. a regular
         EmsChangeReport for sysBatBackupRatio) must leave the timestamp
-        alone — only the ParamChange path proves the app-side value is
+        alone - only the ParamChange path proves the app-side value is
         fresh."""
         coordinator = self._make_coordinator(hass, enhanced_config_entry)
         coordinator._last_ems_param_change_ts = 1234.0

--- a/tests/ha/test_state_dedup.py
+++ b/tests/ha/test_state_dedup.py
@@ -279,7 +279,7 @@ class TestSwitchDedup:
             patch.object(coordinator, "async_send_set_command", new_callable=AsyncMock),
             patch.object(switch, "async_write_ha_state") as mock_write,
         ):
-            # _send_command always writes — it bypasses _handle_coordinator_update
+            # _send_command always writes - it bypasses _handle_coordinator_update
             await switch._send_command(False)
             assert mock_write.call_count == 1
 
@@ -611,7 +611,7 @@ class TestOptimisticDedupSync:
             assert mock_write.call_count == 1
             assert switch._last_written_value is False
 
-            # Coordinator tick during lock window — is_on still returns False (lock active).
+            # Coordinator tick during lock window - is_on still returns False (lock active).
             # Because _last_written_value is already False, no second write.
             with patch("time.monotonic", return_value=1001.0):  # still within 5 s lock
                 switch._handle_coordinator_update()

--- a/tests/ha/test_stream_number.py
+++ b/tests/ha/test_stream_number.py
@@ -1,4 +1,4 @@
-"""Tests for Stream AC Pro number entities — backup reserve SET via WSS proto.
+"""Tests for Stream AC Pro number entities - backup reserve SET via WSS proto.
 
 Covers the SET path that Issue #98 fixed: the Stream backup-reserve number
 must build a protobuf frame on the verified ConfigWrite write path

--- a/tests/test_cloud_http.py
+++ b/tests/test_cloud_http.py
@@ -1,4 +1,4 @@
-"""Tests for EcoFlowHTTPQuota — signature, rate limiting, dead code removal."""
+"""Tests for EcoFlowHTTPQuota - signature, rate limiting, dead code removal."""
 
 import asyncio
 import hashlib
@@ -303,7 +303,7 @@ class TestError8521Retry:
 
         result = await client.get_quota_all()
         assert result is None
-        # Only called once — no retry for non-8521 errors
+        # Only called once - no retry for non-8521 errors
         assert mock_session.get.call_count == 1
 
 
@@ -321,7 +321,7 @@ class AsyncContextManager:
 
 
 class TestError1006Handling:
-    """Error 1006 (device not linked to API key) — config issue, not auth (#2)."""
+    """Error 1006 (device not linked to API key) - config issue, not auth (#2)."""
 
     def _make_1006_response(self):
         resp = AsyncMock()
@@ -362,7 +362,7 @@ class TestError1006Handling:
 
     @pytest.mark.asyncio
     async def test_1006_not_retried(self):
-        """Error 1006 is not retried — only one HTTP call."""
+        """Error 1006 is not retried - only one HTTP call."""
         mock_session = MagicMock()
         mock_session.get = MagicMock(
             return_value=AsyncContextManager(self._make_1006_response())
@@ -425,7 +425,7 @@ class TestFullSerialNeverLogged:
     """A full device serial must never reach the HA logs (only the prefix).
 
     Unsupported devices commonly return 1006, and the diagnostics feature
-    exists to make users attach their HA log to a GitHub issue — so a full
+    exists to make users attach their HA log to a GitHub issue - so a full
     serial in the logs would leak. Every error/status log path is checked.
     """
 

--- a/tests/test_cloud_mqtt.py
+++ b/tests/test_cloud_mqtt.py
@@ -1,4 +1,4 @@
-"""Tests for EcoFlowMQTTClient — subscribe_data, client creation, reconnect, disconnect."""
+"""Tests for EcoFlowMQTTClient - subscribe_data, client creation, reconnect, disconnect."""
 
 import logging
 import time
@@ -40,7 +40,7 @@ class TestSubscribeDataFlag:
         # Simulate successful connection (rc=0)
         client._on_connect(mock_paho, None, None, 0)
 
-        # Must subscribe to set_reply only — no data topics
+        # Must subscribe to set_reply only - no data topics
         topics_subscribed = [call[0][0] for call in mock_paho.subscribe.call_args_list]
         assert len(topics_subscribed) == 1
         assert "/set_reply" in topics_subscribed[0]
@@ -75,7 +75,7 @@ class TestClientCreation:
         assert client._wss_mode is False
 
     def test_wss_mode_requires_user_id(self):
-        """WSS mode needs user_id — without it, falls back to TCP."""
+        """WSS mode needs user_id - without it, falls back to TCP."""
         client = _make_client(wss_mode=True, user_id="")
         assert client._wss_mode is False
 
@@ -541,7 +541,7 @@ class TestPingEchoFilter:
         handler.assert_called_once_with("/app/device/property/TEST1234SN", payload)
 
     def test_ping_marker_on_other_topic_not_dropped(self):
-        """The filter is topic-scoped — same marker on another topic passes through."""
+        """The filter is topic-scoped - same marker on another topic passes through."""
         handler = MagicMock()
         client = _make_client(message_handler=handler)
 
@@ -686,7 +686,7 @@ class TestAuthErrorHandler:
             handler.assert_not_called()
 
     def test_auth_error_handler_called_on_reasoncode_135(self):
-        """paho 2.x VERSION2 delivers ReasonCode objects — 135 (Not authorized)
+        """paho 2.x VERSION2 delivers ReasonCode objects - 135 (Not authorized)
         must fire the auth-error handler without raising (ReasonCode is unhashable)."""
         from paho.mqtt.packettypes import PacketTypes
         from paho.mqtt.reasoncodes import ReasonCode

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,4 +1,4 @@
-"""Tests for entity definitions in const.py — uniqueness and completeness."""
+"""Tests for entity definitions in const.py - uniqueness and completeness."""
 
 from __future__ import annotations
 
@@ -265,7 +265,7 @@ def _extract_sensor_keys(var_name: str) -> list[str]:
     Uses runtime import for lists that are dynamically extended (e.g. pack sensors),
     falls back to AST extraction for lists defined purely as literals.
     """
-    # Runtime approach — covers dynamically extended lists
+    # Runtime approach - covers dynamically extended lists
     _RUNTIME_MAP = {
         "POWEROCEAN_SENSORS": POWEROCEAN_SENSORS,
         "DELTA2MAX_SENSORS": DELTA2MAX_SENSORS,

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,4 +1,4 @@
-"""Tests for diagnostics — verifies no credentials are exposed."""
+"""Tests for diagnostics - verifies no credentials are exposed."""
 
 import json
 import re
@@ -19,7 +19,7 @@ def test_diagnostics_redacts_credentials():
 
     # Email/password are never needed by diagnostics and must never be
     # referenced. Access/secret key ARE read (read-only) to sign the raw
-    # quota request for unsupported devices, so they are allowed here — the
+    # quota request for unsupported devices, so they are allowed here - the
     # runtime tests prove their values never reach the output.
     for conf_name in ("CONF_EMAIL", "CONF_PASSWORD"):
         assert conf_name not in source, f"{conf_name} must not appear in diagnostics.py"

--- a/tests/test_energy_stream.py
+++ b/tests/test_energy_stream.py
@@ -1,4 +1,4 @@
-"""Tests for EcoFlow Protobuf encoder — EnergyStreamSwitch and SoC limit SET."""
+"""Tests for EcoFlow Protobuf encoder - EnergyStreamSwitch and SoC limit SET."""
 
 import pytest
 

--- a/tests/test_iot_api.py
+++ b/tests/test_iot_api.py
@@ -1,4 +1,4 @@
-"""Tests for IoTApiClient — signature, caching, rate-limit, device list."""
+"""Tests for IoTApiClient - signature, caching, rate-limit, device list."""
 
 import hashlib
 import hmac
@@ -152,7 +152,7 @@ class TestCredentialCaching:
         result1 = await client.get_mqtt_credentials()
         assert result1 == creds1
 
-        # Force refresh — but rate-limit will block (< 60s)
+        # Force refresh - but rate-limit will block (< 60s)
         # Reset _last_fetch_ts to bypass rate limit
         client._last_fetch_ts = 0.0
         result2 = await client.refresh_credentials()
@@ -171,7 +171,7 @@ class TestCredentialCaching:
         result1 = await client.get_mqtt_credentials()
         assert result1 == creds1
 
-        # Still inside the rate-limit window — forced refresh must fetch anyway
+        # Still inside the rate-limit window - forced refresh must fetch anyway
         result2 = await client.refresh_credentials()
         assert result2 == creds2
         assert session.get.call_count == 2

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,4 +1,4 @@
-"""Tests for manifest.json — validates HACS/hassfest requirements."""
+"""Tests for manifest.json - validates HACS/hassfest requirements."""
 
 import json
 from pathlib import Path
@@ -19,7 +19,7 @@ class TestManifest:
         assert m["domain"] == "ecoflow_energy"
 
     def test_iot_class_is_cloud_push(self):
-        """Enhanced Mode + Delta MQTT push — iot_class reflects primary data source."""
+        """Enhanced Mode + Delta MQTT push - iot_class reflects primary data source."""
         m = _load_manifest()
         assert m["iot_class"] == "cloud_push", (
             f"iot_class must be 'cloud_push', got '{m['iot_class']}'"
@@ -38,11 +38,11 @@ class TestManifest:
         m = _load_manifest()
         for req in m["requirements"]:
             assert "pycryptodome" not in req.lower(), (
-                f"pycryptodome must not be in requirements — use cryptography instead (found: {req})"
+                f"pycryptodome must not be in requirements - use cryptography instead (found: {req})"
             )
 
     def test_requirements_does_not_redeclare_paho_mqtt(self):
-        """paho-mqtt ships with HA core via the `mqtt` integration — must not be redeclared here."""
+        """paho-mqtt ships with HA core via the `mqtt` integration - must not be redeclared here."""
         m = _load_manifest()
         for req in m["requirements"]:
             assert "paho-mqtt" not in req.lower(), (
@@ -50,7 +50,7 @@ class TestManifest:
             )
 
     def test_requirements_does_not_redeclare_protobuf(self):
-        """protobuf ships with HA core via several core integrations — must not be redeclared here."""
+        """protobuf ships with HA core via several core integrations - must not be redeclared here."""
         m = _load_manifest()
         for req in m["requirements"]:
             assert "protobuf" not in req.lower(), (

--- a/tests/test_powerocean_parser.py
+++ b/tests/test_powerocean_parser.py
@@ -972,7 +972,7 @@ class TestMultiBatteryPack:
         assert result["pack2_power_w"] == pytest.approx(2529.1938)
 
     def test_phantom_empty_pack_skipped(self):
-        """Phantom/empty pack at position 0 is skipped — real packs start at 1."""
+        """Phantom/empty pack at position 0 is skipped - real packs start at 1."""
         data = {
             "bp_addr.PHANTOM_EMS": {},  # empty entry (EMS module)
             "bp_addr.HJ32ZDH5ZG190227": dict(self.PACK1_DATA),
@@ -1006,7 +1006,7 @@ class TestMultiBatteryPack:
         assert result["bp_cycles"] == 42.0
 
     def test_aggregate_bp_phantom_only(self):
-        """Only phantom packs — no aggregate sensors produced."""
+        """Only phantom packs - no aggregate sensors produced."""
         data = {"bp_addr.PHANTOM": {}}
         result = {}
         _extract_battery_pack(data, result)

--- a/tests/test_proto_decoder.py
+++ b/tests/test_proto_decoder.py
@@ -79,7 +79,7 @@ class TestRuntimeDecoder:
         assert result.mapped["_is_full_power_frame"] is True
 
     def test_energy_stream_zero_fill(self):
-        """Proto3 omits 0.0 — runtime decoder must zero-fill power fields."""
+        """Proto3 omits 0.0 - runtime decoder must zero-fill power fields."""
         msg = JTS1EnergyStreamReport()
         msg.bp_soc = 50
         # All power fields are 0.0 (proto3 omits them)

--- a/tests/test_smartplug_parser.py
+++ b/tests/test_smartplug_parser.py
@@ -225,7 +225,7 @@ class TestMQTTReportWithDirectFields:
         assert result["led_brightness"] == pytest.approx(100.0)  # 1023 -> 100%
 
     def test_max_watts_no_scaling(self):
-        """maxWatts has no scaling — consistent with HTTP parser."""
+        """maxWatts has no scaling - consistent with HTTP parser."""
         result = parse_smartplug_report({"maxWatts": 2500})
         assert result["max_power_w"] == 2500.0
 


### PR DESCRIPTION
## Summary

This is a public repository, and an em dash is a writing marker the project does not want in anything it publishes. They had spread well past the places that get proofread: **177 of them across 43 files**.

The distribution is the point. Only 44 were in the changelog. The rest sat in code comments, docstrings, tests, and in the log lines this integration writes into somebody else's Home Assistant:

```
"MQTT connect failed: rc=%s (%s) - scheduling credential refresh"
"HTTP quota failed %d consecutive times for %s - triggering re-authentication"
"HTTP: transient error 8521 for %s - will retry"
"MQTT: reconnect scheduled - attempts: %d/%d"
```

Those are the ones that mattered. A marker in a comment is seen by whoever reads the source. A marker in a reconnect log is seen by every user who ever opens their log.

## What changed

Spaced em dashes become spaced hyphens, which is how the rest of the tree already writes an aside. Unspaced ones become a bare hyphen. Nothing else.

**No translation file contained one**, checked before touching anything, so nothing a user reads in the interface moves. Entity names, entity ids, units and behaviour are untouched.

## Verification

- 2360 tests pass.
- Ruff reports exactly the same 49 findings before and after, so nothing was introduced.
- Zero em dashes remain in any tracked file.

Manifest stays at `1.17.0`, same cycle. The changelog entry says plainly that this is cosmetic and exists only because those log lines leave this repository.

## Checklist

- [x] Tests pass (`pytest`)
- [x] CHANGELOG.md updated
- [x] Version correct for the cycle
- [x] No secrets or real device serial numbers