### PR TITLE
docs: list the J327 PowerOcean prefix where the others are listed

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 | Device | Serial prefix | Sensors | Controls | Energy Sensors | Update Rate |
 |:---|:---|:---:|:---:|:---:|:---|
-| **PowerOcean** - Home Battery | `HJ31` `HJ32` `HJ35` `J32B` `J32D`\* `J32E`\* | 222 + 5 binary | 2 numbers, 1 select (Enhanced only) | 6 (solar, grid import/export, battery charge/discharge, home) | ~30 s standard / ~3 s enhanced |
+| **PowerOcean** - Home Battery | `HJ31` `HJ32` `HJ35` `J32B` `J327`\* `J32D`\* `J32E`\* | 222 + 5 binary | 2 numbers, 1 select (Enhanced only) | 6 (solar, grid import/export, battery charge/discharge, home) | ~30 s standard / ~3 s enhanced |
 | **PowerOcean Plus** - 3-phase Hybrid | `R371`\* `R372`\* `R374`\* `HJ3C`\* | 222 + 5 binary | 2 numbers, 1 select (Enhanced only) | 6 (solar, grid import/export, battery charge/discharge, home) | ~3 s enhanced |
 | **Delta 2 Max** - Portable Power | `R351` `R331` | 94 + 4 binary | 7 switches, 8 numbers | 4 (solar 1+2, AC in/out) | ~30 s standard (+ MQTT push) |
 | **Delta 3** - Portable Power | `D3M1` `D3N1` `P321` `P231` | 47 | 7 switches, 4 numbers, 5 selects (selects and 1 number Enhanced only); `D3M` serials add 3 switches, 3 numbers and 1 binary sensor for port priority | 4 (solar 1+2, AC in, output) | ~30 s standard / ~2 s enhanced |
@@ -144,14 +144,14 @@ Download the [latest release](https://github.com/shuette42/ecoflow-energy-ha/rel
 | | Standard | Enhanced |
 |:---|:---|:---|
 | **Credentials** | Access Key + Secret Key ([Developer Portal](https://developer.ecoflow.com)) | EcoFlow email + password (same as mobile app) |
-| **Devices** | All except the Enhanced-only serials (`J32D`, `J32E`, `R371`, `R372`, `R374`, `HJ3C`) | All supported devices |
+| **Devices** | All except the Enhanced-only serials (`J327`, `J32D`, `J32E`, `R371`, `R372`, `R374`, `HJ3C`) | All supported devices |
 | **Update rate** | ~30 s HTTP polling (+ MQTT push for Delta/Smart Plug) | ~2-4 s real-time via WSS MQTT |
 | **Delta / Smart Plug controls** | All switches and numbers | All switches and numbers |
 | **PowerOcean controls** | Read-only sensors only | Full energy strategy controls (Backup Reserve, Solar Surplus Threshold, Work Mode) |
 | **Stability** | Official EcoFlow API - supported and stable | Community-driven - unofficial, use at your own risk |
 | **Best for** | Reliable long-term operation | Real-time monitoring, fast automations, PowerOcean control |
 
-**Standard Mode** uses the official EcoFlow IoT Developer API. Apply for free API keys at [developer.ecoflow.com](https://developer.ecoflow.com). Note: the European PowerOcean variants (`J32D`, `J32E`) and the PowerOcean Plus units (`R371`, `R372`, `R374`, `HJ3C`) are currently not exposed through the Developer API and cannot be linked to an API key (error 1006). These devices work in Enhanced Mode only.
+**Standard Mode** uses the official EcoFlow IoT Developer API. Apply for free API keys at [developer.ecoflow.com](https://developer.ecoflow.com). Note: the European PowerOcean variants (`J327`, `J32D`, `J32E`) and the PowerOcean Plus units (`R371`, `R372`, `R374`, `HJ3C`) are currently not exposed through the Developer API and cannot be linked to an API key (error 1006). These devices work in Enhanced Mode only.
 
 **Enhanced Mode** connects with your EcoFlow email and password. No Developer API keys needed. Faster updates, but this is an unofficial, community-driven protocol based on observed behaviour that may change without notice. Stream-family devices report an empty product name, so they are identified by their serial prefix (`BK01`, `BK11`, `BK31`, `BK41`, `BK51`, `BK61`) and appear under the correct model name in Home Assistant in both modes. The Stream Micro (`BK01`) is not exposed through the Developer API at all and therefore needs Enhanced Mode.
 
@@ -440,7 +440,7 @@ If the devices are not linked to the API key, HTTP polling fails with error 1006
 
 Since v1.8.3, the integration handles this gracefully: error 1006 is logged once with a clear message and does not trigger re-authentication.
 
-**PowerOcean variants with serial prefix `J32D` or `J32E`:** the Developer Portal currently offers no way to link these devices to an API key, so Standard Mode entities stay unavailable (error 1006). This is an EcoFlow API limitation, not a configuration problem. Use Enhanced Mode for these devices - it delivers full real-time data.
+**PowerOcean variants with serial prefix `J327`, `J32D` or `J32E`:** the Developer Portal currently offers no way to link these devices to an API key, so Standard Mode entities stay unavailable (error 1006). This is an EcoFlow API limitation, not a configuration problem. Use Enhanced Mode for these devices - it delivers full real-time data.
 
 </details>
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -8,7 +8,7 @@ For installation and quick-start, see the main [README](../README.md).
 
 Complete list of all sensors, switches, numbers, and binary sensors per device:
 
-- [PowerOcean](entities/powerocean.md) - 222 sensors, 5 binary sensors, 2 numbers, 1 select (`HJ31`, `HJ32`, `HJ35`, `J32B`, `J32D`, `J32E`, and the Plus variants `R371`, `R372`, `R374`, `HJ3C`)
+- [PowerOcean](entities/powerocean.md) - 222 sensors, 5 binary sensors, 2 numbers, 1 select (`HJ31`, `HJ32`, `HJ35`, `J32B`, `J327`, `J32D`, `J32E`, and the Plus variants `R371`, `R372`, `R374`, `HJ3C`)
 - [Delta 2 Max](entities/delta-2-max.md) - 94 sensors, 4 binary sensors, 7 switches, 8 numbers (`R351`, `R331`)
 - [Delta 3 Max Plus](entities/delta-3-max-plus.md) - 47 sensors, 7 switches, 4 numbers, 5 selects (`D3M1`, `D3N1`, `P321`, `P231`), plus 3 switches, 3 numbers and 1 binary sensor for port priority on `D3M` serials
 - [Smart Plug](entities/smart-plug.md) - 11 sensors, 1 binary sensor, 1 switch, 2 numbers (`HW52`)

--- a/documentation/entities/powerocean.md
+++ b/documentation/entities/powerocean.md
@@ -2,9 +2,9 @@
 
 Full list of all entities created for PowerOcean devices.
 
-**Serial prefixes:** `HJ31`, `HJ32`, `HJ35` (standard) · `J32B`, `J32D`, `J32E` (European variants) · `R371`, `R372`, `R374`, `HJ3C` (PowerOcean Plus). All share the entity set below.
+**Serial prefixes:** `HJ31`, `HJ32`, `HJ35` (standard) · `J32B`, `J327`, `J32D`, `J32E` (European variants) · `R371`, `R372`, `R374`, `HJ3C` (PowerOcean Plus). All share the entity set below.
 
-> **Note:** The European variants (`J32D`, `J32E`) and the PowerOcean Plus units (`R371`, `R372`, `R374`, `HJ3C`) are currently not exposed through the EcoFlow Developer API and therefore require Enhanced Mode. In Standard Mode these devices report error 1006 and all entities stay unavailable. Single-phase variants (`J32E`) report only the phases that are physically present; the remaining phase entities stay empty. Whether `J32B` can be linked to an API key has not been tested, so Standard Mode is unproven for that prefix.
+> **Note:** The European variants (`J327`, `J32D`, `J32E`) and the PowerOcean Plus units (`R371`, `R372`, `R374`, `HJ3C`) are currently not exposed through the EcoFlow Developer API and therefore require Enhanced Mode. In Standard Mode these devices report error 1006 and all entities stay unavailable. Single-phase variants (`J327`, `J32E`) report only the phases that are physically present; the remaining phase entities stay empty. Whether `J32B` can be linked to an API key has not been tested, so Standard Mode is unproven for that prefix.
 
 > **The heating rod readings are optional and need Standard Mode.** They belong
 > to the PowerGlow accessory, so they are only created once your system actually
@@ -12,7 +12,7 @@ Full list of all entities created for PowerOcean devices.
 > The readings come from the API quota, and that quota is only polled when the
 > integration runs with developer keys, so with EcoFlow account sign-in they do
 > not appear. This also means a PowerGlow attached to a unit that only works in
-> Enhanced Mode (`J32D`, `J32E`, and the PowerOcean Plus prefixes) cannot be read
+> Enhanced Mode (`J327`, `J32D`, `J32E`, and the PowerOcean Plus prefixes) cannot be read
 > at all today. If you ran an earlier 1.16.0 beta, the four entities were created
 > on every PowerOcean; leftover ones are removed automatically as soon as your
 > system reports data without a heating rod, unless you had enabled them, in


### PR DESCRIPTION
The single-phase 5 kW hybrid inverter (`J327`) has been routed to the PowerOcean parser since #226, but it appears in none of the places that enumerate which serials are supported:

- README device table
- README Standard/Enhanced comparison table
- README Standard Mode note about prefixes the Developer API does not expose
- README error 1006 troubleshooting entry
- `documentation/README.md` index
- `documentation/entities/powerocean.md` prefix list and Enhanced-only note

A reader checking whether their unit is covered found six lists that said no.

It is Enhanced Mode only, like `J32D` and `J32E`, and single-phase, so it joins `J32E` in the note about phase entities that stay empty.

Found during the release check for v1.17.0-beta.11: a sweep of every prefix in `ecoflow/const.py` against README and documentation shows `J327` was the only gap; all 25 other prefixes are listed in both.

Docs only, no code change, so no version bump.

Ref #225