### PR TITLE
feat: record the app's own writes in the raw capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.18.0] - unreleased
+
+### Added
+
+- The raw data capture now records the settings the EcoFlow app writes to a device, alongside the reports it was already keeping. It could not before, and not because nobody asked: the integration never subscribed to the topic the app publishes writes on, so a capture could run for a day while its owner changed every setting in the app and none of it would appear. That is the missing half of every question about controls on a model nobody here owns. Reading a device tells you what it reports; only watching a real write tells you what it accepts, and until now that needed a script, a checkout and an EcoFlow login rather than a switch in the options. Both STREAM 5000 recordings on file show the gap exactly: read traffic only, not one write frame between them, which is why that model has readings and no controls. The frames are recorded and then dropped rather than parsed, deliberately: a value somebody asked a device for is not a value the device reported, and letting one through would publish a request as a reading. They keep their own place in the capture, because reports outnumber writes by four orders of magnitude on a live unit and would otherwise crowd out the one frame the capture was opened for. Nothing is published from this path, the recording still stops by itself after 24 hours, and the option's description now says what it collects. (Ref #231)
+
+### Fixed
+
+### Changed
+
 ## [1.17.0] - 2026-08-20
 
 ### Added

--- a/custom_components/ecoflow_energy/coordinator/mqtt_ingest.py
+++ b/custom_components/ecoflow_energy/coordinator/mqtt_ingest.py
@@ -147,6 +147,17 @@ class MqttIngestMixin:
                 self._check_delta3_set_ack(payload)
             return
 
+        # A write, published by the vendor app and delivered to us because we
+        # subscribed while the capture window is open. It is recorded and then
+        # dropped, deliberately and without exception: a value somebody asked
+        # the device for is not a value the device reported, and letting one
+        # into the parser would publish a request as if it were a reading.
+        # The check sits after `/set_reply` above, which returns first.
+        if topic.endswith("/thing/property/set"):
+            self._capture_raw_frame(topic, payload, None)
+            self._log_event("app_write", "topic=app/set")
+            return
+
         if not self._enhanced_mode and self.device_type not in (
             DEVICE_TYPE_DELTA,
             DEVICE_TYPE_DELTA3,

--- a/custom_components/ecoflow_energy/coordinator/setup.py
+++ b/custom_components/ecoflow_energy/coordinator/setup.py
@@ -23,6 +23,7 @@ from ..const import (
     DEVICE_TYPE_SMARTPLUG,
     DEVICE_TYPE_STREAM,
     HTTP_FALLBACK_INTERVAL_S,
+    raw_capture_window_open,
 )
 from ..ecoflow.broker import broker_from_credentials
 from ..ecoflow.cloud_http import EcoFlowHTTPQuota
@@ -105,6 +106,10 @@ class SetupMixin:
             wss_mode=True,
             enhanced_mode=(self._enhanced_mode and self.device_type == DEVICE_TYPE_POWEROCEAN),
             auth_error_handler=self._on_mqtt_auth_error,
+            # Read once here, like the buffer depth in core.py: writing the
+            # flag reloads the entry and builds a new client, so it never has
+            # to change underneath a live subscription.
+            capture_writes=raw_capture_window_open(self.config_entry.data),
         )
 
         self._credential_obtained_ts = time.monotonic()

--- a/custom_components/ecoflow_energy/ecoflow/cloud_mqtt.py
+++ b/custom_components/ecoflow_energy/ecoflow/cloud_mqtt.py
@@ -83,6 +83,7 @@ class EcoFlowMQTTClient:
         enhanced_mode: bool = False,
         subscribe_data: bool = True,
         listen_only: bool = False,
+        capture_writes: bool = False,
         status_handler: Callable | None = None,
         auth_error_handler: Callable[[], None] | None = None,
         max_reconnect_attempts: int = DEFAULT_MAX_RECONNECT_ATTEMPTS,
@@ -91,6 +92,11 @@ class EcoFlowMQTTClient:
     ) -> None:
         self._cert_account = certificate_account
         self._cert_password = certificate_password
+        # Subscribing to the topic the vendor app writes on. Off unless the
+        # raw capture window is open, because it is only ever wanted as
+        # evidence. Subscribing is not publishing: the listen-only guarantee
+        # is untouched by it.
+        self._capture_writes = capture_writes
         self._device_sn = device_sn
         self._user_id = user_id
         self.message_handler = message_handler
@@ -316,6 +322,20 @@ class EcoFlowMQTTClient:
                 if self._user_id:
                     topic_reply = f"/app/{self._user_id}/{self._device_sn}/thing/property/get_reply"
                     client.subscribe(topic_reply, qos=1)
+
+                    if self._capture_writes:
+                        # The topic the vendor app publishes its writes on.
+                        # The broker delivers them to every subscriber, so
+                        # watching one is the only way to learn what a device
+                        # accepts without guessing at the envelope. Nothing is
+                        # ever published here from this branch, and the frames
+                        # are captured rather than parsed: a value an owner
+                        # asked for is not a value the device reported.
+                        topic_write = (
+                            f"/app/{self._user_id}/{self._device_sn}"
+                            "/thing/property/set"
+                        )
+                        client.subscribe(topic_write, qos=1)
 
                 if not self._notified_connected:
                     self._notified_connected = True

--- a/custom_components/ecoflow_energy/ecoflow/frame_capture.py
+++ b/custom_components/ecoflow_energy/ecoflow/frame_capture.py
@@ -104,6 +104,25 @@ def frame_budget(
     return min(bundle_cap, max(bundle_max, len(cmds) * message_max))
 
 
+def _topic_class(topic: str) -> str:
+    """Return the bucket a topic belongs to: report, full dump, or write.
+
+    Three classes rather than two. `frame_key` puts the class in front of
+    the message type, so a write gets its own bucket and cannot be crowded
+    out of the capture by telemetry - which outnumbers it by four orders of
+    magnitude on a live device.
+
+    `set_reply` is not a write. It is the device answering one, it is
+    handled before a frame ever reaches here, and it must not fall into the
+    write bucket if that order ever changes.
+    """
+    if "get_reply" in topic:
+        return "get_reply"
+    if topic.endswith("/set"):
+        return "set"
+    return "property"
+
+
 def build_frame_entry(
     topic: str,
     payload: bytes,
@@ -130,7 +149,7 @@ def build_frame_entry(
     sanitized = sanitize_frame(payload, secrets)
     entry: dict[str, Any] = {
         "ts": time.time(),
-        "topic": "get_reply" if "get_reply" in topic else "property",
+        "topic": _topic_class(topic),
         "size": len(payload),
         "hex": sanitized[:max_bytes].hex(),
     }

--- a/custom_components/ecoflow_energy/manifest.json
+++ b/custom_components/ecoflow_energy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/shuette42/ecoflow-energy-ha/issues",
   "requirements": [],
-  "version": "1.17.0"
+  "version": "1.18.0"
 }

--- a/custom_components/ecoflow_energy/strings.json
+++ b/custom_components/ecoflow_energy/strings.json
@@ -105,7 +105,7 @@
           "raw_capture": "Record extra diagnostic data for 24 hours"
         },
         "data_description": {
-          "raw_capture": "Keeps more of the raw messages your devices send, and records any device this integration does not support yet. Only worth switching on if it was asked for in a GitHub issue, since the data is only useful attached to a diagnostics download. Nothing is ever sent to your devices, and the recording stops by itself after 24 hours."
+          "raw_capture": "Keeps more of the raw messages your devices send, records any device this integration does not support yet, and records the settings the EcoFlow app writes to your devices while it runs. That last one is how a control gets built for a model nobody here owns: changing the setting in the app once, with this on, shows what the device accepts. Only worth switching on if it was asked for in a GitHub issue, since the data is only useful attached to a diagnostics download. Nothing is ever sent to your devices, and the recording stops by itself after 24 hours."
         }
       },
       "developer": {

--- a/custom_components/ecoflow_energy/translations/de.json
+++ b/custom_components/ecoflow_energy/translations/de.json
@@ -105,7 +105,7 @@
           "raw_capture": "24 Stunden lang zusätzliche Diagnosedaten aufzeichnen"
         },
         "data_description": {
-          "raw_capture": "Behält mehr der Rohdaten, die deine Geräte senden, und zeichnet jedes Gerät auf, das diese Integration noch nicht unterstützt. Nur sinnvoll, wenn in einem GitHub-Issue danach gefragt wurde, denn die Daten helfen nur zusammen mit einem Diagnose-Download. An deine Geräte wird nie etwas gesendet, und die Aufzeichnung endet nach 24 Stunden von selbst."
+          "raw_capture": "Behält mehr der Rohdaten, die deine Geräte senden, zeichnet jedes Gerät auf, das diese Integration noch nicht unterstützt, und hält fest, welche Einstellungen die EcoFlow-App währenddessen an deine Geräte schreibt. Das Letzte ist der Weg zu einer Steuerung für ein Modell, das hier niemand besitzt: die Einstellung einmal in der App ändern, während das läuft, zeigt was das Gerät annimmt. Nur sinnvoll, wenn in einem GitHub-Issue danach gefragt wurde, denn die Daten helfen nur zusammen mit einem Diagnose-Download. An deine Geräte wird nie etwas gesendet, und die Aufzeichnung endet nach 24 Stunden von selbst."
         }
       },
       "developer": {

--- a/custom_components/ecoflow_energy/translations/en.json
+++ b/custom_components/ecoflow_energy/translations/en.json
@@ -105,7 +105,7 @@
           "raw_capture": "Record extra diagnostic data for 24 hours"
         },
         "data_description": {
-          "raw_capture": "Keeps more of the raw messages your devices send, and records any device this integration does not support yet. Only worth switching on if it was asked for in a GitHub issue, since the data is only useful attached to a diagnostics download. Nothing is ever sent to your devices, and the recording stops by itself after 24 hours."
+          "raw_capture": "Keeps more of the raw messages your devices send, records any device this integration does not support yet, and records the settings the EcoFlow app writes to your devices while it runs. That last one is how a control gets built for a model nobody here owns: changing the setting in the app once, with this on, shows what the device accepts. Only worth switching on if it was asked for in a GitHub issue, since the data is only useful attached to a diagnostics download. Nothing is ever sent to your devices, and the recording stops by itself after 24 hours."
         }
       },
       "developer": {

--- a/tests/ha/test_coordinator.py
+++ b/tests/ha/test_coordinator.py
@@ -7455,3 +7455,99 @@ class TestLinkedUnitPower:
         coordinator._apply_data({"_unit_batt_w_by_sn": {"ES22TESTUNITAAAA": 689.0}})
         coordinator._apply_data({"soc_pct": 76})
         assert coordinator.data["unit_batt_w"] == 689.0
+
+
+class TestAppWriteCapture:
+    """Frames the vendor app writes, recorded as evidence and never parsed.
+
+    The capture exists because the integration cannot otherwise learn what a
+    device accepts: both ES21 recordings on file carry read traffic only, and
+    no `254/38` at all, because the set topic was never subscribed. Watching a
+    real app write is the only way to see the envelope without guessing.
+    """
+
+    def _frame(self, sn: str) -> bytes:
+        return b"\x0a" + bytes([len(sn)]) + sn.encode()
+
+    def _write_topic(self, coordinator) -> str:
+        return f"/app/user123/{coordinator.device_sn}/thing/property/set"
+
+    async def test_a_write_is_captured(
+        self, hass: HomeAssistant, enhanced_config_entry: MockConfigEntry
+    ) -> None:
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+
+        coordinator._on_mqtt_message(
+            self._write_topic(coordinator), self._frame(coordinator.device_sn)
+        )
+
+        frames = coordinator.raw_frames
+        assert len(frames) == 1
+        assert frames[0]["topic"] == "set"
+
+    async def test_a_write_never_reaches_the_parser(
+        self, hass: HomeAssistant, enhanced_config_entry: MockConfigEntry
+    ) -> None:
+        """The point of the whole feature, and the one way it could do harm.
+
+        A value somebody asked the device for is not a value the device
+        reported. If a write reached the parser, a request would be published
+        as a reading and an entity would show a setting the device may have
+        refused.
+        """
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        before = dict(coordinator._device_data)
+
+        with patch.object(
+            coordinator, "_parse_message", side_effect=AssertionError("parsed")
+        ):
+            coordinator._on_mqtt_message(
+                self._write_topic(coordinator), self._frame(coordinator.device_sn)
+            )
+
+        assert coordinator._device_data == before
+
+    async def test_a_set_reply_is_not_a_write(
+        self, hass: HomeAssistant, enhanced_config_entry: MockConfigEntry
+    ) -> None:
+        """`set_reply` is the device answering, and must not land in the bucket."""
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+
+        coordinator._on_mqtt_message(
+            f"/app/user123/{coordinator.device_sn}/thing/property/set_reply",
+            self._frame(coordinator.device_sn),
+        )
+
+        assert coordinator.raw_frames == []
+
+    async def test_a_write_keeps_its_own_bucket(
+        self, hass: HomeAssistant, enhanced_config_entry: MockConfigEntry
+    ) -> None:
+        """Telemetry outnumbers writes by orders of magnitude on a live unit.
+
+        The write has to survive a run of reports carrying the same message
+        type, or the capture would reliably lose the one frame it was opened
+        for.
+        """
+        enhanced_config_entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(
+            hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
+        )
+        payload = self._frame(coordinator.device_sn)
+
+        coordinator._on_mqtt_message(self._write_topic(coordinator), payload)
+        for _ in range(200):
+            coordinator._on_mqtt_message(
+                f"/app/device/property/{coordinator.device_sn}", payload
+            )
+
+        assert any(f["topic"] == "set" for f in coordinator.raw_frames)

--- a/tests/test_cloud_mqtt.py
+++ b/tests/test_cloud_mqtt.py
@@ -858,3 +858,36 @@ class TestMaskTopic:
         assert client.mask_topic("/app/device/property/TEST1234SN") == (
             "/app/device/property/{sn}"
         )
+
+
+class TestAppWriteSubscription:
+    """The set topic is subscribed only while a capture window is open.
+
+    It exists to record what the vendor app writes, which is the only way to
+    learn what a device accepts without guessing at the envelope. It is off by
+    default because it is wanted as evidence and not as a running cost, and
+    subscribing is not publishing: the listen-only guarantee is untouched.
+    """
+
+    def _topics(self, **kwargs) -> list[str]:
+        with patch("ecoflow_energy.ecoflow.cloud_mqtt.mqtt.Client") as mock_cls:
+            mock_paho = MagicMock()
+            mock_cls.return_value = mock_paho
+            client = _make_client(wss_mode=True, user_id="user123", **kwargs)
+            client.client = mock_paho
+            client._on_connect(mock_paho, None, None, 0)
+            return [call[0][0] for call in mock_paho.subscribe.call_args_list]
+
+    def test_off_by_default(self):
+        assert not any(t.endswith("/thing/property/set") for t in self._topics())
+
+    def test_subscribed_when_capturing(self):
+        topics = self._topics(capture_writes=True)
+        assert any(t.endswith("/thing/property/set") for t in topics)
+
+    def test_capturing_does_not_drop_the_data_topics(self):
+        """The evidence subscription is additive, never a swap."""
+        plain = self._topics()
+        capturing = self._topics(capture_writes=True)
+        assert set(plain) <= set(capturing)
+        assert len(capturing) == len(plain) + 1


### PR DESCRIPTION
Implements PLAN-088.

## Why

The raw capture could not record a write. The integration subscribes to the quota topic, the property push and `get_reply`, and never to `/app/{user_id}/{sn}/thing/property/set`, which is where the vendor app publishes. So an owner could run a capture for a full day, change every setting in the app, and none of it would appear in the download.

That is the missing half of every controls question. Reading a device tells you what it reports; only watching a real write tells you what it accepts. Both `ES21` recordings in `docs/captures/` show it: read traffic only, commands `254.39`, `254.40`, `32.2`, `32.50`, `50.2`, `53.77`, `254.42`, and no `254/38` between them. That is exactly why the STREAM 5000 ships with readings and no controls.

The evidence was reachable only through `scripts/probe/probe_app_wss_listen.py`, which needs a checkout, Python and the owner's EcoFlow login. Not something to ask a reporter for, so #231 and #140 were blocked on tooling rather than on anyone's willingness.

## What changes

- `cloud_mqtt.py` subscribes to the set topic when `capture_writes` is set, which `setup.py` reads from the capture window. Off otherwise, additive when on, and subscribing is not publishing so the listen-only guarantee is untouched.
- `mqtt_ingest.py` captures a frame from that topic and returns before the parse.
- `frame_capture.py` gains a third topic class, `set`, so `frame_key` gives writes their own bucket.
- The option's description says what it now collects, in both languages.

## Two properties the tests hold to

**A write is never parsed.** A value somebody asked a device for is not a value the device reported. Letting one through would publish a request as a reading, and show a setting the device may have refused. Mutation checked: removing the early return fails the test.

**A write keeps its own bucket.** Reports outnumber writes by four orders of magnitude on a live unit, so a shared budget would reliably lose the one frame the capture was opened for.

Also covered: `set_reply` is not a write, the subscription is off by default, and turning it on does not drop a data topic.

Tests: 2511 pass, 7 new.

## Not in this PR

No new write. This produces evidence, it does not act on it.

Ref #231
Ref #140