### PR TITLE
feat(smart-meter): read the EcoFlow Smart Meter (BK21) in Enhanced Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.19.0] - 2026-09-01
+
+### Added
+
+- EcoFlow Smart Meter (`BK21`, EF-EM-P3-120) is recognised as its own device in Enhanced Mode: grid power, per-phase power, voltage and current, energy today and in total, per-phase energy today, power factor, grid state and per-phase connection flags. Read-only; the developer API exposes no data for this meter, so Standard Mode does not apply, and the device picker now marks the meter as needing Enhanced Mode, leaves it unticked on the developer-key path and refuses the selection there rather than setting up entities that could never fill. The energy counters are named after what they measure rather than after a direction. The app labels them as import, and there is no separate export counter in the message definition to set that against, so a day on which the house exports is the first thing that will show whether they hold import only or a net figure. Until that day exists the lifetime counter is published as a plain total, which reads a decrease as a negative delta rather than as a meter change; the daily counters do reset to zero at midnight by design and carry the monotonic class that reset is built for. Field map verified against the reporter's capture and app screenshot. (Ref #331)
+
 ## [1.18.1] - 2026-09-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -49,10 +49,13 @@
 | **PowerStream** - Microinverter | `HW51` | 25 | none, see below | 2 default (solar, inverter output), 2 optional diagnostic (PV 1-2) | ~30 s standard |
 | **STREAM AC 5000** - AC-coupled Battery | `ES22`\* | 56 + 2 binary | 2 switches, 7 numbers, 1 select (Enhanced only) | 4 default (grid import/export, battery charge/discharge), 1 optional diagnostic (home) | ~2 s enhanced |
 | **STREAM 5000** - AC-coupled Battery | `ES21`\* | 56 + 2 binary | 2 switches, 7 numbers, 1 select (Enhanced only) | 4 default (grid import/export, battery charge/discharge), 1 optional diagnostic (home) | ~2 s enhanced |
+| **Smart Meter** - Grid Meter | `BK21`\* | 17 + 3 binary | none, read-only | 1 (grid energy) | ~3 s enhanced |
 
 > **\* Enhanced Mode only.** These serial prefixes cannot currently be linked to an IoT Developer API key, so Standard Mode reports error 1006 and their entities stay unavailable. This is an EcoFlow API limitation, not a configuration problem.
 >
 > **PowerOcean and PowerOcean Plus share one entity set.** A Plus unit simply reports more of it: per-phase reactive power (var) and apparent power (VA), plus MPPT strings 3 and 4. Those entities exist for every PowerOcean but are disabled by default, because a standard unit never sends them and the entity would sit at "unknown" forever. Enable them under **Settings > Devices & services > Entities** on a Plus device.
+>
+> **The Smart Meter has no separate export counter.** It keeps one energy counter for the connection as a whole and one per phase, and the message definition holds nothing on the return side, so the Energy Dashboard gets a single grid entry from it. The app labels those counters as import; whether they really are import only or a net figure will show on the first day the house exports. Its connection state does report when the house is feeding into the grid, so the direction is visible even where the energy is not. See [entity reference](documentation/entities/smart-meter.md).
 >
 > **Tip:** Other Delta-series devices (Delta Pro, Delta 2, etc.) should work automatically with the Delta sensor set. Base Delta 3 and Delta 3 Plus use the Delta 3 sensor set. The five AC-coupled Stream models share one sensor set.
 >

--- a/custom_components/ecoflow_energy/__init__.py
+++ b/custom_components/ecoflow_energy/__init__.py
@@ -25,6 +25,7 @@ from .const import (
     DATA_DEVICE_PROBES,
     DATA_SKIPPED_DEVICES,
     DEVICE_TYPE_POWERSTREAM,
+    DEVICE_TYPE_SMART_METER,
     DEVICE_TYPE_UNKNOWN,
     DOMAIN,
     MODE_ENHANCED,
@@ -295,6 +296,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: EcoFlowConfigEntry) -> b
                 "sn": sn,
                 "product_name": product_name or "PowerStream",
                 "reason": "PowerStream requires Standard Mode",
+                "probe_eligible": False,
+            })
+            continue
+        if (
+            entry.data.get(CONF_AUTH_METHOD) != AUTH_METHOD_APP
+            and device_type == DEVICE_TYPE_SMART_METER
+        ):
+            # The developer API answers for this meter with an empty quota,
+            # so a Standard Mode entry would create entities that can never
+            # fill. It reports on the app channel and nowhere else.
+            _LOGGER.warning(
+                "Skipping Smart Meter %s...: this device requires Enhanced Mode",
+                sn[:4],
+            )
+            skipped_devices.append({
+                "sn_prefix": sn[:4],
+                "sn": sn,
+                "product_name": product_name or "Smart Meter",
+                "reason": "Smart Meter requires Enhanced Mode",
                 "probe_eligible": False,
             })
             continue

--- a/custom_components/ecoflow_energy/binary_sensor.py
+++ b/custom_components/ecoflow_energy/binary_sensor.py
@@ -19,6 +19,7 @@ from .const import (
     DEVICE_TYPE_DELTA,
     DEVICE_TYPE_DELTA3,
     DEVICE_TYPE_POWEROCEAN,
+    DEVICE_TYPE_SMART_METER,
     DEVICE_TYPE_SMARTPLUG,
     DEVICE_TYPE_STREAM,
     DEVICE_TYPE_STREAM_AC5000,
@@ -26,6 +27,7 @@ from .const import (
     EcoFlowBinarySensorDef,
     filter_defs_for_serial,
     POWEROCEAN_BINARY_SENSORS,
+    SMARTMETER_BINARY_SENSORS,
     SMARTPLUG_BINARY_SENSORS,
     STREAM_BINARY_SENSORS,
     STREAMAC5000_BINARY_SENSORS,
@@ -176,4 +178,6 @@ def _get_binary_sensor_defs(
         return STREAM_BINARY_SENSORS
     if device_type == DEVICE_TYPE_STREAM_AC5000:
         return STREAMAC5000_BINARY_SENSORS
+    if device_type == DEVICE_TYPE_SMART_METER:
+        return SMARTMETER_BINARY_SENSORS
     return []

--- a/custom_components/ecoflow_energy/config_flow_options.py
+++ b/custom_components/ecoflow_energy/config_flow_options.py
@@ -33,6 +33,7 @@ from .const import (
     CONF_USER_ID,
     DEVICE_TYPE_DISPLAY_NAMES,
     DEVICE_TYPE_POWERSTREAM,
+    DEVICE_TYPE_SMART_METER,
     DEVICE_TYPE_UNKNOWN,
     MODE_ENHANCED,
     MODE_STANDARD,
@@ -170,6 +171,11 @@ class OptionsFlowMixin:
                 == DEVICE_TYPE_POWERSTREAM
                 for sn in selected_sns
             )
+            selected_smart_meter = any(
+                self._stored_device_type(known_devices, sn)
+                == DEVICE_TYPE_SMART_METER
+                for sn in selected_sns
+            )
 
             if not selected_sns:
                 errors["base"] = "no_devices"
@@ -178,6 +184,10 @@ class OptionsFlowMixin:
                 # changing any pending option. PowerStream has no app-auth
                 # data path and must stay on the official Standard API.
                 errors["base"] = "powerstream_requires_standard"
+            elif new_mode != MODE_ENHANCED and selected_smart_meter:
+                # The mirror of the line above. The Smart Meter reports on
+                # the app channel only, so it must stay on Enhanced Mode.
+                errors["base"] = "smart_meter_requires_enhanced"
             elif new_mode == MODE_ENHANCED and current_mode != MODE_ENHANCED:
                 # Switching to Enhanced - need email + password
                 if CONF_RAW_CAPTURE in user_input:
@@ -222,6 +232,7 @@ class OptionsFlowMixin:
                     f" ({sn[:12]})"
                     f"{unsupported_suffix(stored_types[sn])}"
                     f"{' - requires Standard Mode' if stored_types[sn] == DEVICE_TYPE_POWERSTREAM else ''}"
+                    f"{' - requires Enhanced Mode' if stored_types[sn] == DEVICE_TYPE_SMART_METER else ''}"
                 )
                 for sn in current_device_sns
             }

--- a/custom_components/ecoflow_energy/config_flow_setup.py
+++ b/custom_components/ecoflow_energy/config_flow_setup.py
@@ -24,6 +24,7 @@ from .const import (
     CONF_USER_ID,
     DEVICE_TYPE_DISPLAY_NAMES,
     DEVICE_TYPE_POWERSTREAM,
+    DEVICE_TYPE_SMART_METER,
     DEVICE_TYPE_UNKNOWN,
     MODE_ENHANCED,
     MODE_STANDARD,
@@ -78,6 +79,8 @@ def _device_label(device: dict[str, Any]) -> str:
     status += unsupported_suffix(device.get("device_type"))
     if device.get("device_type") == DEVICE_TYPE_POWERSTREAM:
         status += " - requires Standard Mode"
+    elif device.get("device_type") == DEVICE_TYPE_SMART_METER:
+        status += " - requires Enhanced Mode"
     return f"{name} ({sn_short}){status}" if name else f"{sn_short}{status}"
 
 
@@ -236,6 +239,15 @@ class SetupFlowMixin:
                 for d in self._devices
             ):
                 errors["base"] = "powerstream_requires_standard"
+            elif self._auth_type != AUTH_METHOD_APP and any(
+                d["sn"] in selected_sns
+                and d.get("device_type") == DEVICE_TYPE_SMART_METER
+                for d in self._devices
+            ):
+                # The mirror of the PowerStream case. The meter reports on
+                # the app channel only, so a developer-key entry would set
+                # it up and then never receive a reading.
+                errors["base"] = "smart_meter_requires_enhanced"
             else:
                 self._selected_devices = [
                     d for d in self._devices if d["sn"] in selected_sns
@@ -270,10 +282,14 @@ class SetupFlowMixin:
                         default=[
                             sn
                             for sn in device_options
-                            if self._auth_type != AUTH_METHOD_APP
-                            or next(
+                            if next(
                                 d for d in self._devices if d["sn"] == sn
-                            ).get("device_type") != DEVICE_TYPE_POWERSTREAM
+                            ).get("device_type")
+                            != (
+                                DEVICE_TYPE_POWERSTREAM
+                                if self._auth_type == AUTH_METHOD_APP
+                                else DEVICE_TYPE_SMART_METER
+                            )
                         ],
                     ): SelectSelector(
                         SelectSelectorConfig(

--- a/custom_components/ecoflow_energy/const.py
+++ b/custom_components/ecoflow_energy/const.py
@@ -15,6 +15,7 @@ from .ecoflow.const import (  # noqa: E402
     DEVICE_TYPE_DELTA3,
     DEVICE_TYPE_POWEROCEAN,
     DEVICE_TYPE_POWERSTREAM,
+    DEVICE_TYPE_SMART_METER,
     DEVICE_TYPE_SMARTPLUG,
     DEVICE_TYPE_STREAM,
     DEVICE_TYPE_STREAM_AC5000,
@@ -267,6 +268,7 @@ DEVICE_TYPE_DISPLAY_NAMES: dict[str, str] = {
     DEVICE_TYPE_STREAM: "Stream",
     DEVICE_TYPE_STREAM_AC5000: "STREAM AC 5000",
     DEVICE_TYPE_POWERSTREAM: "PowerStream",
+    DEVICE_TYPE_SMART_METER: "Smart Meter",
 }
 
 # Delta write/profile variants.
@@ -1675,6 +1677,52 @@ POWERSTREAM_SENSORS: list[EcoFlowSensorDef] = [
     EcoFlowSensorDef("pv1_energy_kwh", "PV 1 Energy", "kWh", "energy", "total_increasing", "mdi:solar-power-variant", "diagnostic", suggested_display_precision=2, disabled_by_default=True),
     EcoFlowSensorDef("pv2_energy_kwh", "PV 2 Energy", "kWh", "energy", "total_increasing", "mdi:solar-power-variant", "diagnostic", suggested_display_precision=2, disabled_by_default=True),
 ]
+
+# =====================================================================
+# Smart Meter sensor definitions
+# =====================================================================
+
+# The meter reports through the app channel only, so every reading here
+# arrives as a push. Phase labels follow the app, which counts A/B/C, while
+# the keys keep the L1/L2/L3 form the wire uses.
+SMARTMETER_SENSORS: list[EcoFlowSensorDef] = [
+    # --- Grid power ---
+    EcoFlowSensorDef("grid_w", "Grid Power", "W", "power", "measurement", "mdi:transmission-tower", suggested_display_precision=0),
+    EcoFlowSensorDef("grid_l1_w", "Phase A Power", "W", "power", "measurement", "mdi:transmission-tower", suggested_display_precision=0),
+    EcoFlowSensorDef("grid_l2_w", "Phase B Power", "W", "power", "measurement", "mdi:transmission-tower", suggested_display_precision=0),
+    EcoFlowSensorDef("grid_l3_w", "Phase C Power", "W", "power", "measurement", "mdi:transmission-tower", suggested_display_precision=0),
+    # --- Per-phase electrical readings, sent with the full uploads ---
+    EcoFlowSensorDef("grid_l1_voltage_v", "Phase A Voltage", "V", "voltage", "measurement", "mdi:sine-wave", suggested_display_precision=1),
+    EcoFlowSensorDef("grid_l2_voltage_v", "Phase B Voltage", "V", "voltage", "measurement", "mdi:sine-wave", suggested_display_precision=1),
+    EcoFlowSensorDef("grid_l3_voltage_v", "Phase C Voltage", "V", "voltage", "measurement", "mdi:sine-wave", suggested_display_precision=1),
+    EcoFlowSensorDef("grid_l1_current_a", "Phase A Current", "A", "current", "measurement", "mdi:current-ac", suggested_display_precision=2),
+    EcoFlowSensorDef("grid_l2_current_a", "Phase B Current", "A", "current", "measurement", "mdi:current-ac", suggested_display_precision=2),
+    EcoFlowSensorDef("grid_l3_current_a", "Phase C Current", "A", "current", "measurement", "mdi:current-ac", suggested_display_precision=2),
+    # --- Energy counters the meter keeps itself ---
+    # The lifetime counter is the one for the Energy Dashboard, and it is
+    # `total`, not `total_increasing`: the message definition carries no
+    # export counter, so a day on which the house exports would show up as a
+    # decrease. `total` reads that as a negative delta; `total_increasing`
+    # would read it as a meter change and count the standing total again.
+    # The daily figures are the opposite case. They reset to zero at
+    # midnight by design, which is exactly the reset `total_increasing` is
+    # built for, so they carry it and their zeros are published.
+    EcoFlowSensorDef("grid_energy_total_wh", "Grid Energy Total", "Wh", "energy", "total", "mdi:transmission-tower-import", suggested_display_precision=0),
+    EcoFlowSensorDef("grid_energy_today_wh", "Grid Energy Today", "Wh", "energy", "total_increasing", "mdi:transmission-tower-import", suggested_display_precision=0),
+    EcoFlowSensorDef("grid_l1_energy_today_wh", "Phase A Energy Today", "Wh", "energy", "total_increasing", "mdi:transmission-tower-import", suggested_display_precision=0),
+    EcoFlowSensorDef("grid_l2_energy_today_wh", "Phase B Energy Today", "Wh", "energy", "total_increasing", "mdi:transmission-tower-import", suggested_display_precision=0),
+    EcoFlowSensorDef("grid_l3_energy_today_wh", "Phase C Energy Today", "Wh", "energy", "total_increasing", "mdi:transmission-tower-import", suggested_display_precision=0),
+    # --- Diagnostics ---
+    EcoFlowSensorDef("grid_power_factor", "Power Factor", None, "power_factor", "measurement", "mdi:angle-acute", "diagnostic", suggested_display_precision=2),
+    EcoFlowSensorDef("grid_connection_state", "Grid Connection State", None, "enum", None, "mdi:transmission-tower", "diagnostic", options=["invalid", "grid_in", "not_online", "feed_grid"]),
+]
+
+SMARTMETER_BINARY_SENSORS: list[EcoFlowBinarySensorDef] = [
+    EcoFlowBinarySensorDef("grid_l1_connected", "Phase A Connected", "connectivity", "mdi:transmission-tower", "diagnostic"),
+    EcoFlowBinarySensorDef("grid_l2_connected", "Phase B Connected", "connectivity", "mdi:transmission-tower", "diagnostic"),
+    EcoFlowBinarySensorDef("grid_l3_connected", "Phase C Connected", "connectivity", "mdi:transmission-tower", "diagnostic"),
+]
+
 
 # =====================================================================
 # Power → Energy mappings (Riemann sum integration per device type)

--- a/custom_components/ecoflow_energy/coordinator/mqtt_ingest.py
+++ b/custom_components/ecoflow_energy/coordinator/mqtt_ingest.py
@@ -12,6 +12,7 @@ from ..const import (
     DEVICE_TYPE_DELTA3,
     DEVICE_TYPE_POWEROCEAN,
     DEVICE_TYPE_POWERSTREAM,
+    DEVICE_TYPE_SMART_METER,
     DEVICE_TYPE_SMARTPLUG,
     DEVICE_TYPE_STREAM,
     DEVICE_TYPE_STREAM_AC5000,
@@ -38,6 +39,7 @@ from ..ecoflow.parsers.powerocean_proto import (
     remap_proto_keys,
     remap_timer_task_keys,
 )
+from ..ecoflow.parsers.smart_meter_proto import parse_smart_meter_message
 from ..ecoflow.parsers.smartplug import (
     parse_smartplug_http_quota,
     parse_smartplug_report,
@@ -405,6 +407,8 @@ class MqttIngestMixin:
                     return parse_stream_proto_message(payload)
                 if self.device_type == DEVICE_TYPE_STREAM_AC5000:
                     return parse_stream_ac5000_message(payload)
+                if self.device_type == DEVICE_TYPE_SMART_METER:
+                    return parse_smart_meter_message(payload)
                 return self._parse_proto_device_data(payload)
             return None
 
@@ -501,6 +505,11 @@ class MqttIngestMixin:
                 # Delta 3 generation but means different things by them.
                 if self.device_type == DEVICE_TYPE_STREAM_AC5000:
                     return parse_stream_ac5000_message(payload)
+                # The meter shares (254, 21) with the Stream AC Pro and means
+                # a different set of fields by it, so it routes by device type
+                # before any registry lookup, for the same reason as above.
+                if self.device_type == DEVICE_TYPE_SMART_METER:
+                    return parse_smart_meter_message(payload)
                 if self.device_type == DEVICE_TYPE_POWEROCEAN:
                     return self._parse_powerocean_proto_frame(payload)
 

--- a/custom_components/ecoflow_energy/ecoflow/const.py
+++ b/custom_components/ecoflow_energy/ecoflow/const.py
@@ -42,6 +42,10 @@ DEVICE_TYPE_STREAM_AC5000 = "stream_ac5000"
 # Microinverter, not a battery. Shares nothing with the Stream line but the
 # five letters in the middle of its name (#230).
 DEVICE_TYPE_POWERSTREAM = "powerstream"
+# Three-phase grid meter (EF-EM-P3-120). It measures and reports; it stores
+# nothing and switches nothing, so it shares the BK-series envelope with the
+# Stream line and none of its battery, PV or outlet fields (#331).
+DEVICE_TYPE_SMART_METER = "smart_meter"
 DEVICE_TYPE_UNKNOWN = "unknown"
 
 # Keywords used to classify devices from productName strings.
@@ -206,6 +210,15 @@ _SN_PREFIX_MAP = {
     # the field names. Mapping the prefix is what makes the name check below
     # the second line of defence instead of the only one.
     "HW51": DEVICE_TYPE_POWERSTREAM,
+    # EcoFlow Smart Meter (EF-EM-P3-120), the three-phase clamp meter sold
+    # alongside the Stream line (#331). It reports on the BK-series envelope
+    # and its own command pair 254/21 and 254/22, and the reporter capture
+    # decodes completely against it: aggregate grid power, per-phase power,
+    # voltage and current, the daily and lifetime import counters, the grid
+    # connection state and the three phase flags. The app API leaves its
+    # product name empty like every other BK prefix, so without this entry
+    # the unit is classified by name alone and skipped as unsupported.
+    "BK21": DEVICE_TYPE_SMART_METER,
 }
 
 _SN_PREFIX_DISPLAY_NAMES: dict[str, str] = {
@@ -222,6 +235,7 @@ _SN_PREFIX_DISPLAY_NAMES: dict[str, str] = {
     "BK61": "Stream Ultra X",
     "ES22": "STREAM AC 5000",
     "ES21": "STREAM 5000",
+    "BK21": "Smart Meter",
 }
 
 def get_device_name(product_name: str, sn: str = "") -> str:
@@ -254,7 +268,12 @@ def get_device_type(product_name: str, sn: str = "") -> str:
 
     Returns DEVICE_TYPE_POWEROCEAN, DEVICE_TYPE_DELTA, DEVICE_TYPE_DELTA3,
     DEVICE_TYPE_SMARTPLUG, DEVICE_TYPE_STREAM, DEVICE_TYPE_STREAM_AC5000,
-    DEVICE_TYPE_POWERSTREAM, or DEVICE_TYPE_UNKNOWN.
+    DEVICE_TYPE_POWERSTREAM, DEVICE_TYPE_SMART_METER, or DEVICE_TYPE_UNKNOWN.
+
+    The Smart Meter has no keyword of its own: it is reached by its serial
+    prefix only. "Smart Meter" matches none of the keyword lists below, and
+    the app API reports an empty product name for it, so a keyword would be
+    an assumption about a string no capture has ever shown.
     """
     # The prefix is exact evidence, the product name a substring guess, so
     # the prefix wins. Every prefix mapped before this ordering existed

--- a/custom_components/ecoflow_energy/ecoflow/parsers/smart_meter_proto.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/smart_meter_proto.py
@@ -1,0 +1,224 @@
+"""Protobuf telemetry parser for the EcoFlow Smart Meter (BK21, EF-EM-P3-120).
+
+Derived from a 17-minute capture of a live BK21 in app-auth MQTT mode
+(2026-08-31, issue #331). The meter measures and reports and does nothing
+else: there is no battery, no PV, no outlet and no write path worth having
+(its config message covers the timezone, the upload periods and a factory
+reset), so it gets its own device type and its own map rather than a branch
+inside the Stream parser.
+
+The envelope is the BK-series one, so everything that unwraps a frame is
+imported from `stream_proto.py`: the header decode, the per-header XOR mask
+keyed on the low byte of the sequence number, the one-level field walk and
+the scalar decoder. Only the map lives here, because this message nests its
+energy counters where the Stream frames use flat scalars, so the walk is
+run a second time on the nested record.
+
+Two message types arrive, both under cmd_func 254:
+
+- `21` DisplayPropertyUpload, the telemetry frame. Three shapes were
+  observed: a 24-byte incremental (aggregate power plus the three phase
+  powers), a 47-byte one that adds the energy record, and a 146-byte full
+  upload that adds voltages, currents, the phase flags and the grid state.
+- `22` RuntimePropertyUpload, the upload periods only. Nothing there is a
+  reading, so no field of it is mapped; it is left out of the map entirely
+  rather than mapped and discarded.
+
+The full upload also arrives bundled with a `22` in a `get_reply` frame,
+unmasked. Both candidates from `_pdata_candidates` are tried, so the masked
+`property` frames and the plain `get_reply` bundles decode through the same
+path.
+
+Field notes:
+
+- `515` pow_get_sys_grid is the aggregate the app shows as the current
+  power. `616` grid_connection_power exists in the message definition and
+  was never sent, so the aggregate is read from 515 alone.
+- The per-phase power, voltage and current fields do not multiply out to
+  each other: 240 V and 2.107 A against 318 W on L2. That is the meter
+  reporting apparent and active power separately, not a scaling error;
+  no factor is applied to any of them. The app shows the same numbers.
+- `773` is the only nested field. Its `.4` (today) and `.7` (lifetime)
+  counters are equal in every frame of the capture because the meter was
+  installed that day, so which is which cannot be told from these bytes.
+  `.7` is named lifetime here because the message definition says so; the
+  split stays unconfirmed until a capture spanning midnight exists.
+- `773.1` (`today_active_L1`) is the one mapped field the capture never
+  carried: L1 drew nothing all day, and its power, voltage and current
+  fields are all present and all zero. Its two siblings `.2` and `.3` are
+  on the wire in the same record, so the record shape is shown rather than
+  assumed and only the idle phase is missing.
+
+Deliberately not mapped: `133`/`134`/`135` (timezone), `627` (error code
+list), `728`/`729`/`732`/`733` (country, town, factory and debug mode),
+`984` (unidentified constant), and the `254/22` upload periods. Not on the
+wire in this capture and therefore absent from the map: `616`, `617`
+(reactive power), `601`/`602` (WiFi), `484` (ambient temperature),
+`773.5`/`773.6` (reactive energy). The message definition has no export
+counter at all - export shows only as a negative sign on the power fields.
+
+Values are published unrounded, as in `stream_proto.py`. Display precision
+belongs to the sensor definitions, and rounding the current to one decimal
+here would make this integration less precise than the app, which shows
+2.14 A.
+"""
+
+from __future__ import annotations
+
+from math import isfinite
+from typing import Any
+
+from ..proto.decoder import decode_header_message
+from .stream_proto import (
+    _FLOAT_ZERO_EPS,
+    _GRID_CONNECTION_STATE,
+    _TYPE_FLOAT,
+    _TYPE_INT,
+    _decode_scalar,
+    _iter_fields,
+    _pdata_candidates,
+)
+
+# The nested record holding the energy counters. It is the only
+# length-delimited field this parser descends into: everything else the
+# message carries in a length-delimited field is a string or an error list.
+_ENERGY_RECORD_FIELD = 773
+
+# cmd_func/cmd_id -> field_number -> (sensor_key, scalar_type)
+_SMART_METER_FIELD_MAP: dict[tuple[int, int], dict[int, tuple[str, str]]] = {
+    (254, 21): {
+        # Aggregate grid power, the app's "current power".
+        515: ("grid_w", _TYPE_FLOAT),
+        # Per-phase active power. L1 reads 0.0 throughout the capture; that
+        # is an idle phase on the reporter's installation, not an absent
+        # field - it is sent explicitly in every frame.
+        962: ("grid_l1_w", _TYPE_FLOAT),
+        963: ("grid_l2_w", _TYPE_FLOAT),
+        772: ("grid_l3_w", _TYPE_FLOAT),
+        # Per-phase voltage and current, full uploads only.
+        956: ("grid_l1_voltage_v", _TYPE_FLOAT),
+        957: ("grid_l2_voltage_v", _TYPE_FLOAT),
+        771: ("grid_l3_voltage_v", _TYPE_FLOAT),
+        958: ("grid_l1_current_a", _TYPE_FLOAT),
+        959: ("grid_l2_current_a", _TYPE_FLOAT),
+        784: ("grid_l3_current_a", _TYPE_FLOAT),
+        # Present in every full upload and 0.0 in all of them.
+        618: ("grid_power_factor", _TYPE_FLOAT),
+        # Grid connection state, mapped to its enum labels in `_finalize`.
+        619: ("_grid_connection_state_raw", _TYPE_INT),
+        # Per-phase connection flags, booleans on the wire.
+        762: ("_grid_l1_connected_raw", _TYPE_INT),
+        763: ("_grid_l2_connected_raw", _TYPE_INT),
+        764: ("_grid_l3_connected_raw", _TYPE_INT),
+    },
+}
+
+# Subfields of `_ENERGY_RECORD_FIELD`, all watt-hours.
+_ENERGY_RECORD_MAP: dict[int, tuple[str, str]] = {
+    1: ("grid_l1_energy_today_wh", _TYPE_FLOAT),
+    2: ("grid_l2_energy_today_wh", _TYPE_FLOAT),
+    3: ("grid_l3_energy_today_wh", _TYPE_FLOAT),
+    4: ("grid_energy_today_wh", _TYPE_FLOAT),
+    7: ("grid_energy_total_wh", _TYPE_FLOAT),
+}
+
+# Keys that carry a lifetime counter. Such a counter only ever stands still
+# or moves, so a zero on one is a glitch rather than a reading, and a glitch
+# published to the Energy Dashboard sensor would show as the house giving
+# back everything it ever drew. It is dropped rather than published. The
+# daily counters are the opposite case: their midnight zero is the reading.
+_LIFETIME_KEYS = frozenset({"grid_energy_total_wh"})
+
+_BOOL_KEYS = {
+    "_grid_l1_connected_raw": "grid_l1_connected",
+    "_grid_l2_connected_raw": "grid_l2_connected",
+    "_grid_l3_connected_raw": "grid_l3_connected",
+}
+
+
+def _decode_mapped_fields(
+    pdata: bytes,
+    field_map: dict[int, tuple[str, str]],
+) -> dict[str, Any]:
+    """Decode the mapped scalars plus the nested energy record."""
+    result: dict[str, Any] = {}
+
+    for field_num, wire_type, raw in _iter_fields(pdata):
+        if field_num == _ENERGY_RECORD_FIELD and wire_type == 2:
+            for sub_num, sub_wire, sub_raw in _iter_fields(raw):
+                mapping = _ENERGY_RECORD_MAP.get(sub_num)
+                if mapping is None:
+                    continue
+                sensor_key, scalar_type = mapping
+                value = _decode_scalar(sub_wire, sub_raw, scalar_type)
+                if value is not None:
+                    result[sensor_key] = value
+            continue
+
+        mapping = field_map.get(field_num)
+        if mapping is None:
+            continue
+
+        sensor_key, scalar_type = mapping
+        value = _decode_scalar(wire_type, raw, scalar_type)
+        if value is not None:
+            result[sensor_key] = value
+
+    return result
+
+
+def _finalize(parsed: dict[str, Any]) -> dict[str, Any]:
+    """Normalize near-zero floats and resolve the enum and boolean fields."""
+    result = dict(parsed)
+
+    for key, value in list(result.items()):
+        if isinstance(value, float) and isfinite(value) and abs(value) < _FLOAT_ZERO_EPS:
+            result[key] = 0.0
+
+    grid_state_raw = result.pop("_grid_connection_state_raw", None)
+    if isinstance(grid_state_raw, int):
+        result["grid_connection_state"] = _GRID_CONNECTION_STATE.get(grid_state_raw)
+
+    for raw_key, sensor_key in _BOOL_KEYS.items():
+        raw_value = result.pop(raw_key, None)
+        if isinstance(raw_value, int):
+            result[sensor_key] = bool(raw_value)
+
+    for key in _LIFETIME_KEYS:
+        value = result.get(key)
+        if isinstance(value, (int, float)) and not value:
+            del result[key]
+
+    return result
+
+
+def parse_smart_meter_message(payload: bytes) -> dict[str, Any] | None:
+    """Parse a Smart Meter protobuf frame into flat sensor keys."""
+    try:
+        headers, _ = decode_header_message(payload)
+        if not headers:
+            return None
+
+        merged: dict[str, Any] = {}
+        for header in headers:
+            cmd_key = (int(header.get("cmd_func", -1)), int(header.get("cmd_id", -1)))
+            field_map = _SMART_METER_FIELD_MAP.get(cmd_key)
+            if field_map is None:
+                continue
+            for pdata in _pdata_candidates(header):
+                try:
+                    decoded = _decode_mapped_fields(pdata, field_map)
+                except (IndexError, ValueError):
+                    # Only a payload that is not valid protobuf falls through
+                    # to the next candidate; a clean decode ends the attempt,
+                    # empty or not (see `_pdata_candidates`).
+                    continue
+                merged.update(decoded)
+                break
+    except Exception:
+        return None
+    if not merged:
+        return None
+
+    finalized = _finalize(merged)
+    return finalized or None

--- a/custom_components/ecoflow_energy/ecoflow/parsers/stream_proto.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/stream_proto.py
@@ -217,13 +217,18 @@ def _decode_scalar(wire_type: int, raw: bytes, scalar_type: str) -> float | int 
     return None
 
 
-def _decode_mapped_fields(
-    pdata: bytes,
-    field_map: dict[int, tuple[str, str]],
-) -> dict[str, Any]:
-    """Decode only the mapped fields from a protobuf payload."""
-    result: dict[str, Any] = {}
-    mv = memoryview(pdata)
+def _iter_fields(payload: bytes) -> list[tuple[int, int, bytes]]:
+    """Return ``(field_number, wire_type, raw_bytes)`` for one protobuf level.
+
+    One level only: a length-delimited field comes back as its raw bytes, so
+    a caller that needs to descend into a nested record calls this again on
+    them. That is what the Smart Meter parser does with its energy record.
+
+    Raises ``ValueError`` or ``IndexError`` on malformed input, which the
+    caller treats as "this payload candidate is not protobuf".
+    """
+    fields: list[tuple[int, int, bytes]] = []
+    mv = memoryview(payload)
     pos = 0
 
     while pos < len(mv):
@@ -248,6 +253,19 @@ def _decode_mapped_fields(
         else:
             break
 
+        fields.append((field_num, wire_type, raw))
+
+    return fields
+
+
+def _decode_mapped_fields(
+    pdata: bytes,
+    field_map: dict[int, tuple[str, str]],
+) -> dict[str, Any]:
+    """Decode only the mapped fields from a protobuf payload."""
+    result: dict[str, Any] = {}
+
+    for field_num, wire_type, raw in _iter_fields(pdata):
         mapping = field_map.get(field_num)
         if mapping is None:
             continue

--- a/custom_components/ecoflow_energy/manifest.json
+++ b/custom_components/ecoflow_energy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/shuette42/ecoflow-energy-ha/issues",
   "requirements": [],
-  "version": "1.18.1"
+  "version": "1.19.0"
 }

--- a/custom_components/ecoflow_energy/sensor.py
+++ b/custom_components/ecoflow_energy/sensor.py
@@ -21,6 +21,7 @@ from .const import (
     DEVICE_TYPE_DELTA3,
     DEVICE_TYPE_POWEROCEAN,
     DEVICE_TYPE_POWERSTREAM,
+    DEVICE_TYPE_SMART_METER,
     DEVICE_TYPE_SMARTPLUG,
     DEVICE_TYPE_STREAM,
     DEVICE_TYPE_STREAM_AC5000,
@@ -31,6 +32,7 @@ from .const import (
     filter_defs_for_serial,
     POWEROCEAN_SENSORS,
     POWERSTREAM_SENSORS,
+    SMARTMETER_SENSORS,
     SMARTPLUG_SENSORS,
     STREAM_SENSORS,
     STREAMAC5000_SENSORS,
@@ -318,4 +320,6 @@ def _get_sensor_defs(device_type: str) -> list[EcoFlowSensorDef]:
         return STREAMAC5000_SENSORS
     if device_type == DEVICE_TYPE_POWERSTREAM:
         return POWERSTREAM_SENSORS
+    if device_type == DEVICE_TYPE_SMART_METER:
+        return SMARTMETER_SENSORS
     return []

--- a/custom_components/ecoflow_energy/strings.json
+++ b/custom_components/ecoflow_energy/strings.json
@@ -94,6 +94,7 @@
       "enhanced_login_failed": "Enhanced Mode login failed. Check your EcoFlow app email and password.",
       "enhanced_decrypt_failed": "Enhanced Mode credential decryption failed.",
       "powerstream_requires_standard": "PowerStream requires Standard Mode with Developer API keys.",
+      "smart_meter_requires_enhanced": "The Smart Meter requires Enhanced Mode with your EcoFlow account.",
       "unknown": "An unexpected error occurred."
     },
     "abort": {
@@ -154,6 +155,7 @@
       "enhanced_decrypt_failed": "Enhanced Mode credential decryption failed.",
       "no_devices": "Please select at least one device.",
       "powerstream_requires_standard": "PowerStream requires Standard Mode with Developer API keys.",
+      "smart_meter_requires_enhanced": "The Smart Meter requires Enhanced Mode with your EcoFlow account.",
       "unknown": "An unexpected error occurred."
     }
   },
@@ -1430,6 +1432,51 @@
       },
       "unit_soc_pct": {
         "name": "Unit Battery SOC"
+      },
+      "grid_l1_w": {
+        "name": "Phase A Power"
+      },
+      "grid_l2_w": {
+        "name": "Phase B Power"
+      },
+      "grid_l3_w": {
+        "name": "Phase C Power"
+      },
+      "grid_l1_voltage_v": {
+        "name": "Phase A Voltage"
+      },
+      "grid_l2_voltage_v": {
+        "name": "Phase B Voltage"
+      },
+      "grid_l3_voltage_v": {
+        "name": "Phase C Voltage"
+      },
+      "grid_l1_current_a": {
+        "name": "Phase A Current"
+      },
+      "grid_l2_current_a": {
+        "name": "Phase B Current"
+      },
+      "grid_l3_current_a": {
+        "name": "Phase C Current"
+      },
+      "grid_energy_total_wh": {
+        "name": "Grid Energy Total"
+      },
+      "grid_energy_today_wh": {
+        "name": "Grid Energy Today"
+      },
+      "grid_l1_energy_today_wh": {
+        "name": "Phase A Energy Today"
+      },
+      "grid_l2_energy_today_wh": {
+        "name": "Phase B Energy Today"
+      },
+      "grid_l3_energy_today_wh": {
+        "name": "Phase C Energy Today"
+      },
+      "grid_power_factor": {
+        "name": "Power Factor"
       }
     },
     "binary_sensor": {
@@ -1474,6 +1521,15 @@
       },
       "backup_socket_enabled": {
         "name": "Backup Socket"
+      },
+      "grid_l1_connected": {
+        "name": "Phase A Connected"
+      },
+      "grid_l2_connected": {
+        "name": "Phase B Connected"
+      },
+      "grid_l3_connected": {
+        "name": "Phase C Connected"
       }
     },
     "switch": {

--- a/custom_components/ecoflow_energy/translations/de.json
+++ b/custom_components/ecoflow_energy/translations/de.json
@@ -94,6 +94,7 @@
       "enhanced_login_failed": "Enhanced-Modus Login fehlgeschlagen. Überprüfe E-Mail und Passwort deines EcoFlow-App-Kontos.",
       "enhanced_decrypt_failed": "Enhanced-Modus Entschlüsselung der Zugangsdaten fehlgeschlagen.",
       "powerstream_requires_standard": "PowerStream benötigt den Standard-Modus mit Developer-API-Schlüsseln.",
+      "smart_meter_requires_enhanced": "Der Smart Meter benötigt den Enhanced-Modus mit deinem EcoFlow-Konto.",
       "unknown": "Ein unerwarteter Fehler ist aufgetreten."
     },
     "abort": {
@@ -154,6 +155,7 @@
       "enhanced_decrypt_failed": "Enhanced-Modus Entschlüsselung fehlgeschlagen.",
       "no_devices": "Bitte mindestens ein Gerät auswählen.",
       "powerstream_requires_standard": "PowerStream benötigt den Standard-Modus mit Developer-API-Schlüsseln.",
+      "smart_meter_requires_enhanced": "Der Smart Meter benötigt den Enhanced-Modus mit deinem EcoFlow-Konto.",
       "unknown": "Ein unerwarteter Fehler ist aufgetreten."
     }
   },
@@ -1518,6 +1520,51 @@
           "power_supply": "Verbrauch bevorzugen",
           "battery_storage": "Speicher bevorzugen"
         }
+      },
+      "grid_l1_w": {
+        "name": "Phase A Leistung"
+      },
+      "grid_l2_w": {
+        "name": "Phase B Leistung"
+      },
+      "grid_l3_w": {
+        "name": "Phase C Leistung"
+      },
+      "grid_l1_voltage_v": {
+        "name": "Phase A Spannung"
+      },
+      "grid_l2_voltage_v": {
+        "name": "Phase B Spannung"
+      },
+      "grid_l3_voltage_v": {
+        "name": "Phase C Spannung"
+      },
+      "grid_l1_current_a": {
+        "name": "Phase A Strom"
+      },
+      "grid_l2_current_a": {
+        "name": "Phase B Strom"
+      },
+      "grid_l3_current_a": {
+        "name": "Phase C Strom"
+      },
+      "grid_energy_total_wh": {
+        "name": "Netzenergie gesamt"
+      },
+      "grid_energy_today_wh": {
+        "name": "Netzenergie heute"
+      },
+      "grid_l1_energy_today_wh": {
+        "name": "Phase A Energie heute"
+      },
+      "grid_l2_energy_today_wh": {
+        "name": "Phase B Energie heute"
+      },
+      "grid_l3_energy_today_wh": {
+        "name": "Phase C Energie heute"
+      },
+      "grid_power_factor": {
+        "name": "Leistungsfaktor"
       }
     },
     "binary_sensor": {
@@ -1589,6 +1636,15 @@
       },
       "schedule_8_running": {
         "name": "Zeitplan 8 läuft"
+      },
+      "grid_l1_connected": {
+        "name": "Phase A verbunden"
+      },
+      "grid_l2_connected": {
+        "name": "Phase B verbunden"
+      },
+      "grid_l3_connected": {
+        "name": "Phase C verbunden"
       }
     },
     "switch": {

--- a/custom_components/ecoflow_energy/translations/en.json
+++ b/custom_components/ecoflow_energy/translations/en.json
@@ -94,6 +94,7 @@
       "enhanced_login_failed": "Enhanced Mode login failed. Check your EcoFlow app email and password.",
       "enhanced_decrypt_failed": "Enhanced Mode credential decryption failed.",
       "powerstream_requires_standard": "PowerStream requires Standard Mode with Developer API keys.",
+      "smart_meter_requires_enhanced": "The Smart Meter requires Enhanced Mode with your EcoFlow account.",
       "unknown": "An unexpected error occurred."
     },
     "abort": {
@@ -154,6 +155,7 @@
       "enhanced_decrypt_failed": "Enhanced Mode credential decryption failed.",
       "no_devices": "Please select at least one device.",
       "powerstream_requires_standard": "PowerStream requires Standard Mode with Developer API keys.",
+      "smart_meter_requires_enhanced": "The Smart Meter requires Enhanced Mode with your EcoFlow account.",
       "unknown": "An unexpected error occurred."
     }
   },
@@ -1518,6 +1520,51 @@
           "power_supply": "Prioritize Power Supply",
           "battery_storage": "Prioritize Battery Storage"
         }
+      },
+      "grid_l1_w": {
+        "name": "Phase A Power"
+      },
+      "grid_l2_w": {
+        "name": "Phase B Power"
+      },
+      "grid_l3_w": {
+        "name": "Phase C Power"
+      },
+      "grid_l1_voltage_v": {
+        "name": "Phase A Voltage"
+      },
+      "grid_l2_voltage_v": {
+        "name": "Phase B Voltage"
+      },
+      "grid_l3_voltage_v": {
+        "name": "Phase C Voltage"
+      },
+      "grid_l1_current_a": {
+        "name": "Phase A Current"
+      },
+      "grid_l2_current_a": {
+        "name": "Phase B Current"
+      },
+      "grid_l3_current_a": {
+        "name": "Phase C Current"
+      },
+      "grid_energy_total_wh": {
+        "name": "Grid Energy Total"
+      },
+      "grid_energy_today_wh": {
+        "name": "Grid Energy Today"
+      },
+      "grid_l1_energy_today_wh": {
+        "name": "Phase A Energy Today"
+      },
+      "grid_l2_energy_today_wh": {
+        "name": "Phase B Energy Today"
+      },
+      "grid_l3_energy_today_wh": {
+        "name": "Phase C Energy Today"
+      },
+      "grid_power_factor": {
+        "name": "Power Factor"
       }
     },
     "binary_sensor": {
@@ -1589,6 +1636,15 @@
       },
       "schedule_8_running": {
         "name": "Schedule 8 Running"
+      },
+      "grid_l1_connected": {
+        "name": "Phase A Connected"
+      },
+      "grid_l2_connected": {
+        "name": "Phase B Connected"
+      },
+      "grid_l3_connected": {
+        "name": "Phase C Connected"
       }
     },
     "switch": {

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -17,5 +17,6 @@ Complete list of all sensors, switches, numbers, and binary sensors per device:
 - [Stream Micro](entities/stream.md#stream-micro-bk01) - 21 sensors (`BK01`) - a grid-tie inverter without a battery, so it gets a reduced version of the Stream entity set
 - [PowerStream](entities/powerstream.md) - 25 sensors (`HW51`) - a microinverter, read-only, Standard Mode only
 - [STREAM AC 5000](entities/stream-ac-5000.md) - 56 sensors, 2 binary sensors, 2 switches, 7 numbers, 1 select (`ES22` and `ES21`) - shares the Stream name but not the Stream protocol, so it has its own parser and entity set
+- [Smart Meter](entities/smart-meter.md) - 17 sensors, 3 binary sensors (`BK21`) - a grid meter, read-only, Enhanced Mode only
 
 Counts are the device-specific entity definitions. Every device additionally exposes 2 universal diagnostic sensors (connection status and active mode) that are not included above.

--- a/documentation/entities/smart-meter.md
+++ b/documentation/entities/smart-meter.md
@@ -1,0 +1,72 @@
+# Smart Meter - Entity Reference
+
+Full list of all entities created for the EcoFlow Smart Meter (BK21 series).
+
+**Totals:** 17 sensors, 3 binary sensors
+
+> Entities marked with *disabled* are available but hidden by default. Enable them in **Settings > Devices > EcoFlow Smart Meter > Entities**.
+
+The meter is read-only. It reports through the account connection only, so it needs **Enhanced Mode**; the Developer API answers for it with an empty response, which is why a Standard Mode setup skips it and says so in the log.
+
+The phases are keyed L1, L2 and L3 on the wire and lettered A, B and C in the EcoFlow app. The entity names follow the app.
+
+---
+
+## Sensors
+
+| Entity | Unit | Category | Default | Description |
+|:---|:---:|:---:|:---:|:---|
+| Grid Power | W | - | enabled | Total power at the grid connection, the figure the app shows |
+| Phase A Power | W | - | enabled | Active power on phase A |
+| Phase B Power | W | - | enabled | Active power on phase B |
+| Phase C Power | W | - | enabled | Active power on phase C |
+| Phase A Voltage | V | - | enabled | Line voltage on phase A |
+| Phase B Voltage | V | - | enabled | Line voltage on phase B |
+| Phase C Voltage | V | - | enabled | Line voltage on phase C |
+| Phase A Current | A | - | enabled | Current on phase A |
+| Phase B Current | A | - | enabled | Current on phase B |
+| Phase C Current | A | - | enabled | Current on phase C |
+| Power Factor | - | diagnostic | enabled | Power factor at the grid connection, see the note below |
+| Grid Connection State | - | diagnostic | enabled | Drawing from the grid, feeding into it, not connected, or invalid |
+
+## Sensors - Energy Dashboard
+
+| Entity | Unit | Default | Description |
+|:---|:---:|:---:|:---|
+| Grid Energy Total | Wh | enabled | Lifetime counter the meter keeps itself |
+| Grid Energy Today | Wh | enabled | Energy since midnight, total for all phases |
+| Phase A Energy Today | Wh | enabled | Energy since midnight, phase A |
+| Phase B Energy Today | Wh | enabled | Energy since midnight, phase B |
+| Phase C Energy Today | Wh | enabled | Energy since midnight, phase C |
+
+> **Grid Energy Total** is the one to add to the Energy Dashboard. It is the meter's own lifetime counter, so it survives restarts and gaps without being rebuilt from power readings. The app labels this counter as import; whether it is really import only or a net figure will show on the first day the house exports, which is why it is published as a plain total and not as a monotonic one. The daily figures do reset to zero at midnight by design, which is the reset a monotonic counter is built for, so those carry it.
+
+---
+
+## Binary Sensors
+
+| Entity | Category | Default | Description |
+|:---|:---:|:---:|:---|
+| Phase A Connected | diagnostic | enabled | Whether the meter sees phase A |
+| Phase B Connected | diagnostic | enabled | Whether the meter sees phase B |
+| Phase C Connected | diagnostic | enabled | Whether the meter sees phase C |
+
+---
+
+## Controls
+
+None. The meter measures and reports; it has nothing to set.
+
+---
+
+## Notes
+
+**Where the readings come from.** Support was built from a recording an owner took on 2026-08-31 with the EcoFlow app open beside it, and the values above match what the app showed at that moment: 407 W total, 318 W on phase B and 89 W on phase C with phase A idle, and 1345 Wh imported. The meter sends a short frame every few seconds and a full one less often; voltages, currents, the power factor and the connection flags only appear in the full frames, so those entities update more slowly than the power readings.
+
+**Today and lifetime read the same for now.** In that recording the daily figure and the lifetime figure carried the same number, which is what you would expect on a meter commissioned the same day. Which of the two is really the lifetime counter is therefore not yet settled by observation; the field named as the lifetime one is the field used for the Energy Dashboard sensor. A recording taken across midnight is what confirms it, and until then a jump in **Grid Energy Today** at midnight is the thing to report.
+
+**No separate export counter.** There is no export or feed-in total in the message definition, and no second counter to derive one from, so the Energy Dashboard gets one grid entry from this device and nothing on the return side. The house in the recording never exported, so whether the counters above hold import only or a net figure is not something that recording can settle. **Grid Connection State** does report feeding into the grid, so the direction is visible even where the energy is not.
+
+**Power Factor reads zero.** The field is sent in every full frame and was zero throughout the recording. It is kept as a diagnostic entity rather than dropped, because zero on an idle phase is a plausible reading and the entity is the cheapest way for an owner to confirm whether it ever moves.
+
+**Readings that are defined but never sent.** The meter's message also has room for reactive power, apparent power and a signal strength value. None of them appeared once in the recording, so none of them became entities. A recording from a second installation is what settles whether they exist on other units or nowhere at all.

--- a/tests/fixtures/smart_meter/bk21_frames_issue331.json
+++ b/tests/fixtures/smart_meter/bk21_frames_issue331.json
@@ -1,0 +1,235 @@
+{
+  "note": "EcoFlow Smart Meter (BK21, EF-EM-P3-120) frames from the issue #331 reporter capture, 2026-08-31. 9 telemetry frames on 254/21, 3 upload period frames on 254/22 and 3 bundled get_reply frames. The property frames are XOR-masked with the low byte of their sequence number, the get_reply frames are not.",
+  "source_topics": [
+    "/app/device/property/{sn}",
+    "/app/{uid}/{sn}/thing/property/get_reply"
+  ],
+  "truncated_at_bytes": {
+    "message": 1024,
+    "bundle": 4096
+  },
+  "frames": [
+    {
+      "ts": 1788212631.95656,
+      "ts_iso": "2026-08-31T21:43:51.956560+00:00",
+      "topic": "property",
+      "size": 61,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a3b0a18ef525d3fd631d74207d8c030e74e72727272ef4e51371d3110021820200128013001380340fe0148155018580170f25e788172800103880101"
+    },
+    {
+      "ts": 1788212665.2590966,
+      "ts_iso": "2026-08-31T21:44:25.259097+00:00",
+      "topic": "get_reply",
+      "size": 193,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 22
+        },
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a1e0a13a812c0a907b012d00fb812e0a712c012e0d403100240fe014816704b0a9e010a9201a808c801b2080d4575726f70652f585858585858b808019d201555a443d52600000000d826019a2700c22d00c82d00e02d00e82d00d02f01d82f01e02f019d30d3337143a5300f21b142aa30141500c066441d0000c743250020a5443d0020a544853192b3563fe53b902b7043ed3b077f6f43f53b00000000fd3bda1be53f953c000000009d3ca2197043c03d8280c9ac02100240fe014815704b"
+    },
+    {
+      "ts": 1788212767.9425964,
+      "ts_iso": "2026-08-31T21:46:07.942596+00:00",
+      "topic": "property",
+      "size": 61,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a3b0a18c974a1bff217f1641fa2e516c16854545454c9689088201710021820200128013001380340fe0148155018580170d462788172800103880101"
+    },
+    {
+      "ts": 1788212893.9984126,
+      "ts_iso": "2026-08-31T21:48:13.998413+00:00",
+      "topic": "property",
+      "size": 54,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 22
+        }
+      ],
+      "hex": "0a340a13bc06d4bd13a406c41bac06f4b306d406f4c01710021820200128013001380340fe0148165013709466788172800103880101"
+    },
+    {
+      "ts": 1788212901.3712075,
+      "ts_iso": "2026-08-31T21:48:21.371207+00:00",
+      "topic": "property",
+      "size": 184,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0ab5010a92018626e62f9c26236b5b5c415e4b0176767676767696262fb30e427de56dfb082e2e2e2ef6082fb4092eec032ee6032ece032ec6032efe012ff6012fce012fb31eeff15e6d8b1e1b829f6c841e3a3b2e6e456a332e2ee46d0b2e0e866a132e0e866aab1f95f17b11cb153cd9416dc315355f416ddb152e2e2e2ed315cbf3286ebb122e2e2e2eb31271c6b06dee13acaee7822c10021820200128013001380340fe01481550920170ae66788172800103880101"
+    },
+    {
+      "ts": 1788213035.6380475,
+      "ts_iso": "2026-08-31T21:50:35.638047+00:00",
+      "topic": "property",
+      "size": 61,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a3b0a18932e375bd64dab3ece86bf4c9b320e0e0e0e933207fda54d10021820200128013001380340fe01481550185801708e6a788172800103880101"
+    },
+    {
+      "ts": 1788213169.569712,
+      "ts_iso": "2026-08-31T21:52:49.569712+00:00",
+      "topic": "property",
+      "size": 84,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a520a2f74c94ede31aa4cd9b7eb5aab43d9fdfce92998adf4e96924aacce9a945add4e9a945ad7cd5e9e9e9e974d5f99e42aa10021820200128013001380340fe014815502f580170e96d788172800103880101"
+    },
+    {
+      "ts": 1788213193.9547014,
+      "ts_iso": "2026-08-31T21:53:13.954701+00:00",
+      "topic": "property",
+      "size": 54,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 22
+        }
+      ],
+      "hex": "0a340a13e85280e947f052904ff852a0e7528052a0944310021820200128013001380340fe014816501370c06e788172800103880101"
+    },
+    {
+      "ts": 1788213303.4426758,
+      "ts_iso": "2026-08-31T21:55:03.442676+00:00",
+      "topic": "property",
+      "size": 61,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a3b0a185be6baf9138563f6b103768453fac6c6c6c65bfad9c86f8510021820200128013001380340fe0148155018580170c671788172800103880101"
+    },
+    {
+      "ts": 1788213357.4965343,
+      "ts_iso": "2026-08-31T21:55:57.496534+00:00",
+      "topic": "get_reply",
+      "size": 193,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 22
+        },
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a1e0a13a812c0a907b012d00fb812e0a712c012e0d403100240fe01481670040a9e010a9201a808c801b2080d4575726f70652f585858585858b808019d20b385d643d52600000000d826019a2700c22d00c82d00e02d00e82d00d02f01d82f01e02f019d309e0d7143a530a96cb042aa301415000076441d0080cf432500e0ae443d00e0ae448531481b5a3fe53ba2c66f43ed3b50e96f43f53b00000000fd3b5fb90f40953c000000009d3c886aaa43c03d8280c9ac02100240fe0148157004"
+    },
+    {
+      "ts": 1788213359.3448856,
+      "ts_iso": "2026-08-31T21:55:59.344886+00:00",
+      "topic": "get_reply",
+      "size": 193,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 22
+        },
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a1e0a13a812c0a907b012d00fb812e0a712c012e0d403100240fe01481670050a9e010a9201a808c801b2080d4575726f70652f585858585858b808019d20b385d643d52600000000d826019a2700c22d00c82d00e02d00e82d00d02f01d82f01e02f019d309e0d7143a530dda5b242aa301415000076441d0080cf432500e0ae443d00e0ae448531481b5a3fe53ba2c66f43ed3b50e96f43f53b00000000fd3b5fb90f40953c000000009d3cf67ba943c03d8280c9ac02100240fe0148157005"
+    },
+    {
+      "ts": 1788213437.2658932,
+      "ts_iso": "2026-08-31T21:57:17.265893+00:00",
+      "topic": "property",
+      "size": 84,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a520a2f3e8353af71e00693078612e10993b7b6a3a3dbe7bea32373e086a38313e79ea38313e7369fa3a3a3a33e9f246006e010021820200128013001380340fe014815502f580170a375788172800103880101"
+    },
+    {
+      "ts": 1788213494.070543,
+      "ts_iso": "2026-08-31T21:58:14.070543+00:00",
+      "topic": "property",
+      "size": 54,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 22
+        }
+      ],
+      "hex": "0a340a13c47eacc56bdc7ebc63d47e8ccb7eac7e8cb86f10021820200128013001380340fe014816501370ec76788172800103880101"
+    },
+    {
+      "ts": 1788213571.176635,
+      "ts_iso": "2026-08-31T21:59:31.176635+00:00",
+      "topic": "property",
+      "size": 61,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a3b0a18e25f5cf5ce3cda4ffbc7ce3dea437f7f7f7fe2437d63fa3c10021820200128013001380340fe0148155018580170ff78788172800103880101"
+    },
+    {
+      "ts": 1788213673.5875525,
+      "ts_iso": "2026-08-31T22:01:13.587553+00:00",
+      "topic": "property",
+      "size": 61,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a3b0a1870cd11194bae48dd31425caf78d1edededed70d1e7ff98ae10021820200128013001380340fe0148155018580170ed7b788172800103880101"
+    }
+  ]
+}

--- a/tests/ha/test_config_flow.py
+++ b/tests/ha/test_config_flow.py
@@ -202,6 +202,199 @@ class TestPowerStreamModeBoundary:
         }]
 
 
+SMART_METER_DEVICE = {
+    "sn": "BK21TEST00000001",
+    "name": "Smart Meter",
+    "product_name": "Smart Meter",
+    "device_type": "smart_meter",
+    "online": 1,
+}
+
+
+def _device_marker(result: Any):
+    """Return the schema marker for the device selector on a devices step."""
+    return next(
+        key
+        for key in result["data_schema"].schema
+        if getattr(key, "schema", None) == CONF_DEVICES
+    )
+
+
+async def _advance_developer_flow_with_smart_meter(hass: HomeAssistant):
+    with patch(
+        "custom_components.ecoflow_energy.config_flow_setup.IoTApiClient",
+    ) as mock_cls:
+        api = mock_cls.return_value
+        api.get_mqtt_credentials = AsyncMock(return_value=MOCK_MQTT_CREDENTIALS)
+        api.get_device_list = AsyncMock(return_value=[
+            {"sn": "BK21TEST00000001", "productName": "", "online": 1},
+            {"sn": "HJ31TEST00000001", "productName": "PowerOcean", "online": 1},
+        ])
+
+        result = await _select_mode(hass, MODE_STANDARD)
+        return await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_ACCESS_KEY: "ak", CONF_SECRET_KEY: "sk"},
+        )
+
+
+async def _advance_app_flow_with_smart_meter(hass: HomeAssistant):
+    result = await _select_mode(hass, MODE_ENHANCED)
+    with (
+        patch(
+            "custom_components.ecoflow_energy.config_flow_setup.enhanced_login",
+            new_callable=AsyncMock,
+            return_value={"token": "jwt_token", "user_id": "uid123"},
+        ),
+        patch(
+            "custom_components.ecoflow_energy.config_flow_setup.get_app_device_list",
+            new_callable=AsyncMock,
+            return_value=[
+                SMART_METER_DEVICE,
+                {
+                    "sn": "HJ31TEST00000001",
+                    "product_name": "PowerOcean",
+                    "device_type": "powerocean",
+                    "online": 1,
+                },
+            ],
+        ),
+    ):
+        return await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_EMAIL: "test@example.com", CONF_PASSWORD: "secret"},
+        )
+
+
+class TestSmartMeterModeBoundary:
+    """The PowerStream boundary with the modes swapped.
+
+    The meter reports on the app channel only, so a developer-key entry
+    would create entities that can never fill. Before this guard the picker
+    rendered it clean and pre-selected, which is worse than the "not
+    supported yet" it used to show.
+    """
+
+    async def test_developer_flow_shows_but_does_not_preselect_the_meter(
+        self, hass: HomeAssistant
+    ) -> None:
+        result = await _advance_developer_flow_with_smart_meter(hass)
+
+        marker = _device_marker(result)
+        options = result["data_schema"].schema[marker].config["options"]
+        assert any(
+            option["value"] == SMART_METER_DEVICE["sn"]
+            and "requires Enhanced Mode" in option["label"]
+            for option in options
+        )
+        assert marker.default() == ["HJ31TEST00000001"]
+
+    async def test_developer_flow_rejects_explicit_meter_selection(
+        self, hass: HomeAssistant
+    ) -> None:
+        result = await _advance_developer_flow_with_smart_meter(hass)
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_DEVICES: [SMART_METER_DEVICE["sn"]]}
+        )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["errors"]["base"] == "smart_meter_requires_enhanced"
+
+    async def test_app_flow_preselects_the_meter_and_accepts_it(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Negative control for the two mode-dependent assertions above.
+
+        Without it a guard that fired in both modes would satisfy them and
+        take the meter away from the only mode it works in. The label
+        marker is deliberately not part of this control: like the
+        PowerStream one it states which mode the device needs, which is
+        true whichever mode the flow is currently in.
+        """
+        result = await _advance_app_flow_with_smart_meter(hass)
+
+        marker = _device_marker(result)
+        assert SMART_METER_DEVICE["sn"] in marker.default()
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_DEVICES: [SMART_METER_DEVICE["sn"]]}
+        )
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    async def test_options_reject_switch_to_standard_before_mutation(
+        self, hass: HomeAssistant
+    ) -> None:
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="EcoFlow Energy",
+            data={
+                CONF_AUTH_METHOD: AUTH_METHOD_APP,
+                CONF_MODE: MODE_ENHANCED,
+                CONF_EMAIL: "test@example.com",
+                CONF_PASSWORD: "secret",
+                CONF_USER_ID: "uid123",
+                CONF_ACCESS_KEY: "ak",
+                CONF_SECRET_KEY: "sk",
+                CONF_DEVICES: [SMART_METER_DEVICE],
+            },
+            unique_id="test@example.com",
+        )
+        entry.add_to_hass(hass)
+        before = dict(entry.data)
+
+        with patch(
+            "custom_components.ecoflow_energy.config_flow_options."
+            "_async_fetch_app_devices",
+            new_callable=AsyncMock,
+            return_value=[SMART_METER_DEVICE],
+        ):
+            result = await hass.config_entries.options.async_init(entry.entry_id)
+            result = await hass.config_entries.options.async_configure(
+                result["flow_id"],
+                {
+                    CONF_MODE: MODE_STANDARD,
+                    CONF_DEVICES: [SMART_METER_DEVICE["sn"]],
+                },
+            )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["errors"]["base"] == "smart_meter_requires_enhanced"
+        assert entry.data == before
+
+    async def test_options_stored_fallback_keeps_enhanced_mode_hint(
+        self, hass: HomeAssistant
+    ) -> None:
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="EcoFlow Energy",
+            data={
+                CONF_AUTH_METHOD: AUTH_METHOD_APP,
+                CONF_MODE: MODE_ENHANCED,
+                CONF_EMAIL: "test@example.com",
+                CONF_PASSWORD: "secret",
+                CONF_USER_ID: "uid123",
+                CONF_DEVICES: [SMART_METER_DEVICE],
+            },
+            unique_id="test@example.com",
+        )
+        entry.add_to_hass(hass)
+
+        with patch(
+            "custom_components.ecoflow_energy.config_flow_options."
+            "_async_fetch_app_devices",
+            new_callable=AsyncMock,
+            side_effect=TimeoutError,
+        ):
+            result = await hass.config_entries.options.async_init(entry.entry_id)
+
+        options = result["data_schema"].schema[CONF_DEVICES].config["options"]
+        assert options == [{
+            "value": SMART_METER_DEVICE["sn"],
+            "label": "Smart Meter (0001) (BK21TEST0000) - requires Enhanced Mode",
+        }]
+
+
 # ===========================================================================
 # Step 1: Mode selection
 # ===========================================================================

--- a/tests/ha/test_diagnostics.py
+++ b/tests/ha/test_diagnostics.py
@@ -119,9 +119,9 @@ class TestConfigEntryDiagnostics:
     ) -> None:
         """Diagnostics expose the skipped_devices list for the entry."""
         unsupported_device = {
-            "sn": "BK21TEST00000001",
-            "name": "Smart Meter",
-            "product_name": "Smart Meter",
+            "sn": "ZZ01TEST00000001",
+            "name": "Unmapped Device",
+            "product_name": "Unmapped Device",
             "device_type": "unknown",
             "online": 1,
         }
@@ -147,8 +147,8 @@ class TestConfigEntryDiagnostics:
 
         result = await async_get_config_entry_diagnostics(hass, entry)
         assert len(result["skipped_devices"]) == 1
-        assert result["skipped_devices"][0]["sn_prefix"] == "BK21"
-        assert result["skipped_devices"][0]["product_name"] == "Smart Meter"
+        assert result["skipped_devices"][0]["sn_prefix"] == "ZZ01"
+        assert result["skipped_devices"][0]["product_name"] == "Unmapped Device"
 
 
 # ===========================================================================
@@ -958,7 +958,7 @@ class TestSkippedDeviceRawQuotaDiagnostics:
     DIAG_QUOTA_PATH = (
         "custom_components.ecoflow_energy.diagnostics.EcoFlowHTTPQuota"
     )
-    # Fictional Smart Meter serial: a device we do not yet parse.
+    # Fictional serial on a prefix no parser claims.
     SKIPPED_SN = "SM3ATEST00000001"
     # A 16-char alphanumeric quota value that looks like a serial and must
     # be redacted, alongside numeric fields that must be preserved.
@@ -969,7 +969,7 @@ class TestSkippedDeviceRawQuotaDiagnostics:
             {
                 "sn_prefix": self.SKIPPED_SN[:4],
                 "sn": self.SKIPPED_SN,
-                "product_name": "Smart Meter",
+                "product_name": "Unmapped Device",
                 "reason": "no parser available for this device type",
             }
         ]

--- a/tests/ha/test_init.py
+++ b/tests/ha/test_init.py
@@ -448,6 +448,119 @@ class TestUnsupportedDeviceSkip:
             }
         ]
 
+    async def test_developer_keys_smart_meter_is_skipped_without_probe(
+        self,
+        hass: HomeAssistant,
+        mock_mqtt_client,
+        caplog,
+    ) -> None:
+        """The mirror of the PowerStream case, with the modes swapped.
+
+        The meter reports on the app channel and nowhere else, so a
+        developer-key entry would create seventeen entities that can never
+        fill. It is skipped with one warning and no probe.
+        """
+        smart_meter = {
+            "sn": "BK21TEST00000001",
+            "name": "Smart Meter",
+            "product_name": "Smart Meter",
+            "device_type": "smart_meter",
+            "online": 1,
+        }
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="EcoFlow Energy",
+            data={
+                CONF_AUTH_METHOD: AUTH_METHOD_DEVELOPER,
+                CONF_ACCESS_KEY: "test_ak",
+                CONF_SECRET_KEY: "test_sk",
+                CONF_MODE: MODE_STANDARD,
+                CONF_DEVICES: [smart_meter],
+            },
+            unique_id="test_ak",
+        )
+        entry.add_to_hass(hass)
+
+        import logging
+        caplog.set_level(logging.WARNING)
+
+        with (
+            patch(
+                "custom_components.ecoflow_energy.coordinator."
+                "EcoFlowDeviceCoordinator.async_config_entry_first_refresh",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "custom_components.ecoflow_energy.async_start_probes",
+                new_callable=AsyncMock,
+            ) as start_probes,
+        ):
+            assert await hass.config_entries.async_setup(entry.entry_id) is True
+            await hass.async_block_till_done()
+
+        assert hass.data[DOMAIN][entry.entry_id] == {}
+        start_probes.assert_not_awaited()
+        assert hass.data[DATA_SKIPPED_DEVICES][entry.entry_id] == [
+            {
+                "sn_prefix": "BK21",
+                "sn": "BK21TEST00000001",
+                "product_name": "Smart Meter",
+                "reason": "Smart Meter requires Enhanced Mode",
+                "probe_eligible": False,
+            }
+        ]
+        warnings = [
+            r.getMessage() for r in caplog.records
+            if r.levelno == logging.WARNING and "Smart Meter" in r.getMessage()
+        ]
+        assert len(warnings) == 1
+        assert "requires Enhanced Mode" in warnings[0]
+
+    async def test_app_auth_smart_meter_is_not_skipped(
+        self,
+        hass: HomeAssistant,
+        mock_mqtt_client,
+        mock_enhanced_auth,
+    ) -> None:
+        """Negative control: the same serial on Enhanced Mode gets a coordinator.
+
+        Without it the test above would still pass if the skip fired on
+        every entry, which would take the meter away from the only mode it
+        works in.
+        """
+        smart_meter = {
+            "sn": "BK21TEST00000001",
+            "name": "Smart Meter",
+            "product_name": "Smart Meter",
+            "device_type": "smart_meter",
+            "online": 1,
+        }
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="EcoFlow Energy",
+            data={
+                CONF_AUTH_METHOD: AUTH_METHOD_APP,
+                CONF_MODE: MODE_ENHANCED,
+                CONF_EMAIL: "test@example.com",
+                CONF_PASSWORD: "test_password",
+                CONF_USER_ID: "uid",
+                CONF_DEVICES: [smart_meter],
+            },
+            unique_id="test@example.com",
+        )
+        entry.add_to_hass(hass)
+
+        with patch(
+            "custom_components.ecoflow_energy.coordinator."
+            "EcoFlowDeviceCoordinator.async_config_entry_first_refresh",
+            new_callable=AsyncMock,
+        ):
+            assert await hass.config_entries.async_setup(entry.entry_id) is True
+            await hass.async_block_till_done()
+
+        assert set(hass.data[DOMAIN][entry.entry_id]) == {"BK21TEST00000001"}
+        assert hass.data[DATA_SKIPPED_DEVICES][entry.entry_id] == []
+
     async def test_unsupported_device_skipped(
         self,
         hass: HomeAssistant,
@@ -621,9 +734,9 @@ class TestUnsupportedDeviceSkip:
     ) -> None:
         """Unsupported device: setup succeeds, one WARNING, tracked as skipped."""
         unsupported_device = {
-            "sn": "BK21TEST00000001",
-            "name": "Smart Meter",
-            "product_name": "Smart Meter",
+            "sn": "ZZ01TEST00000001",
+            "name": "Unmapped Device",
+            "product_name": "Unmapped Device",
             "device_type": "unknown",
             "online": 1,
         }
@@ -675,14 +788,14 @@ class TestUnsupportedDeviceSkip:
         ]
         assert len(warnings) == 1
         # SN prefix only (privacy) - full serial must not leak
-        assert "BK21" in warnings[0].getMessage()
-        assert "BK21TEST00000001" not in warnings[0].getMessage()
+        assert "ZZ01" in warnings[0].getMessage()
+        assert "ZZ01TEST00000001" not in warnings[0].getMessage()
 
         # Tracked under the top-level skipped-devices namespace
         skipped = hass.data[DATA_SKIPPED_DEVICES][entry.entry_id]
         assert len(skipped) == 1
-        assert skipped[0]["sn_prefix"] == "BK21"
-        assert skipped[0]["product_name"] == "Smart Meter"
+        assert skipped[0]["sn_prefix"] == "ZZ01"
+        assert skipped[0]["product_name"] == "Unmapped Device"
 
     async def test_unsupported_device_hint_matches_account_signin(
         self,
@@ -692,9 +805,9 @@ class TestUnsupportedDeviceSkip:
     ) -> None:
         """Account sign-in: the hint points at the capture switch, which exists there."""
         unsupported_device = {
-            "sn": "BK21TEST00000001",
-            "name": "Smart Meter",
-            "product_name": "Smart Meter",
+            "sn": "ZZ01TEST00000001",
+            "name": "Unmapped Device",
+            "product_name": "Unmapped Device",
             "device_type": "unknown",
             "online": 1,
         }
@@ -760,9 +873,9 @@ class TestUnsupportedDeviceSkip:
         turn on.
         """
         unsupported_device = {
-            "sn": "BK21TEST00000001",
-            "name": "Smart Meter",
-            "product_name": "Smart Meter",
+            "sn": "ZZ01TEST00000001",
+            "name": "Unmapped Device",
+            "product_name": "Unmapped Device",
             "device_type": "unknown",
             "online": 1,
         }
@@ -815,9 +928,9 @@ class TestUnsupportedDeviceSkip:
         re-create #188 for exactly this entry.
         """
         unsupported_device = {
-            "sn": "BK21TEST00000001",
-            "name": "Smart Meter",
-            "product_name": "Smart Meter",
+            "sn": "ZZ01TEST00000001",
+            "name": "Unmapped Device",
+            "product_name": "Unmapped Device",
             "device_type": "unknown",
             "online": 1,
         }
@@ -863,9 +976,9 @@ class TestUnsupportedDeviceSkip:
     ) -> None:
         """Unload removes the entry from the skipped-devices namespace."""
         unsupported_device = {
-            "sn": "BK21TEST00000001",
-            "name": "Smart Meter",
-            "product_name": "Smart Meter",
+            "sn": "ZZ01TEST00000001",
+            "name": "Unmapped Device",
+            "product_name": "Unmapped Device",
             "device_type": "unknown",
             "online": 1,
         }

--- a/tests/ha/test_smart_meter_entities.py
+++ b/tests/ha/test_smart_meter_entities.py
@@ -1,0 +1,373 @@
+"""Entity-set tests for the EcoFlow Smart Meter (BK21).
+
+The parser tests prove the field map against the reporter's capture. These
+run one of the same frames through the coordinator, because the failure this
+family already had once was never in a parser: a BK-series serial that lands
+on the wrong device type produces readings that are correct for a device
+nobody has.
+
+The meter shares two keys with the Stream, so "the meter's entities exist"
+is not enough on its own - a Stream must keep its own set, and the per-phase
+readings must not appear on it.
+"""
+
+from __future__ import annotations
+
+import binascii
+import json
+from pathlib import Path
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.ecoflow_energy.binary_sensor import (
+    async_setup_entry as binary_sensor_setup,
+)
+from custom_components.ecoflow_energy.const import (
+    AUTH_METHOD_APP,
+    CONF_AUTH_METHOD,
+    CONF_DEVICES,
+    CONF_EMAIL,
+    CONF_MODE,
+    CONF_PASSWORD,
+    CONF_USER_ID,
+    DEVICE_TYPE_SMART_METER,
+    DEVICE_TYPE_STREAM,
+    DOMAIN,
+    MODE_ENHANCED,
+    SMARTMETER_BINARY_SENSORS,
+    SMARTMETER_SENSORS,
+)
+from custom_components.ecoflow_energy.coordinator import EcoFlowDeviceCoordinator
+from custom_components.ecoflow_energy.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+from custom_components.ecoflow_energy.ecoflow.const import (
+    get_device_name,
+    get_device_type,
+)
+from custom_components.ecoflow_energy.sensor import async_setup_entry as sensor_setup
+
+CAPTURE = (
+    Path(__file__).parent.parent
+    / "fixtures"
+    / "smart_meter"
+    / "bk21_frames_issue331.json"
+)
+
+# The 146-byte full upload of the reporter's capture: the one frame that
+# carries every reading at once, including the voltages and currents the
+# shorter frames leave out.
+FULL_UPLOAD_INDEX = 4
+
+BK21_DEVICE: dict[str, Any] = {
+    "sn": "BK21TEST00000001",
+    "name": "",
+    "product_name": "",
+    "device_type": DEVICE_TYPE_SMART_METER,
+    "online": 1,
+}
+
+BK31_DEVICE: dict[str, Any] = {
+    "sn": "BK31TEST00000001",
+    "name": "",
+    "product_name": "",
+    "device_type": DEVICE_TYPE_STREAM,
+    "online": 1,
+}
+
+# Readings only the meter has. `grid_w` and `grid_connection_state` are
+# deliberately absent from this set: the Stream reports both, so neither
+# would separate the two device types.
+METER_ONLY_KEYS = {
+    "grid_l1_w",
+    "grid_l2_w",
+    "grid_l3_w",
+    "grid_l1_voltage_v",
+    "grid_l2_voltage_v",
+    "grid_l3_voltage_v",
+    "grid_l1_current_a",
+    "grid_l2_current_a",
+    "grid_l3_current_a",
+    "grid_energy_total_wh",
+    "grid_energy_today_wh",
+    "grid_l1_energy_today_wh",
+    "grid_l2_energy_today_wh",
+    "grid_l3_energy_today_wh",
+    "grid_power_factor",
+}
+
+
+def _entry(device: dict[str, Any]) -> MockConfigEntry:
+    """Build an Enhanced-mode entry for one device."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="EcoFlow Energy",
+        data={
+            CONF_AUTH_METHOD: AUTH_METHOD_APP,
+            CONF_MODE: MODE_ENHANCED,
+            CONF_EMAIL: "test@example.com",
+            CONF_PASSWORD: "test_password",
+            CONF_USER_ID: "user123",
+            CONF_DEVICES: [device],
+        },
+        unique_id="test@example.com",
+    )
+
+
+async def _setup_entities(
+    hass: HomeAssistant,
+    platform_setup,
+    device: dict[str, Any],
+    reported: dict[str, Any] | None = None,
+) -> list[Any]:
+    """Run one platform's setup and return the definition-driven entities."""
+    entry = _entry(device)
+    entry.add_to_hass(hass)
+    coordinator = EcoFlowDeviceCoordinator(hass, entry, device)
+    if reported:
+        coordinator.async_set_updated_data(dict(reported))
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {device["sn"]: coordinator}
+
+    created: list[Any] = []
+    await platform_setup(hass, entry, created.extend)
+    return [entity for entity in created if hasattr(entity, "_definition")]
+
+
+def _frame(index: int) -> bytes:
+    frames = json.loads(CAPTURE.read_text())["frames"]
+    return binascii.unhexlify(frames[index]["hex"])
+
+
+class TestSmartMeterRouting:
+    def test_bk21_is_its_own_device_type(self) -> None:
+        assert get_device_type("", "BK21TEST00000001") == DEVICE_TYPE_SMART_METER
+
+    def test_bk21_display_name(self) -> None:
+        assert get_device_name("", "BK21TEST00001234") == "Smart Meter (1234)"
+
+
+class TestSmartMeterEntitySet:
+    async def test_the_meter_gets_its_seventeen_sensors(
+        self, hass: HomeAssistant
+    ) -> None:
+        entities = await _setup_entities(hass, sensor_setup, BK21_DEVICE)
+
+        keys = {entity._definition.key for entity in entities}
+        assert len(entities) == 17
+        assert keys == {sensor.key for sensor in SMARTMETER_SENSORS}
+
+    async def test_the_meter_gets_its_three_binary_sensors(
+        self, hass: HomeAssistant
+    ) -> None:
+        entities = await _setup_entities(hass, binary_sensor_setup, BK21_DEVICE)
+
+        keys = {entity._definition.key for entity in entities}
+        assert len(entities) == 3
+        assert keys == {sensor.key for sensor in SMARTMETER_BINARY_SENSORS}
+
+    async def test_a_stream_does_not_get_the_meter_readings(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A BK31 is a Stream. It shares two keys with the meter and must
+        keep exactly those, or the split has leaked."""
+        entities = await _setup_entities(hass, sensor_setup, BK31_DEVICE)
+
+        keys = {entity._definition.key for entity in entities}
+        assert not keys & METER_ONLY_KEYS
+
+    async def test_a_stream_does_not_get_the_phase_connection_flags(
+        self, hass: HomeAssistant
+    ) -> None:
+        entities = await _setup_entities(hass, binary_sensor_setup, BK31_DEVICE)
+
+        keys = {entity._definition.key for entity in entities}
+        assert not keys & {sensor.key for sensor in SMARTMETER_BINARY_SENSORS}
+
+
+class TestSmartMeterDefinitions:
+    def test_the_daily_counters_are_the_only_monotonic_ones(self) -> None:
+        """A midnight zero is the reset `total_increasing` is built for.
+
+        The lifetime counter must stay out of that set. The message
+        definition carries no export counter, so a day on which the house
+        exports can move the lifetime figure down, and `total_increasing`
+        would read that as a meter change and count the standing total a
+        second time.
+        """
+        monotonic = [
+            sensor.key
+            for sensor in SMARTMETER_SENSORS
+            if sensor.state_class == "total_increasing"
+        ]
+
+        assert sorted(monotonic) == [
+            "grid_energy_today_wh",
+            "grid_l1_energy_today_wh",
+            "grid_l2_energy_today_wh",
+            "grid_l3_energy_today_wh",
+        ]
+
+    def test_the_lifetime_counter_is_a_plain_total(self) -> None:
+        lifetime = next(
+            sensor
+            for sensor in SMARTMETER_SENSORS
+            if sensor.key == "grid_energy_total_wh"
+        )
+
+        assert lifetime.state_class == "total"
+
+    def test_every_daily_counter_is_monotonic(self) -> None:
+        daily = [
+            sensor for sensor in SMARTMETER_SENSORS if sensor.key.endswith("_today_wh")
+        ]
+
+        assert len(daily) == 4
+        assert all(sensor.state_class == "total_increasing" for sensor in daily)
+
+    def test_every_energy_counter_reports_watt_hours(self) -> None:
+        energy = [
+            sensor for sensor in SMARTMETER_SENSORS if sensor.device_class == "energy"
+        ]
+
+        assert len(energy) == 5
+        assert all(sensor.unit == "Wh" for sensor in energy)
+
+    def test_the_enum_offers_exactly_the_states_the_parser_produces(self) -> None:
+        from custom_components.ecoflow_energy.ecoflow.parsers.stream_proto import (
+            _GRID_CONNECTION_STATE,
+        )
+
+        state = next(
+            sensor
+            for sensor in SMARTMETER_SENSORS
+            if sensor.key == "grid_connection_state"
+        )
+
+        assert set(state.options or []) == set(_GRID_CONNECTION_STATE.values())
+
+    def test_the_phase_readings_are_labelled_the_way_the_app_counts_them(
+        self,
+    ) -> None:
+        """The wire numbers the phases L1-L3 and the app letters them A-C.
+        The keys follow the wire, the labels follow the app."""
+        assert [
+            sensor.name for sensor in SMARTMETER_SENSORS if sensor.key.endswith("_w")
+        ] == ["Grid Power", "Phase A Power", "Phase B Power", "Phase C Power"]
+
+    def test_every_phase_reading_has_a_device_class(self) -> None:
+        assert all(sensor.device_class for sensor in SMARTMETER_SENSORS)
+
+
+class TestTheCaptureReachesTheEntities:
+    """The point of the whole phase: a frame the reporter's meter sent, in,
+    and Home Assistant states out."""
+
+    async def test_the_full_upload_fills_the_sensors(
+        self, hass: HomeAssistant
+    ) -> None:
+        entry = _entry(BK21_DEVICE)
+        entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(hass, entry, BK21_DEVICE)
+
+        parsed = coordinator._parse_message(
+            f"/app/device/property/{BK21_DEVICE['sn']}", _frame(FULL_UPLOAD_INDEX)
+        )
+        assert parsed is not None
+        coordinator.async_set_updated_data(dict(parsed))
+        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+            BK21_DEVICE["sn"]: coordinator
+        }
+
+        created: list[Any] = []
+        await sensor_setup(hass, entry, created.extend)
+        values = {
+            entity._definition.key: entity.native_value
+            for entity in created
+            if hasattr(entity, "_definition")
+        }
+
+        # 406.65 W on the wire, shown as whole watts.
+        assert values["grid_w"] == 407
+        assert values["grid_energy_total_wh"] == 1345
+        assert values["grid_connection_state"] == "grid_in"
+        # Phase B carries most of the load in this frame, phase A none.
+        assert values["grid_l1_w"] == 0
+        assert values["grid_l2_w"] == 318
+        assert values["grid_l2_voltage_v"] == 239.4
+        assert values["grid_l2_current_a"] == 2.11
+
+    async def test_the_full_upload_fills_the_connection_flags(
+        self, hass: HomeAssistant
+    ) -> None:
+        entry = _entry(BK21_DEVICE)
+        entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(hass, entry, BK21_DEVICE)
+
+        parsed = coordinator._parse_message(
+            f"/app/device/property/{BK21_DEVICE['sn']}", _frame(FULL_UPLOAD_INDEX)
+        )
+        assert parsed is not None
+        coordinator.async_set_updated_data(dict(parsed))
+        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+            BK21_DEVICE["sn"]: coordinator
+        }
+
+        created: list[Any] = []
+        await binary_sensor_setup(hass, entry, created.extend)
+        values = {
+            entity._definition.key: entity.is_on
+            for entity in created
+            if hasattr(entity, "_definition")
+        }
+
+        assert values == {
+            "grid_l1_connected": True,
+            "grid_l2_connected": True,
+            "grid_l3_connected": True,
+        }
+
+
+class TestSmartMeterDiagnostics:
+    """A device that reports fine but shows up as skipped in a diagnostics
+    download sends every future reporter down the wrong path."""
+
+    async def test_the_meter_is_a_device_not_a_skipped_one(
+        self, hass: HomeAssistant
+    ) -> None:
+        entry = _entry(BK21_DEVICE)
+        entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(hass, entry, BK21_DEVICE)
+        parsed = coordinator._parse_message(
+            f"/app/device/property/{BK21_DEVICE['sn']}", _frame(FULL_UPLOAD_INDEX)
+        )
+        assert parsed is not None
+        coordinator._device_data.update(parsed)
+        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+            BK21_DEVICE["sn"]: coordinator
+        }
+
+        diag = await async_get_config_entry_diagnostics(hass, entry)
+
+        assert diag["skipped_devices"] == []
+        assert len(diag["devices"]) == 1
+        assert diag["devices"][0]["device_sn"].startswith("BK21")
+        assert "grid_w" in diag["devices"][0]["data_keys"]
+
+    async def test_the_meter_carries_no_raw_quota_section(
+        self, hass: HomeAssistant
+    ) -> None:
+        """It has no HTTP quota at all, so an empty raw quota block would
+        read as a device that answered with nothing."""
+        entry = _entry(BK21_DEVICE)
+        entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(hass, entry, BK21_DEVICE)
+        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+            BK21_DEVICE["sn"]: coordinator
+        }
+
+        diag = await async_get_config_entry_diagnostics(hass, entry)
+
+        assert "raw_quota" not in diag["devices"][0]

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -306,10 +306,23 @@ class TestDeviceTypeRouting:
             ), powerstream_keyword
             assert get_device_type(powerstream_keyword, "") == "powerstream"
 
-    def test_bk21_smart_meter_stays_unknown(self) -> None:
-        # Smart Meter support is deferred: it must remain unknown so it
-        # shows up as a visible skip, not silently mapped to a wrong parser.
-        assert get_device_type("", "BK21TEST00000001") == "unknown"
+    def test_bk21_is_the_smart_meter(self) -> None:
+        """The Smart Meter is reached by prefix only (#331).
+
+        Its product name arrives empty from the app API, and "Smart Meter"
+        matches none of the keyword lists, so without the prefix entry the
+        device is skipped as unsupported.
+        """
+        assert get_device_type("", "BK21TEST00000001") == "smart_meter"
+        assert _SN_PREFIX_MAP["BK21"] == "smart_meter"
+        assert get_device_name("", "BK21TEST00000001") == "Smart Meter (0001)"
+
+    def test_an_unmapped_bk_prefix_still_stays_unknown(self) -> None:
+        # The BK prefixes are enumerated one by one on purpose: a family
+        # match would route an unknown model into a parser whose field map
+        # it does not share, and a visible skip is worth more than a device
+        # full of empty entities.
+        assert get_device_type("", "BK99TEST00000001") == "unknown"
 
     def test_plain_delta_pro_stays_delta(self) -> None:
         # "DELTA Pro" (no "3") keeps its existing Delta behavior.

--- a/tests/test_smart_meter_parser.py
+++ b/tests/test_smart_meter_parser.py
@@ -1,0 +1,346 @@
+"""Tests for the EcoFlow Smart Meter (BK21) protobuf parser.
+
+Every expectation below is a number the reporter's meter put on the wire on
+2026-08-31 (#331). They are written out per frame rather than recomputed
+from the parser, because a test that derives its expectation from the code
+under test holds for any field map.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ecoflow_energy.ecoflow.parsers.smart_meter_proto import (
+    _ENERGY_RECORD_MAP,
+    _SMART_METER_FIELD_MAP,
+    parse_smart_meter_message,
+)
+from ecoflow_energy.ecoflow.proto_encoding import (
+    encode_field_bytes,
+    encode_field_varint,
+    encode_varint,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "smart_meter" / "bk21_frames_issue331.json"
+STREAM_FIXTURE = Path(__file__).parent / "fixtures" / "stream" / "bk01_capture_masked.json"
+
+
+def _frames(path: Path) -> list[dict[str, Any]]:
+    return json.loads(path.read_text())["frames"]
+
+
+def _payload(index: int) -> bytes:
+    return bytes.fromhex(_frames(FIXTURE)[index]["hex"])
+
+
+def _encode_fixed32_field(field_number: int, value: float) -> bytes:
+    tag = (field_number << 3) | 5
+    return encode_varint(tag) + struct.pack("<f", value)
+
+
+def _build_frame(cmd_func: int, cmd_id: int, inner: bytes) -> bytes:
+    """Build a minimal unmasked EcoFlow header frame."""
+    header = bytearray()
+    header.extend(encode_field_bytes(1, inner))
+    header.extend(encode_field_varint(8, cmd_func))
+    header.extend(encode_field_varint(9, cmd_id))
+    return encode_field_bytes(1, bytes(header))
+
+
+# Frame index -> the reading the meter reported in that frame. Three shapes
+# occur: the 24-byte incremental upload, the 47-byte one that adds the
+# energy record, and the 146-byte full upload. The bundled `get_reply`
+# frames (1, 9, 10) carry a full upload unmasked next to an upload-period
+# message.
+_INCREMENTAL = {
+    0: {"grid_w": 328.6029968261719, "grid_l1_w": 0.0,
+        "grid_l2_w": 239.2700653076172, "grid_l3_w": 89.33292388916016},
+    2: {"grid_w": 333.8434143066406, "grid_l1_w": 0.0,
+        "grid_l2_w": 244.86236572265625, "grid_l3_w": 88.98104095458984},
+    5: {"grid_w": 432.6658020019531, "grid_l1_w": 0.0,
+        "grid_l2_w": 343.8987121582031, "grid_l3_w": 88.76708984375},
+    8: {"grid_w": 426.4959716796875, "grid_l1_w": 0.0,
+        "grid_l2_w": 338.1103210449219, "grid_l3_w": 88.38567352294922},
+    13: {"grid_w": 355.0791931152344, "grid_l1_w": 0.0,
+         "grid_l2_w": 266.21881103515625, "grid_l3_w": 88.86038208007812},
+    14: {"grid_w": 333.9139404296875, "grid_l1_w": 0.0,
+         "grid_l2_w": 245.07046508789062, "grid_l3_w": 88.84347534179688},
+}
+
+_WITH_ENERGY_RECORD = {
+    6: {"grid_w": 432.4347839355469, "grid_l1_w": 0.0,
+        "grid_l2_w": 342.93017578125, "grid_l3_w": 89.50462341308594,
+        "grid_l2_energy_today_wh": 967.0, "grid_l3_energy_today_wh": 411.0,
+        "grid_energy_today_wh": 1378.0, "grid_energy_total_wh": 1378.0},
+    11: {"grid_w": 420.10107421875, "grid_l1_w": 0.0,
+         "grid_l2_w": 331.5275573730469, "grid_l3_w": 88.57351684570312,
+         "grid_l2_energy_today_wh": 992.0, "grid_l3_energy_today_wh": 417.0,
+         "grid_energy_today_wh": 1409.0, "grid_energy_total_wh": 1409.0},
+}
+
+# The 146-byte full upload, frame 4, and the two bundles that followed it
+# eleven minutes later. Those two carry the same voltages, currents and
+# counters but different per-phase power, so they are not one reading sent
+# twice.
+_FULL = {
+    4: {"grid_w": 406.6517333984375,
+        "grid_l1_w": 0.0, "grid_l2_w": 317.8153991699219,
+        "grid_l3_w": 88.83634185791016,
+        "grid_l1_voltage_v": 239.96511840820312,
+        "grid_l2_voltage_v": 239.4418182373047,
+        "grid_l3_voltage_v": 240.87403869628906,
+        "grid_l1_current_a": 0.0,
+        "grid_l2_current_a": 2.1072933673858643,
+        "grid_l3_current_a": 0.8354451060295105,
+        "grid_l2_energy_today_wh": 941.0, "grid_l3_energy_today_wh": 404.0,
+        "grid_energy_today_wh": 1345.0, "grid_energy_total_wh": 1345.0,
+        "grid_power_factor": 0.0, "grid_connection_state": "grid_in",
+        "grid_l1_connected": True, "grid_l2_connected": True,
+        "grid_l3_connected": True},
+    1: {"grid_w": 328.6647033691406,
+        "grid_l1_w": 0.0, "grid_l2_w": 240.10012817382812,
+        "grid_l3_w": 88.56456756591797,
+        "grid_l1_voltage_v": 240.170166015625,
+        "grid_l2_voltage_v": 239.49620056152344,
+        "grid_l3_voltage_v": 241.2024383544922,
+        "grid_l1_current_a": 0.0,
+        "grid_l2_current_a": 1.789912462234497,
+        "grid_l3_current_a": 0.8386775255203247,
+        "grid_l2_energy_today_wh": 923.0, "grid_l3_energy_today_wh": 398.0,
+        "grid_energy_today_wh": 1321.0, "grid_energy_total_wh": 1321.0,
+        "grid_power_factor": 0.0, "grid_connection_state": "grid_in",
+        "grid_l1_connected": True, "grid_l2_connected": True,
+        "grid_l3_connected": True},
+    9: {"grid_w": 429.0445251464844,
+        "grid_l1_w": 0.0, "grid_l2_w": 340.832275390625,
+        "grid_l3_w": 88.21222686767578,
+        "grid_l1_voltage_v": 239.77590942382812,
+        "grid_l2_voltage_v": 239.911376953125,
+        "grid_l3_voltage_v": 241.05319213867188,
+        "grid_l1_current_a": 0.0,
+        "grid_l2_current_a": 2.2456891536712646,
+        "grid_l3_current_a": 0.8519787788391113,
+        "grid_l2_energy_today_wh": 984.0, "grid_l3_energy_today_wh": 415.0,
+        "grid_energy_today_wh": 1399.0, "grid_energy_total_wh": 1399.0,
+        "grid_power_factor": 0.0, "grid_connection_state": "grid_in",
+        "grid_l1_connected": True, "grid_l2_connected": True,
+        "grid_l3_connected": True},
+    10: {"grid_w": 429.0445251464844,
+         "grid_l1_w": 0.0, "grid_l2_w": 338.96844482421875,
+         "grid_l3_w": 89.3239517211914,
+         "grid_l1_voltage_v": 239.77590942382812,
+         "grid_l2_voltage_v": 239.911376953125,
+         "grid_l3_voltage_v": 241.05319213867188,
+         "grid_l1_current_a": 0.0,
+         "grid_l2_current_a": 2.2456891536712646,
+         "grid_l3_current_a": 0.8519787788391113,
+         "grid_l2_energy_today_wh": 984.0, "grid_l3_energy_today_wh": 415.0,
+         "grid_energy_today_wh": 1399.0, "grid_energy_total_wh": 1399.0,
+         "grid_power_factor": 0.0, "grid_connection_state": "grid_in",
+         "grid_l1_connected": True, "grid_l2_connected": True,
+         "grid_l3_connected": True},
+}
+
+_EXPECTED = {**_INCREMENTAL, **_WITH_ENERGY_RECORD, **_FULL}
+
+# Upload periods only, nothing readable.
+_RUNTIME_ONLY = (3, 7, 12)
+
+
+def _assert_matches(result: dict[str, Any] | None, expected: dict[str, Any]) -> None:
+    assert result is not None
+    assert set(result) == set(expected)
+    for key, want in expected.items():
+        got = result[key]
+        if isinstance(want, bool):
+            # `is`, not `==`: a raw 1 from the wire would satisfy `== True`
+            # and reach a binary sensor as an int.
+            assert got is want, key
+        elif isinstance(want, float):
+            assert got == pytest.approx(want, rel=1e-9), key
+        else:
+            assert got == want, key
+
+
+class TestFixture:
+    def test_the_fixture_carries_the_capture_it_claims_to(self) -> None:
+        """A shrunk or re-cut fixture must not quietly narrow the tests."""
+        frames = _frames(FIXTURE)
+        assert len(frames) == 15
+
+        property_21 = [
+            f for f in frames
+            if f["topic"] == "property" and f["cmds"] == [{"cmd_func": 254, "cmd_id": 21}]
+        ]
+        property_22 = [
+            f for f in frames
+            if f["topic"] == "property" and f["cmds"] == [{"cmd_func": 254, "cmd_id": 22}]
+        ]
+        get_reply = [f for f in frames if f["topic"] == "get_reply"]
+
+        assert len(property_21) == 9
+        assert len(property_22) == 3
+        assert len(get_reply) == 3
+        assert all(len(f["cmds"]) == 2 for f in get_reply)
+
+
+class TestSmartMeterParser:
+    @pytest.mark.parametrize("index", sorted(_EXPECTED))
+    def test_frame_decodes_to_the_reported_reading(self, index: int) -> None:
+        _assert_matches(parse_smart_meter_message(_payload(index)), _EXPECTED[index])
+
+    def test_the_full_upload_carries_the_whole_meter(self) -> None:
+        """Frame 4, the 146-byte full upload, is the widest frame captured."""
+        result = parse_smart_meter_message(_payload(4))
+
+        assert result is not None
+        assert len(result) == 19
+        assert result["grid_w"] == pytest.approx(406.65173, rel=1e-6)
+        # The phases do not multiply out: 239.44 V at 2.107 A against
+        # 317.8 W on L2. That is the meter separating apparent from active
+        # power, and no factor may be applied to reconcile them.
+        assert result["grid_l2_voltage_v"] == pytest.approx(239.44182, rel=1e-6)
+        assert result["grid_l2_current_a"] == pytest.approx(2.1072934, rel=1e-6)
+        assert result["grid_l2_w"] == pytest.approx(317.8154, rel=1e-6)
+        assert result["grid_connection_state"] == "grid_in"
+
+    def test_the_bundled_get_reply_frames_decode_unmasked(self) -> None:
+        """The three bundles carry no enc_type, so the plain bytes are used.
+
+        A masked-only reader would return None for all three, and the
+        integration would lose the only frames that arrive on request.
+        """
+        for index in (1, 9, 10):
+            result = parse_smart_meter_message(_payload(index))
+            assert result is not None, index
+            assert result["grid_connection_state"] == "grid_in"
+
+    @pytest.mark.parametrize("index", _RUNTIME_ONLY)
+    def test_upload_period_frames_carry_no_reading(self, index: int) -> None:
+        """254/22 is upload periods only and is deliberately unmapped."""
+        assert parse_smart_meter_message(_payload(index)) is None
+
+    def test_the_aggregate_never_comes_from_a_phase(self) -> None:
+        """515 is the app's current power; the phases must not sum into it.
+
+        Frame 10 is the one frame in the capture where the meter disagrees
+        with itself: it reports 429.0445 W on 515 while its phases add to
+        428.2924 W. A parser that summed the phases would pass every other
+        assertion in this file and fail here, which is the whole point of
+        picking this frame rather than one where the two agree to a watt.
+        """
+        result = parse_smart_meter_message(_payload(10))
+        assert result is not None
+
+        phase_sum = (
+            result["grid_l1_w"] + result["grid_l2_w"] + result["grid_l3_w"]
+        )
+        assert result["grid_w"] == pytest.approx(429.0445251464844, rel=1e-9)
+        assert phase_sum == pytest.approx(428.2923965454102, rel=1e-9)
+        assert result["grid_w"] != pytest.approx(phase_sum, rel=1e-6)
+
+
+class TestFieldMapIsPinned:
+    """Mutation controls: the map is held by these tests, not by a comment."""
+
+    def test_removing_a_scalar_field_removes_exactly_its_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        assert "grid_l2_w" in (parse_smart_meter_message(_payload(4)) or {})
+
+        reduced = {
+            number: mapping
+            for number, mapping in _SMART_METER_FIELD_MAP[(254, 21)].items()
+            if number != 963
+        }
+        monkeypatch.setitem(_SMART_METER_FIELD_MAP, (254, 21), reduced)
+
+        result = parse_smart_meter_message(_payload(4))
+        assert result is not None
+        assert "grid_l2_w" not in result
+        assert "grid_l3_w" in result
+
+    def test_removing_an_energy_subfield_removes_exactly_its_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        assert "grid_energy_today_wh" in (parse_smart_meter_message(_payload(4)) or {})
+
+        monkeypatch.delitem(_ENERGY_RECORD_MAP, 4)
+
+        result = parse_smart_meter_message(_payload(4))
+        assert result is not None
+        assert "grid_energy_today_wh" not in result
+        assert "grid_energy_total_wh" in result
+
+
+class TestGuards:
+    def test_a_non_254_command_yields_nothing(self) -> None:
+        """Only 254/21 is mapped; a battery frame must not be read as a meter."""
+        inner = _encode_fixed32_field(515, 1234.0)
+        assert parse_smart_meter_message(_build_frame(32, 50, inner)) is None
+
+    def test_an_unknown_grid_state_never_reaches_a_sensor_as_an_integer(self) -> None:
+        inner = bytearray()
+        inner.extend(_encode_fixed32_field(515, 100.0))
+        inner.extend(encode_field_varint(619, 9))
+
+        result = parse_smart_meter_message(_build_frame(254, 21, bytes(inner)))
+
+        assert result is not None
+        assert result["grid_connection_state"] is None
+
+    def test_a_zero_lifetime_counter_is_dropped(self) -> None:
+        """A lifetime counter at 0 is a glitch, not a reading.
+
+        The daily counters are the opposite case: they reset every night, so
+        a zero there is a reading and stays.
+        """
+        record = bytearray()
+        record.extend(_encode_fixed32_field(1, 0.0))
+        record.extend(_encode_fixed32_field(4, 0.0))
+        record.extend(_encode_fixed32_field(7, 0.0))
+        inner = encode_field_bytes(773, bytes(record))
+
+        result = parse_smart_meter_message(_build_frame(254, 21, inner))
+
+        assert result is not None
+        assert "grid_energy_total_wh" not in result
+        assert result["grid_l1_energy_today_wh"] == 0.0
+        assert result["grid_energy_today_wh"] == 0.0
+
+    def test_a_stream_frame_produces_no_meter_specific_reading(self) -> None:
+        """A BK31/BK01 Stream frame must not be read as a meter.
+
+        Three fields are genuinely shared with the Stream line, because both
+        speak the same BK-series message: the aggregate 515 and the state
+        and power factor at 618/619. What separates the two devices is the
+        device type that picks the parser, not the field numbers. Everything
+        this meter is bought for - the per-phase readings and the import
+        counters - must stay absent from a Stream frame, and does.
+        """
+        meter_only = {
+            "grid_l1_w", "grid_l2_w", "grid_l3_w",
+            "grid_l1_voltage_v", "grid_l2_voltage_v", "grid_l3_voltage_v",
+            "grid_l1_current_a", "grid_l2_current_a", "grid_l3_current_a",
+            "grid_l1_energy_today_wh", "grid_l2_energy_today_wh",
+            "grid_l3_energy_today_wh",
+            "grid_energy_today_wh", "grid_energy_total_wh",
+            "grid_l1_connected", "grid_l2_connected", "grid_l3_connected",
+        }
+
+        decoded_any = False
+        for frame in _frames(STREAM_FIXTURE):
+            result = parse_smart_meter_message(bytes.fromhex(frame["hex"]))
+            if result is None:
+                continue
+            decoded_any = True
+            assert not meter_only & set(result), sorted(meter_only & set(result))
+
+        # Positive control: without it the loop above passes on a fixture
+        # that decoded to nothing at all.
+        assert decoded_any


### PR DESCRIPTION
## Summary

The native EcoFlow Smart Meter (`BK21`, EF-EM-P3-120) gets its own device type and a read-only parser for its status report in Enhanced Mode: grid power, per-phase power, voltage and current, energy today and in total, grid state and per-phase connection flags (17 sensors, 3 binary sensors).

Ref #331

## Evidence

- Field map decoded from the reporter's 17-minute Enhanced Mode capture (15 frames, three message types) and checked against the app screenshot from the same installation: per-phase 0 / 307 / 90 W, aggregate 396 W, 1.49 kWh, 240 V range all reproduce.
- The developer API returns an empty quota for the meter, so a developer-key entry skips it with one warning and the device picker marks it as Enhanced-only instead of listing it clean and pre-selected.
- Energy keys are direction-neutral: the capture never exported, so whether the running total is net or import only is unproven. The lifetime counter carries state class `total`, the daily counters `total_increasing`. Today's and the lifetime counter were identical in every frame (meter installed the same day); a capture across midnight is requested from the reporter.
- Fields the schema defines but no frame carried (reactive and apparent power, signal strength) stay out. The schema has no export counter.
- The protobuf field walk moved into the Stream parser module; the meter parser reuses it.

## Tests

- `./scripts/dev/run_tests.sh`: 2968 passed (25 parser tests pinned to the fixture with mutation controls, 16 entity tests feeding a real frame through the coordinator, config-flow mode-boundary tests, Standard-mode skip test).
- Fixture frames carry no serial; the reporter's timezone string inside the masked frame was re-masked under the same key.
