### PR TITLE
fix(powerocean): restore the scheduled charge controls with the app's power bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [1.19.0] - 2026-09-01
 
+### Changed
+
+- PowerOcean scheduled charge tasks expose their enable switch, charge-power number and time-window sensor again in Enhanced Mode (beta.2). Version 1.18.1 had withheld them; the write path was verified on real hardware before it first shipped, with the device's own task list as the read-back. The charge-power number now follows the app's own limits: steps of 100 W, a minimum of 100 W per online battery pack and a maximum per model, and a value outside them is refused rather than rounded. (Ref #328)
+
 ### Added
 
 - EcoFlow Smart Meter (`BK21`, EF-EM-P3-120) is recognised as its own device in Enhanced Mode: grid power, per-phase power, voltage and current, energy today and in total, per-phase energy today, power factor, grid state and per-phase connection flags. Read-only; the developer API exposes no data for this meter, so Standard Mode does not apply, and the device picker now marks the meter as needing Enhanced Mode, leaves it unticked on the developer-key path and refuses the selection there rather than setting up entities that could never fill. The energy counters are named after what they measure rather than after a direction. The app labels them as import, and there is no separate export counter in the message definition to set that against, so a day on which the house exports is the first thing that will show whether they hold import only or a net figure. Until that day exists the lifetime counter is published as a plain total, which reads a decrease as a negative delta rather than as a meter change; the daily counters do reset to zero at midnight by design and carry the monotonic class that reset is built for. Field map verified against the reporter's capture and app screenshot. (Ref #331)

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@
 
 | Device | Serial prefix | Sensors | Controls | Energy Sensors | Update Rate |
 |:---|:---|:---:|:---:|:---:|:---|
-| **PowerOcean** - Home Battery | `HJ31` `HJ32` `HJ35` `HJ36` `HJ37` `J32B` `J327`\* `J329` `J32D`\* `J32E`\* | 227 + 13 binary | 2 numbers, 1 select (Enhanced only) | 6 (solar, grid import/export, battery charge/discharge, home) | ~30 s standard / ~3 s enhanced |
-| **PowerOcean Plus** - 3-phase Hybrid | `R371`\* `R372`\* `R374`\* `HJ3C`\* | 227 + 13 binary | 2 numbers, 1 select (Enhanced only) | 6 (solar, grid import/export, battery charge/discharge, home) | ~3 s enhanced |
+| **PowerOcean** - Home Battery | `HJ31` `HJ32` `HJ35` `HJ36` `HJ37` `J32B` `J327`\* `J329` `J32D`\* `J32E`\* | 235 + 13 binary | 10 numbers, 8 switches, 1 select (Enhanced only) | 6 (solar, grid import/export, battery charge/discharge, home) | ~30 s standard / ~3 s enhanced |
+| **PowerOcean Plus** - 3-phase Hybrid | `R371`\* `R372`\* `R374`\* `HJ3C`\* | 235 + 13 binary | 10 numbers, 8 switches, 1 select (Enhanced only) | 6 (solar, grid import/export, battery charge/discharge, home) | ~3 s enhanced |
 | **Delta 2 Max** - Portable Power | `R351` `R331` | 94 + 4 binary | 7 switches, 8 numbers | 4 (solar 1+2, AC in/out) | ~30 s standard (+ MQTT push) |
 | **Delta 3** - Portable Power | `D3M1` `D3N1` `P321` `P231` `P351` | 47 | 7 switches, 4 numbers, 5 selects (selects and 1 number Enhanced only); `D3M` serials add 3 switches, 3 numbers and 1 binary sensor for port priority | 4 (solar 1+2, AC in, output) | ~30 s standard / ~2 s enhanced |
 | **Smart Plug** - Switchable Outlet | `HW52` | 11 + 1 binary | 1 switch, 2 numbers | 1 (total energy) | ~30 s standard / ~3 s enhanced |
@@ -88,10 +88,6 @@
 - **Backup Reserve** (`number`, 0-100%) - minimum SoC the system keeps in reserve. Same slider as "Backup-Reserve" in the EcoFlow app.
 - **Solar Surplus Threshold** (`number`, 0-100%) - SoC above which surplus solar is routed to controllable devices. Same slider as "Prioritize controllable devices (Beta)" in the app.
 - **Work Mode** (`select`) - Self-use ("Eigenstromversorgung") or AI Schedule ("Intelligenter Modus"). TOU and Backup modes are deferred (require additional sub-parameters).
-
-Existing scheduled grid-charge tasks expose only their device-reported
-**Running** status. Schedule timing, arming and charge power remain managed in
-the EcoFlow app until safe writable bounds and persisted read-back are known.
 
 The integration enforces the app's `backup_reserve <= solar_surplus_threshold` constraint automatically.
 

--- a/custom_components/ecoflow_energy/__init__.py
+++ b/custom_components/ecoflow_energy/__init__.py
@@ -141,12 +141,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 # withdrawn because the device reports its charge mode only when that mode
 # changes, which is far too rarely for a control that has to show where the
 # device stands.
-_WITHDRAWN_ENTITY_SUFFIXES: tuple[str, ...] = (
-    "_ac_charge_mode",
-    *(f"_schedule_{index}_{suffix}" for index in range(1, 9) for suffix in (
-        "enabled", "power_w", "window",
-    )),
-)
+_WITHDRAWN_ENTITY_SUFFIXES: tuple[str, ...] = ("_ac_charge_mode",)
 
 # HW51 PowerStream microinverters could once be classified as Stream batteries.
 # These are the Stream-only platform/key pairs exposed by v1.17. The 16 sensor

--- a/custom_components/ecoflow_energy/const.py
+++ b/custom_components/ecoflow_energy/const.py
@@ -20,6 +20,9 @@ from .ecoflow.const import (  # noqa: E402
     DEVICE_TYPE_STREAM,
     DEVICE_TYPE_STREAM_AC5000,
     DEVICE_TYPE_UNKNOWN,
+    POWEROCEAN_SCHEDULE_POWER_MAX_DEFAULT_W,
+    POWEROCEAN_SCHEDULE_POWER_MIN_W,
+    POWEROCEAN_SCHEDULE_POWER_STEP_W,
     get_device_name,
     get_device_type,
 )
@@ -249,6 +252,14 @@ ENERGY_STREAM_KEEPALIVE_S = 20  # Re-send EnergyStreamSwitch every 20s
 QUOTAS_KEEPALIVE_S = 30  # latestQuotas poll interval (app-level keepalive)
 APP_SURPLUS_SYNC_MIN_INTERVAL_S = 30.0  # min interval between auto-sync SETs that mirror EmsParamChangeReport.dev_soc into the EMS sysBatBackupRatio
 APP_SURPLUS_SYNC_USER_GRACE_S = 5.0  # ignore discrepancy briefly after a user SET to wait for the device echo
+# How long an arming flag this integration just wrote is held against a device
+# frame that disagrees with it. The device acknowledges a scheduled-task write
+# in about 0.2 s and its task list already carries the change by then, so the
+# only frame that can still hold the old flag is one that left the device
+# before the write arrived. This window has to outlive such a frame and
+# nothing more; it matches the entity-side optimistic lock so both expire
+# together. A frame that agrees with the write clears it immediately.
+POWEROCEAN_SCHEDULE_ARMED_LATCH_S = 5.0
 POWEROCEAN_SOC_DEBOUNCE_S = 0.3  # coalesce slider-drag SETs into one frame; the device cannot keep up with 5%-step sets at 100ms cadence and the EMS/App-layer fields desync
 # The two state keys the PowerOcean SoC sliders write. They are sent as one
 # frame, so a failed write has to undo both. Kept next to the debounce window
@@ -615,19 +626,42 @@ POWEROCEAN_BINARY_SENSORS: list[EcoFlowBinarySensorDef] = [
 
 # --- Scheduled charge tasks ---
 #
-# A PowerOcean has a schedule only when its owner created one in the app. The
-# parser keeps the full task fields for diagnostics and future protocol work,
-# but only the device-reported running flag is exposed. Writable bounds and a
-# correlated persisted read-back are not established well enough to expose
-# the other task fields safely.
+# A PowerOcean has a schedule only when its owner created one in the app, and
+# most owners never do. The device reports its whole task list, so a slot that
+# exists produces schedule_N_* keys and a slot that does not produces nothing
+# at all. Both readings are therefore accessory-gated: the entity appears on
+# the first report that carries its index, and a schedule deleted later leaves
+# the entity unknown rather than frozen on its last reading, because the list
+# retracts the keys it stops mentioning.
 #
 # The upper bound comes from the parser that produces the keys, so the two
 # sides cannot drift apart. It is a guard against a malformed list, not an
 # assumption about how many slots the hardware has - only slot 1 has ever been
 # observed.
 #
-# The task list lives on the app channel, so the flag is Enhanced-only.
+# Two things stay open and neither blocks these readings. The power the device
+# accepts has only ever been seen at 1000 and 1500 W, so the range the write
+# validates against is ours rather than the firmware's; and the three
+# recurrence fields are echoed back exactly as the device reported them,
+# never composed here, so the days and times an owner set in the app cannot
+# be rewritten from Home Assistant.
+#
+# Both the task list and the command that changes it live on the app channel,
+# so with developer keys these would be created and never fill.
 for _schedule_index in range(1, SCHEDULE_MAX_INDEX + 1):
+    POWEROCEAN_SENSORS.append(
+        EcoFlowSensorDef(
+            f"schedule_{_schedule_index}_window",
+            f"Schedule {_schedule_index} Window",
+            None,
+            None,
+            None,
+            "mdi:calendar-clock",
+            None,
+            enhanced_only=True,
+            accessory=True,
+        )
+    )
     POWEROCEAN_BINARY_SENSORS.append(
         EcoFlowBinarySensorDef(
             f"schedule_{_schedule_index}_running",
@@ -673,9 +707,51 @@ POWEROCEAN_SELECTS: list[EcoFlowSelectDef] = [
 ]
 
 
-# Schedule configuration remains read-only at the protocol layer until safe
-# bounds and correlated persistence evidence exist.
+# --- Scheduled charge task controls ---
+#
+# The write side of the schedule readings above. Same gate for the same
+# reason: the definition exists for every slot the device can number, and the
+# entity is created on the first report that carries that slot. A PowerOcean
+# whose owner never made a schedule gets no controls at all.
+#
+# Neither control creates or deletes a task. Creating one means composing a
+# recurrence rather than echoing the device's own, and deleting one cannot be
+# undone from here while creating is out, so a slot is made in the app first
+# and these two change what it does from then on.
 POWEROCEAN_SWITCHES: list[EcoFlowSwitchDef] = []
+
+for _schedule_index in range(1, SCHEDULE_MAX_INDEX + 1):
+    POWEROCEAN_SWITCHES.append(
+        EcoFlowSwitchDef(
+            f"schedule_{_schedule_index}_enabled",
+            f"Schedule {_schedule_index} Enabled",
+            f"schedule_{_schedule_index}_enabled",
+            "mdi:calendar-check-outline",
+            enhanced_only=True,
+            accessory=True,
+        )
+    )
+    # The range is the app's own prompt: minimum 100 W per online battery
+    # pack, maximum per model, step 100 W. Whether the device enforces
+    # anything beyond that is unobserved - no write was ever refused, and the
+    # only two figures on file are 1000 and 1500, both on that grid. The
+    # declared bounds below are the fallback; the entity narrows the minimum
+    # to the reported pack count and the maximum to the serial prefix, which
+    # is exactly what the app does.
+    POWEROCEAN_NUMBERS.append(
+        EcoFlowNumberDef(
+            f"schedule_{_schedule_index}_power_w",
+            f"Schedule {_schedule_index} Charge Power",
+            f"schedule_{_schedule_index}_power_w",
+            "W",
+            "mdi:battery-charging-outline",
+            POWEROCEAN_SCHEDULE_POWER_MIN_W,
+            POWEROCEAN_SCHEDULE_POWER_MAX_DEFAULT_W,
+            POWEROCEAN_SCHEDULE_POWER_STEP_W,
+            enhanced_only=True,
+            accessory=True,
+        )
+    )
 
 
 # =====================================================================

--- a/custom_components/ecoflow_energy/coordinator/core.py
+++ b/custom_components/ecoflow_energy/coordinator/core.py
@@ -237,6 +237,13 @@ class EcoFlowDeviceCoordinator(
         # Whether a Stream ever reported the system state of charge; once it
         # has, a unit's own figure no longer stands in for it (#323).
         self._soc_from_system = False
+        # Arming flags this integration has just written, each with the value
+        # sent and the monotonic time the hold expires. A scheduled-task write
+        # seeds the flag before it sends, and a device frame that was already
+        # in flight would otherwise put the old flag back - a later power
+        # write reads the flag out of the store and would then re-send the
+        # reverted one, undoing what the owner just asked for.
+        self._schedule_armed_latch: dict[str, tuple[bool, float]] = {}
         # Debounce state for the PowerOcean SoC SET. HA Number-Entity sliders
         # send one SET per 5%-step during a mouse drag, which arrives at the
         # device at ~100 ms cadence. The device cannot keep all SETs in sync

--- a/custom_components/ecoflow_energy/coordinator/set_commands.py
+++ b/custom_components/ecoflow_energy/coordinator/set_commands.py
@@ -14,6 +14,11 @@ from ..const import (
     POWEROCEAN_SOC_DEBOUNCE_S,
     POWEROCEAN_SOC_STATE_KEYS,
 )
+from ..ecoflow.const import (
+    POWEROCEAN_SCHEDULE_POWER_STEP_W,
+    schedule_power_max_w,
+    schedule_power_min_w,
+)
 from ..ecoflow.frame_capture import sanitize_frame
 from ..entity import as_known_int
 
@@ -429,6 +434,146 @@ class SetCommandsMixin:
             _LOGGER.warning("Work-mode SET failed: %d (%s)", work_mode, self.device_sn[:4])
             self._log_event("set_work_mode_fail", str(work_mode))
         return ok
+
+    # ------------------------------------------------------------------
+    # PowerOcean scheduled charge tasks (96/125)
+    # ------------------------------------------------------------------
+
+    async def async_set_powerocean_schedule_armed(
+        self, task_index: int, armed: bool,
+    ) -> bool:
+        """Arm or disarm one scheduled charge task.
+
+        A short frame that carries nothing but the slot, so it needs no value
+        from the last read. The slot itself still has to be there. A task the
+        owner deletes in the app simply drops out of the device's task list,
+        and the parser then retracts every key of that slot to None - which
+        leaves the switch standing and toggleable, since a key that is present
+        and None still counts as reported. Sending against a slot the device
+        no longer holds would name a task that does not exist and then show it
+        as armed, so an arming flag that is not a bool refuses the write.
+
+        The flag is seeded before the send rather than after it, because a
+        power change on the same slot has to carry the arming along and the
+        two writes share this lock: a seed that lands after the next read
+        would let that write send the flag it just replaced. The same seed is
+        held against a device frame that was already in flight, for the window
+        named by `POWEROCEAN_SCHEDULE_ARMED_LATCH_S`. A failed send puts the
+        previous value back and drops the hold with it.
+
+        A write that starts during unload is refused outright. Every state it
+        touches - the seed, the hold, the rollback - belongs to a coordinator
+        that is being torn down, and the same guard sits on the other
+        PowerOcean writes for the same reason.
+        """
+        from ..ecoflow.energy_stream import build_timer_task_set_payload
+
+        if self._shutdown:
+            return False
+        state_key = f"schedule_{task_index}_enabled"
+        async with self._device_config_lock:
+            previous = self.device_data.get(state_key)
+            if not isinstance(previous, bool):
+                raise DeviceValueNotReported(f"schedule {task_index} enabled")
+            payload = build_timer_task_set_payload(
+                "arm" if armed else "disarm",
+                task_index,
+                device_sn=self.device_sn,
+            )
+            self._seed_device_values(**{state_key: armed})
+            self.latch_schedule_armed(state_key, armed)
+            if not await self.async_send_proto_set_command(
+                payload, label=f"powerocean_schedule_{task_index}_armed"
+            ):
+                self._seed_device_values(**{state_key: previous})
+                self.clear_schedule_armed_latch(state_key)
+                return False
+            return True
+
+    async def async_set_powerocean_schedule_power(
+        self, task_index: int, power_w: int,
+    ) -> bool:
+        """Change the charge power of one scheduled task.
+
+        The full body carries the whole task, so four fields the device owns
+        travel with it: the task type and the three that hold the recurrence.
+        They go out exactly as the last read reported them. Composing a
+        default for a missing one would rewrite the days and times the owner
+        set in the app, which is the one thing this write refuses to risk, so
+        an unreported field raises `DeviceValueNotReported` instead.
+
+        The arming flag travels too. A full body clears it as a side effect,
+        and the device's own task list confirms that a frame carrying field 4
+        leaves the schedule armed, so the current flag is read and sent back.
+
+        The power itself is checked against the range the app offers for this
+        model - 100 W per online battery pack up to the prefix ceiling, on the
+        100 W grid - and a value outside it raises `ValueError` rather than
+        being rounded onto the grid.
+
+        Refused during unload for the same reason as the arming write above.
+        """
+        from ..ecoflow.energy_stream import build_timer_task_set_payload
+
+        if self._shutdown:
+            return False
+        prefix = f"schedule_{task_index}_"
+        async with self._device_config_lock:
+            data = self.device_data
+            echoed: dict[str, int] = {}
+            for name, suffix in (
+                ("task_type", "type"),
+                ("time_mode", "time_mode"),
+                ("time_param", "time_param"),
+                ("time_table", "time_table"),
+            ):
+                value = as_known_int(data.get(f"{prefix}{suffix}"))
+                if value is None:
+                    raise DeviceValueNotReported(
+                        f"schedule {task_index} {suffix}"
+                    )
+                echoed[name] = value
+
+            armed = data.get(f"{prefix}enabled")
+            if not isinstance(armed, bool):
+                raise DeviceValueNotReported(f"schedule {task_index} enabled")
+
+            # The app's own range, checked here as well as on the entity: a
+            # service call carries any number the caller likes, and the
+            # entity's step and bounds only constrain the slider. Refused
+            # rather than rounded - a value off the 100 W grid is one no app
+            # has ever sent, so silently moving it would put a setpoint on the
+            # wire that nobody asked for.
+            floor = schedule_power_min_w(as_known_int(data.get("bp_online_sum")))
+            ceiling = schedule_power_max_w(self.device_sn)
+            if power_w < floor or power_w > ceiling:
+                raise ValueError(
+                    f"charge power {power_w} W is outside the range this model "
+                    f"accepts ({floor}-{ceiling} W)"
+                )
+            if power_w % POWEROCEAN_SCHEDULE_POWER_STEP_W:
+                raise ValueError(
+                    f"charge power {power_w} W is not a multiple of "
+                    f"{POWEROCEAN_SCHEDULE_POWER_STEP_W} W"
+                )
+
+            state_key = f"{prefix}power_w"
+            previous = data.get(state_key, _UNSET)
+            payload = build_timer_task_set_payload(
+                "power",
+                task_index,
+                device_sn=self.device_sn,
+                power_w=power_w,
+                armed=armed,
+                **echoed,
+            )
+            self._seed_device_values(**{state_key: power_w})
+            if not await self.async_send_proto_set_command(
+                payload, label=f"powerocean_schedule_{task_index}_power"
+            ):
+                self._restore_device_values(**{state_key: previous})
+                return False
+            return True
 
     # ------------------------------------------------------------------
     # Stream BK-series SoC config writes (254/17)

--- a/custom_components/ecoflow_energy/coordinator/state_apply.py
+++ b/custom_components/ecoflow_energy/coordinator/state_apply.py
@@ -10,6 +10,7 @@ from ..const import (
     APP_SURPLUS_SYNC_MIN_INTERVAL_S,
     APP_SURPLUS_SYNC_USER_GRACE_S,
     DEVICE_TYPE_POWEROCEAN,
+    POWEROCEAN_SCHEDULE_ARMED_LATCH_S,
 )
 from ..ecoflow.parsers.stream_ac5000_proto import UNIT_POWER_BY_SN_KEY
 from ..ecoflow.parsers.stream_proto import SOC_FALLBACK_KEY
@@ -72,6 +73,48 @@ class StateApplyMixin:
         if own is not None:
             parsed["unit_batt_w"] = own
 
+    def _resolve_schedule_armed(self, parsed: dict[str, Any]) -> None:
+        """Hold a just-written arming flag against a frame that predates it.
+
+        A scheduled-task write seeds `schedule_N_enabled` in the store before
+        it sends, because the power write for the same slot reads the flag
+        back out of the store and carries it along. A device frame that left
+        before the write arrived would put the old flag back, and the next
+        power change would then re-send it - re-arming a schedule the owner
+        had just disarmed, which is the one side effect this write exists to
+        avoid.
+
+        So a flag under the hold wins over a frame that disagrees with it, and
+        loses to one that agrees: an agreeing frame is the device confirming
+        the write, which ends the hold there and then. Only the flag is held.
+        Everything else the frame carries, this slot included, is applied.
+        """
+        if not self._schedule_armed_latch:
+            return
+        now = time.monotonic()
+        for key, (written, until) in list(self._schedule_armed_latch.items()):
+            expired = now >= until
+            if key in parsed:
+                if parsed[key] == written:
+                    del self._schedule_armed_latch[key]
+                    continue
+                if not expired:
+                    del parsed[key]
+                    continue
+            if expired:
+                del self._schedule_armed_latch[key]
+
+    def latch_schedule_armed(self, state_key: str, armed: bool) -> None:
+        """Start the hold for one arming flag this integration just sent."""
+        self._schedule_armed_latch[state_key] = (
+            armed,
+            time.monotonic() + POWEROCEAN_SCHEDULE_ARMED_LATCH_S,
+        )
+
+    def clear_schedule_armed_latch(self, state_key: str) -> None:
+        """Drop the hold for one arming flag, used when the send failed."""
+        self._schedule_armed_latch.pop(state_key, None)
+
     def _apply_data(self, parsed: dict[str, Any]) -> None:
         """Apply parsed data and notify listeners (HA event loop)."""
         from .core import DeviceSnapshot
@@ -99,6 +142,7 @@ class StateApplyMixin:
             self._last_ems_param_change_ts = now
         self._resolve_unit_power(parsed)
         self._resolve_soc(parsed)
+        self._resolve_schedule_armed(parsed)
         self._note_value_change(parsed)
         self._device_data.update(parsed)
 

--- a/custom_components/ecoflow_energy/ecoflow/const.py
+++ b/custom_components/ecoflow_energy/ecoflow/const.py
@@ -238,6 +238,75 @@ _SN_PREFIX_DISPLAY_NAMES: dict[str, str] = {
     "BK21": "Smart Meter",
 }
 
+# --- Scheduled charge task: the charge power range the app offers ---
+#
+# The app does not read this range from the device. It opens the power prompt
+# with a ceiling picked by product family and refined per model by the first
+# four characters of the serial, and with a floor of 100 W per online battery
+# pack. The step is 100 W. There is no heartbeat field carrying any of it; the
+# only device-reported input is the pack count, which the floor uses.
+POWEROCEAN_SCHEDULE_POWER_MAX_W: dict[str, int] = {
+    # Three-phase units, per model.
+    "HJ31": 10000,
+    "HJ35": 6000,
+    "HJ36": 8000,
+    "HJ37": 12000,
+    # Single-phase units. The app multiplies this by the number of linked
+    # units when a system runs in parallel. Nothing in this integration reads
+    # that count, so a parallel installation is offered the single-unit
+    # ceiling rather than a guessed multiple of it.
+    "J32B": 6000,
+    "J32D": 6000,
+    "J32E": 6000,
+    "J327": 6000,
+    "J329": 6000,
+    # PowerOcean Plus.
+    "R371": 29900,
+    "R372": 29900,
+    "R374": 29900,
+}
+
+# What a prefix outside the table above gets: the value its product family
+# carries, which is what the app falls back to when no per-model override
+# exists. A new PowerOcean prefix therefore lands on its family ceiling
+# instead of on the builder's 30000 W guard.
+_POWEROCEAN_SCHEDULE_POWER_MAX_FAMILY_W: tuple[tuple[str, int], ...] = (
+    ("HJ3", 10000),
+    ("J32", 6000),
+    ("R37", 29900),
+)
+
+# The grid every value sits on, and the floor for one pack. Also the floor
+# used when the pack count has not been reported: never 0, because the app
+# cannot send 0 and the device's answer to it has never been seen.
+POWEROCEAN_SCHEDULE_POWER_STEP_W = 100
+POWEROCEAN_SCHEDULE_POWER_MIN_W = 100
+POWEROCEAN_SCHEDULE_POWER_MAX_DEFAULT_W = 10000
+
+
+def schedule_power_max_w(sn: str) -> int:
+    """Return the scheduled charge power ceiling for this unit, in watts."""
+    prefix = (sn or "")[:4].upper()
+    exact = POWEROCEAN_SCHEDULE_POWER_MAX_W.get(prefix)
+    if exact is not None:
+        return exact
+    for family, ceiling in _POWEROCEAN_SCHEDULE_POWER_MAX_FAMILY_W:
+        if prefix.startswith(family):
+            return ceiling
+    return POWEROCEAN_SCHEDULE_POWER_MAX_DEFAULT_W
+
+
+def schedule_power_min_w(online_battery_packs: int | None) -> int:
+    """Return the scheduled charge power floor, in watts.
+
+    100 W per online battery pack, which is the app's own rule. A pack count
+    that has not been reported yet gives the one-pack floor rather than zero.
+    """
+    if online_battery_packs is None or online_battery_packs < 1:
+        return POWEROCEAN_SCHEDULE_POWER_MIN_W
+    return online_battery_packs * POWEROCEAN_SCHEDULE_POWER_MIN_W
+
+
 def get_device_name(product_name: str, sn: str = "") -> str:
     """Return a human-friendly name for the device.
 

--- a/custom_components/ecoflow_energy/number.py
+++ b/custom_components/ecoflow_energy/number.py
@@ -36,6 +36,7 @@ from .const import (
 )
 from .coordinator import DeviceValueNotReported, EcoFlowDeviceCoordinator
 from .entity import (
+    raise_set_gone,
     as_known_int,
     EcoFlowWriteGateMixin,
     reading_reported,
@@ -48,6 +49,10 @@ from .ecoflow.delta3_commands import (
     build_number_command as build_delta3_number_command,
     build_port_priority_command,
     port_priority_soc_bounds,
+)
+from .ecoflow.const import (
+    schedule_power_max_w,
+    schedule_power_min_w,
 )
 from .ecoflow.energy_stream import stream_backup_reserve_floor
 from .ecoflow.parsers.delta3_proto import port_priority_keys
@@ -101,8 +106,8 @@ def _watch_for_accessory(
     the control steers and the only one the device sends. Every definition
     that reaches this path names the same string for both, so the two are
     interchangeable today; the read-back key is the one named because it is
-    the one a control has to wait for. An accessory can begin reporting while
-    Home Assistant runs, so the wait has no deadline.
+    the one a control has to wait for. A PowerOcean schedule can be created
+    in the app while Home Assistant runs, so the wait has no deadline.
     """
 
     @callback
@@ -265,8 +270,12 @@ class EcoFlowNumber(
         battery limit the user can change while HA runs, the Delta 3 port
         priority cutoffs and the Stream backup reserve. The third, the STREAM
         AC 5000 grid-tied output, follows a ceiling only EcoFlow can raise.
+        The scheduled charge power is a fourth of a different kind: its floor
+        follows the reported pack count, its ceiling the model.
         Every other number keeps the range its definition declares.
         """
+        if self._schedule_slot() is not None:
+            return self._schedule_power_bounds()
         if self._port_priority_stem() is not None:
             lower, upper = self._port_priority_bounds()
             return float(lower), float(upper)
@@ -327,6 +336,26 @@ class EcoFlowNumber(
             and self.coordinator.device_type == DEVICE_TYPE_STREAM
             and supports_stream_controls(self.coordinator.device_sn)
         )
+
+    def _schedule_power_bounds(self) -> tuple[float, float]:
+        """Return the charge power range the app would offer for this unit.
+
+        The floor is 100 W per online battery pack and the ceiling comes from
+        the serial prefix, which is exactly how the app builds this prompt:
+        neither is a device-reported rating, and no frame carries one. A pack
+        count that has not arrived yet gives the one-pack floor rather than
+        zero, because the app cannot send zero and what the device would do
+        with it has never been seen.
+        """
+        packs = as_known_int((self.coordinator.data or {}).get("bp_online_sum"))
+        upper = schedule_power_max_w(self.coordinator.device_sn)
+        lower = schedule_power_min_w(packs)
+        if lower > upper:
+            # More packs than the model's ceiling allows for at 100 W each.
+            # No installation looks like this, and a floor above the ceiling
+            # would leave a control that cannot be moved at all.
+            lower = schedule_power_min_w(None)
+        return float(lower), float(upper)
 
     def _port_priority_stem(self) -> str | None:
         """Return the port stem for a port priority cutoff, else None."""
@@ -503,6 +532,38 @@ class EcoFlowNumber(
         key = self._definition.key
         int_value = int(value)
 
+        slot = self._schedule_slot()
+        if slot is not None:
+            try:
+                ok = await self.coordinator.async_set_powerocean_schedule_power(
+                    slot, int_value
+                )
+            except DeviceValueNotReported:
+                # The write needs four fields the device owns, and composing
+                # one would rewrite the recurrence the owner set in the app.
+                # Two different situations reach here and they need different
+                # words: a schedule the device has stopped reporting is gone
+                # and will not come back on its own, while a slot that simply
+                # has not been reported yet resolves with the next frame. The
+                # armed flag tells them apart, because a retracted slot
+                # publishes it as None.
+                if not isinstance(
+                    self.coordinator.device_data.get(f"schedule_{slot}_enabled"),
+                    bool,
+                ):
+                    raise_set_gone(self.entity_id)
+                raise_set_not_ready(self.entity_id)
+            except ValueError as err:
+                raise_set_rejected(self.entity_id, str(err))
+            if not ok:
+                raise_set_failed(self.entity_id)
+            # The int, not the float Home Assistant handed in: the coordinator
+            # has already seeded this key with the int it put on the wire, and
+            # re-seeding the same key as a float would leave the type of a
+            # stored reading depending on which path last wrote it.
+            self._apply_optimistic_number(int_value)
+            return
+
         if self.coordinator.data is None:
             # Both PowerOcean sliders are sent as a pair, so the unchanged
             # one has to be read from coordinator data. Without data there
@@ -538,6 +599,22 @@ class EcoFlowNumber(
             return
 
         raise_set_unsupported(self.entity_id)
+
+    def _schedule_slot(self) -> int | None:
+        """Return the slot number for a PowerOcean schedule number, else None.
+
+        The device type is checked before the key, as the switch does: the
+        write this routes to is a PowerOcean frame, so a key of the same shape
+        on another device must not reach it. No other device defines one
+        today, and this is here so that adding one cannot quietly change where
+        it is sent.
+        """
+        if self.coordinator.device_type != DEVICE_TYPE_POWEROCEAN:
+            return None
+        key = self._definition.key
+        if not key.startswith("schedule_") or not key.endswith("_power_w"):
+            return None
+        return int(key[len("schedule_") : -len("_power_w")])
 
     async def _async_set_stream_value(self, key: str, value: float) -> bool:
         """Set a Stream AC Pro number value via WSS Protobuf SET.

--- a/custom_components/ecoflow_energy/switch.py
+++ b/custom_components/ecoflow_energy/switch.py
@@ -55,6 +55,7 @@ from .entity import (
     EcoFlowWriteGateMixin,
     reading_reported,
     raise_set_failed,
+    raise_set_gone,
     raise_set_not_ready,
     raise_set_rejected,
     raise_set_unsupported,
@@ -107,8 +108,8 @@ def _watch_for_accessory(
     the control steers and the only one the device sends. Every definition
     that reaches this path names the same string for both, so the two are
     interchangeable today; the read-back key is the one named because it is
-    the one a control has to wait for. An accessory can begin reporting while
-    Home Assistant runs, so the wait has no deadline.
+    the one a control has to wait for. A PowerOcean schedule can be created
+    in the app while Home Assistant runs, so the wait has no deadline.
     """
 
     @callback
@@ -226,6 +227,22 @@ class EcoFlowSwitch(
         received - the switch would show the wrong state for the whole
         lock window and then snap back.
         """
+        schedule_slot = self._schedule_slot()
+        if schedule_slot is not None:
+            try:
+                ok = await self.coordinator.async_set_powerocean_schedule_armed(
+                    schedule_slot, turn_on
+                )
+            except DeviceValueNotReported:
+                # The slot is not in the device's task list. The switch is
+                # still here because a retracted reading keeps its entity, but
+                # there is no task behind it to arm.
+                raise_set_gone(self.entity_id)
+            if not ok:
+                raise_set_failed(self.entity_id)
+            self._apply_optimistic(turn_on)
+            return
+
         # SmartPlug app-auth: use protobuf SET (JSON cmdCode only works on /open/ topic)
         if (
             self.coordinator.device_type == DEVICE_TYPE_SMARTPLUG
@@ -317,6 +334,15 @@ class EcoFlowSwitch(
         self._optimistic_value = turn_on
         self._optimistic_lock_until = time.monotonic() + OPTIMISTIC_LOCK_S
         self._write_state_always(turn_on)
+
+    def _schedule_slot(self) -> int | None:
+        """Return the slot number for a PowerOcean schedule switch, else None."""
+        if self.coordinator.device_type != DEVICE_TYPE_POWEROCEAN:
+            return None
+        key = self._definition.key
+        if not key.startswith("schedule_") or not key.endswith("_enabled"):
+            return None
+        return int(key[len("schedule_") : -len("_enabled")])
 
     def _port_priority_stem(self) -> str | None:
         """Return the port stem for a port priority switch, else None."""

--- a/custom_components/ecoflow_energy/translations/de.json
+++ b/custom_components/ecoflow_energy/translations/de.json
@@ -1565,6 +1565,30 @@
       },
       "grid_power_factor": {
         "name": "Leistungsfaktor"
+      },
+      "schedule_1_window": {
+        "name": "Zeitplan 1 Zeitfenster"
+      },
+      "schedule_2_window": {
+        "name": "Zeitplan 2 Zeitfenster"
+      },
+      "schedule_3_window": {
+        "name": "Zeitplan 3 Zeitfenster"
+      },
+      "schedule_4_window": {
+        "name": "Zeitplan 4 Zeitfenster"
+      },
+      "schedule_5_window": {
+        "name": "Zeitplan 5 Zeitfenster"
+      },
+      "schedule_6_window": {
+        "name": "Zeitplan 6 Zeitfenster"
+      },
+      "schedule_7_window": {
+        "name": "Zeitplan 7 Zeitfenster"
+      },
+      "schedule_8_window": {
+        "name": "Zeitplan 8 Zeitfenster"
       }
     },
     "binary_sensor": {
@@ -1704,6 +1728,30 @@
       },
       "ac_outlet_2_switch": {
         "name": "AC-Ausgang 2"
+      },
+      "schedule_1_enabled": {
+        "name": "Zeitplan 1 aktiv"
+      },
+      "schedule_2_enabled": {
+        "name": "Zeitplan 2 aktiv"
+      },
+      "schedule_3_enabled": {
+        "name": "Zeitplan 3 aktiv"
+      },
+      "schedule_4_enabled": {
+        "name": "Zeitplan 4 aktiv"
+      },
+      "schedule_5_enabled": {
+        "name": "Zeitplan 5 aktiv"
+      },
+      "schedule_6_enabled": {
+        "name": "Zeitplan 6 aktiv"
+      },
+      "schedule_7_enabled": {
+        "name": "Zeitplan 7 aktiv"
+      },
+      "schedule_8_enabled": {
+        "name": "Zeitplan 8 aktiv"
       }
     },
     "number": {
@@ -1778,6 +1826,30 @@
       },
       "max_grid_input_power_w": {
         "name": "Max. Netzbezugsleistung"
+      },
+      "schedule_1_power_w": {
+        "name": "Zeitplan 1 Ladeleistung"
+      },
+      "schedule_2_power_w": {
+        "name": "Zeitplan 2 Ladeleistung"
+      },
+      "schedule_3_power_w": {
+        "name": "Zeitplan 3 Ladeleistung"
+      },
+      "schedule_4_power_w": {
+        "name": "Zeitplan 4 Ladeleistung"
+      },
+      "schedule_5_power_w": {
+        "name": "Zeitplan 5 Ladeleistung"
+      },
+      "schedule_6_power_w": {
+        "name": "Zeitplan 6 Ladeleistung"
+      },
+      "schedule_7_power_w": {
+        "name": "Zeitplan 7 Ladeleistung"
+      },
+      "schedule_8_power_w": {
+        "name": "Zeitplan 8 Ladeleistung"
       }
     },
     "select": {

--- a/custom_components/ecoflow_energy/translations/en.json
+++ b/custom_components/ecoflow_energy/translations/en.json
@@ -1565,6 +1565,30 @@
       },
       "grid_power_factor": {
         "name": "Power Factor"
+      },
+      "schedule_1_window": {
+        "name": "Schedule 1 Window"
+      },
+      "schedule_2_window": {
+        "name": "Schedule 2 Window"
+      },
+      "schedule_3_window": {
+        "name": "Schedule 3 Window"
+      },
+      "schedule_4_window": {
+        "name": "Schedule 4 Window"
+      },
+      "schedule_5_window": {
+        "name": "Schedule 5 Window"
+      },
+      "schedule_6_window": {
+        "name": "Schedule 6 Window"
+      },
+      "schedule_7_window": {
+        "name": "Schedule 7 Window"
+      },
+      "schedule_8_window": {
+        "name": "Schedule 8 Window"
       }
     },
     "binary_sensor": {
@@ -1704,6 +1728,30 @@
       },
       "ac_outlet_2_switch": {
         "name": "AC Outlet 2"
+      },
+      "schedule_1_enabled": {
+        "name": "Schedule 1 Enabled"
+      },
+      "schedule_2_enabled": {
+        "name": "Schedule 2 Enabled"
+      },
+      "schedule_3_enabled": {
+        "name": "Schedule 3 Enabled"
+      },
+      "schedule_4_enabled": {
+        "name": "Schedule 4 Enabled"
+      },
+      "schedule_5_enabled": {
+        "name": "Schedule 5 Enabled"
+      },
+      "schedule_6_enabled": {
+        "name": "Schedule 6 Enabled"
+      },
+      "schedule_7_enabled": {
+        "name": "Schedule 7 Enabled"
+      },
+      "schedule_8_enabled": {
+        "name": "Schedule 8 Enabled"
       }
     },
     "number": {
@@ -1778,6 +1826,30 @@
       },
       "max_grid_input_power_w": {
         "name": "Max Grid Input Power"
+      },
+      "schedule_1_power_w": {
+        "name": "Schedule 1 Charge Power"
+      },
+      "schedule_2_power_w": {
+        "name": "Schedule 2 Charge Power"
+      },
+      "schedule_3_power_w": {
+        "name": "Schedule 3 Charge Power"
+      },
+      "schedule_4_power_w": {
+        "name": "Schedule 4 Charge Power"
+      },
+      "schedule_5_power_w": {
+        "name": "Schedule 5 Charge Power"
+      },
+      "schedule_6_power_w": {
+        "name": "Schedule 6 Charge Power"
+      },
+      "schedule_7_power_w": {
+        "name": "Schedule 7 Charge Power"
+      },
+      "schedule_8_power_w": {
+        "name": "Schedule 8 Charge Power"
       }
     },
     "select": {

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -8,7 +8,7 @@ For installation and quick-start, see the main [README](../README.md).
 
 Complete list of all sensors, switches, numbers, and binary sensors per device:
 
-- [PowerOcean](entities/powerocean.md) - 227 sensors, 13 binary sensors, 2 numbers, 1 select (`HJ31`, `HJ32`, `HJ35`, `HJ36`, `HJ37`, `J32B`, `J327`, `J329`, `J32D`, `J32E`, and the Plus variants `R371`, `R372`, `R374`, `HJ3C`)
+- [PowerOcean](entities/powerocean.md) - 235 sensors, 13 binary sensors, 10 numbers, 8 switches, 1 select (`HJ31`, `HJ32`, `HJ35`, `HJ36`, `HJ37`, `J32B`, `J327`, `J329`, `J32D`, `J32E`, and the Plus variants `R371`, `R372`, `R374`, `HJ3C`)
 - [Delta 2 Max](entities/delta-2-max.md) - 94 sensors, 4 binary sensors, 7 switches, 8 numbers (`R351`, `R331`)
 - [Delta 3 Max Plus](entities/delta-3-max-plus.md) - 47 sensors, 7 switches, 4 numbers, 5 selects (`D3M1`, `D3N1`, `P321`, `P231`), plus 3 switches, 3 numbers and 1 binary sensor for port priority on `D3M` serials
 - [Smart Plug](entities/smart-plug.md) - 11 sensors, 1 binary sensor, 1 switch, 2 numbers (`HW52`)

--- a/documentation/entities/powerocean.md
+++ b/documentation/entities/powerocean.md
@@ -31,17 +31,23 @@ Full list of all entities created for PowerOcean devices.
 > one starts, so the session energy is not a meter and is not meant for the
 > Energy Dashboard. There are no wallbox controls.
 
-> **Schedule status is optional and needs Enhanced Mode.** A PowerOcean only
-> has a schedule if you created one in the EcoFlow app. For each reported
-> schedule Home Assistant exposes only the device's Running flag. Timing,
-> arming and charge power stay in the EcoFlow app because safe writable bounds
-> and a correlated persisted read-back have not been established. The task
-> list travels on the real-time stream, which is why this status needs the
-> EcoFlow account sign-in.
+> **The schedule readings are optional and need Enhanced Mode.** A PowerOcean
+> only has a schedule if you created one yourself in the EcoFlow app, and most
+> systems never do, so having no schedule entities at all is the normal case
+> and not a fault. Four entities appear for each schedule your system reports:
+> a switch that turns it on and off, its charge power, the time of day it runs
+> and whether it is charging right now. Every change is confirmed against the
+> list the PowerOcean sends back, so the switch shows what the device did and
+> not merely what was asked of it. The list travels on the PowerOcean's
+> real-time stream, which is why these entities need the EcoFlow account
+> sign-in.
 >
-> **Schedule configuration stays in the EcoFlow app.** Deleting a schedule
-> there returns its Running entity to unknown instead of freezing the last
-> state.
+> **Creating and deleting a schedule stays in the EcoFlow app.** Home Assistant
+> can operate a schedule you made there, not invent one: without a way to
+> create, a delete from Home Assistant would be a one-way door. Delete one in
+> the app and its entities go back to unknown rather than staying on their last
+> value, and a write against it is refused with a message saying the schedule
+> is gone.
 >
 > Where the settings live in the app: **Settings > Automation > Schedule
 > charging and discharging**. Peak shaving sits on the same page and is a
@@ -50,7 +56,7 @@ Full list of all entities created for PowerOcean devices.
 
 > **PowerOcean Plus** units report more of the same entity set than a standard PowerOcean: per-phase reactive power (var) and apparent power (VA), plus MPPT strings 3 and 4. Those entities are disabled by default, so enable the ones you need after adding a Plus device.
 
-**Totals:** 227 sensors, 13 binary sensors, 2 numbers, 1 select
+**Totals:** 235 sensors, 13 binary sensors, 10 numbers, 8 switches, 1 select
 
 > Entities marked with *disabled* are available but hidden by default. Enable them in **Settings > Devices > EcoFlow PowerOcean > Entities** (click the filter icon and show disabled entities).
 
@@ -202,9 +208,16 @@ Created only for the schedules your system actually reports, up to eight. See th
 
 | Entity | Type | Description | Default |
 |:---|:---:|:---|:---:|
+| Schedule 1 Enabled | Switch | Turns the schedule on and off. Reads back from the list the device sends, so it shows the state the PowerOcean actually holds | enabled |
+| Schedule 1 Charge Power | Number | The maximum power the schedule uses, in watts | enabled |
+| Schedule 1 Window | Sensor | The time of day the schedule runs, written as `20:00-20:30` | enabled |
 | Schedule 1 Running | Binary sensor | Whether the schedule is running right now. Stays off while the schedule exists but its window has not opened yet | enabled |
 
-Further schedules follow the same pattern up to Schedule 8 Running.
+Further schedules follow the same pattern: Schedule 2 Enabled, Schedule 2 Charge Power, and so on up to Schedule 8. The EcoFlow app itself lets you create six schedules, so six is the number a system can actually reach.
+
+Charge Power takes the same range the app offers for the same setting. It moves in steps of 100 W, its minimum is 100 W for every online battery pack your system reports (200 W with two packs), and its maximum comes from the model: 10000 W on the three-phase 10 kW unit, 8000 W on the 8 kW one, 12000 W on the 12 kW one, 6000 W on the 6 kW and single-phase units, and 29900 W on a PowerOcean Plus. A value outside that range, or one that is not a multiple of 100, is refused rather than quietly rounded.
+
+A schedule set in the app to run loads from the battery rather than to charge it keeps the same four entities, and its power is the discharge limit. Which direction a schedule has is set in the app and is not shown as an entity.
 
 ---
 

--- a/tests/ha/test_entities.py
+++ b/tests/ha/test_entities.py
@@ -12,6 +12,7 @@ from homeassistant.exceptions import HomeAssistantError
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ecoflow_energy.const import (
+    SCHEDULE_MAX_INDEX,
     DELTA2MAX_BINARY_SENSORS,
     DELTA2MAX_NUMBERS,
     DELTA2MAX_SENSORS,
@@ -152,8 +153,16 @@ class TestSwitchDefsRouting:
         assert _get_switch_defs(DEVICE_TYPE_STREAM, "BK31TEST00000001") is STREAM_SWITCHES
         assert _get_switch_defs(DEVICE_TYPE_STREAM, "BK11TEST00000001") == []
 
-    def test_powerocean_has_no_schedule_switches(self):
-        assert _get_switch_defs(DEVICE_TYPE_POWEROCEAN) == []
+    def test_powerocean_switches_are_the_schedule_slots(self):
+        """The only PowerOcean switch is the one per scheduled charge task,
+        and each is gated on its slot being reported, so a device with no
+        schedule still ends up with none of them."""
+        defs = _get_switch_defs(DEVICE_TYPE_POWEROCEAN)
+
+        assert {d.key for d in defs} == {
+            f"schedule_{index}_enabled" for index in range(1, SCHEDULE_MAX_INDEX + 1)
+        }
+        assert all(d.accessory and d.enhanced_only for d in defs)
 
 
 class TestNumberDefsRouting:

--- a/tests/ha/test_powerglow_gating.py
+++ b/tests/ha/test_powerglow_gating.py
@@ -30,6 +30,9 @@ from custom_components.ecoflow_energy.const import (
     MODE_ENHANCED,
     POWEROCEAN_SENSORS,
 )
+from custom_components.ecoflow_energy.ecoflow.parsers.powerocean_proto import (
+    SCHEDULE_MAX_INDEX,
+)
 from custom_components.ecoflow_energy.coordinator import EcoFlowDeviceCoordinator
 from custom_components.ecoflow_energy.sensor import async_setup_entry as sensor_setup
 
@@ -60,8 +63,13 @@ WALLBOX_KEYS = {
     "ev_vehicle_id",
 }
 
-# Schedule configuration is withheld; only the binary running status remains.
-SCHEDULE_KEYS: set[str] = set()
+# The scheduled charge tasks are the third user of the gate (#328). A
+# PowerOcean only has one when its owner created it in the app, and the slot
+# numbering comes from the device, so every slot the parser can report has a
+# definition that only becomes an entity once that slot is reported.
+SCHEDULE_KEYS = {
+    f"schedule_{index}_window" for index in range(1, SCHEDULE_MAX_INDEX + 1)
+}
 
 ACCESSORY_KEYS = HEATING_ROD_KEYS | WALLBOX_KEYS | SCHEDULE_KEYS
 

--- a/tests/ha/test_powerocean_number.py
+++ b/tests/ha/test_powerocean_number.py
@@ -16,6 +16,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.ecoflow_energy.const import (
     DEVICE_TYPE_POWEROCEAN,
     POWEROCEAN_NUMBERS,
+    SCHEDULE_MAX_INDEX,
 )
 from custom_components.ecoflow_energy.coordinator import EcoFlowDeviceCoordinator
 from custom_components.ecoflow_energy.number import (
@@ -39,12 +40,19 @@ class TestGetNumberDefs:
         assert defs is POWEROCEAN_NUMBERS
 
     def test_powerocean_number_keys(self):
-        """Only the two hardware-confirmed PowerOcean sliders are exposed."""
+        """Two sliders every PowerOcean has, plus one charge power per
+        scheduled task slot. The schedule ones are accessory-gated, so a
+        device without a schedule never sees them."""
         defs = _get_number_defs(DEVICE_TYPE_POWEROCEAN)
         keys = {d.key for d in defs}
 
-        assert keys == {"backup_reserve", "solar_surplus_threshold"}
-        assert not any(d.accessory for d in defs)
+        assert keys == {"backup_reserve", "solar_surplus_threshold"} | {
+            f"schedule_{index}_power_w"
+            for index in range(1, SCHEDULE_MAX_INDEX + 1)
+        }
+        assert not any(
+            d.accessory for d in defs if not d.key.startswith("schedule_")
+        )
 
     def test_powerocean_numbers_are_enhanced_only(self):
         defs = _get_number_defs(DEVICE_TYPE_POWEROCEAN)

--- a/tests/ha/test_powerocean_schedule_controls.py
+++ b/tests/ha/test_powerocean_schedule_controls.py
@@ -1,39 +1,729 @@
-"""Release-surface checks for PowerOcean scheduled charge tasks."""
+"""Controls for a PowerOcean scheduled charge task (#328).
+
+The read side of the schedule is covered next door in
+`test_powerocean_schedule_entities`. This file is about the write side: a
+switch that arms and disarms a slot, and a number that changes its charge
+power.
+
+Two things decide whether these are safe. The first is the gate: a PowerOcean
+whose owner never made a schedule must get no controls at all, and neither
+must one running on developer keys, where the command has no channel to travel
+on. The second is what the power write carries. A full body hands the whole
+task back to the device, so four fields it owns travel with it, and every one
+of them comes from the last read. A slot that has not reported one of them
+refuses the write rather than composing a value, because a composed
+recurrence would silently move the days and times the owner set in the app.
+
+The frames are the reporter's own, replayed through the ingest loop, and the
+payloads the writes produce are decoded with the integration's own decoder
+rather than compared as opaque bytes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ecoflow_energy.const import (
-    POWEROCEAN_BINARY_SENSORS,
-    POWEROCEAN_NUMBERS,
-    POWEROCEAN_SENSORS,
-    POWEROCEAN_SWITCHES,
-    SCHEDULE_MAX_INDEX,
+    AUTH_METHOD_APP,
+    AUTH_METHOD_DEVELOPER,
+    CONF_ACCESS_KEY,
+    CONF_AUTH_METHOD,
+    CONF_DEVICES,
+    CONF_EMAIL,
+    CONF_MODE,
+    CONF_PASSWORD,
+    CONF_SECRET_KEY,
+    CONF_USER_ID,
+    DEVICE_TYPE_POWEROCEAN,
+    DOMAIN,
+    MODE_ENHANCED,
+    MODE_STANDARD,
 )
 from custom_components.ecoflow_energy.coordinator import EcoFlowDeviceCoordinator
+from custom_components.ecoflow_energy.number import (
+    async_setup_entry as number_setup,
+)
+from custom_components.ecoflow_energy.switch import (
+    async_setup_entry as switch_setup,
+)
+
+from tests.test_powerocean_timer_task import (
+    LIST_ARMED_1000W,
+    LIST_ARMED_1500W,
+    LIST_DISARMED_1500W,
+    LIST_EMPTY,
+    _header,
+)
+from tests.test_powerocean_timer_task_write import pdata_of
+
+POWEROCEAN_DEVICE: dict[str, Any] = {
+    "sn": "HJ31TEST00000001",
+    "name": "PowerOcean",
+    "product_name": "PowerOcean",
+    "device_type": DEVICE_TYPE_POWEROCEAN,
+    "online": 1,
+}
+
+GET_REPLY = f"/app/user123/{POWEROCEAN_DEVICE['sn']}/thing/property/get_reply"
 
 
-def _schedule_keys(definitions) -> set[str]:
+class FakeMqtt:
+    """Records what the coordinator hands the broker.
+
+    Only the two methods the SET path calls. The payload is kept so the test
+    can decode what actually went out rather than trust the return value.
+    """
+
+    def __init__(self, connected: bool = True, delivers: bool = True) -> None:
+        self._connected = connected
+        self.delivers = delivers
+        self.sent: list[bytes] = []
+
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def send_proto_set(self, payload: bytes, wait: bool = False) -> bool:
+        self.sent.append(payload)
+        return self.delivers
+
+
+def _bundle(payload: bytes) -> bytes:
+    """The get-all reply carries the task list twice, as the device sends it."""
+    return _header(96, 10, payload) + _header(96, 10, payload)
+
+
+def _entry(
+    enhanced: bool = True, device: dict[str, Any] | None = None
+) -> MockConfigEntry:
+    device = device or POWEROCEAN_DEVICE
+    if enhanced:
+        data = {
+            CONF_AUTH_METHOD: AUTH_METHOD_APP,
+            CONF_MODE: MODE_ENHANCED,
+            CONF_EMAIL: "test@example.com",
+            CONF_PASSWORD: "test_password",
+            CONF_USER_ID: "user123",
+            CONF_DEVICES: [device],
+        }
+        unique_id = "test@example.com"
+    else:
+        data = {
+            CONF_AUTH_METHOD: AUTH_METHOD_DEVELOPER,
+            CONF_MODE: MODE_STANDARD,
+            CONF_ACCESS_KEY: "test_ak",
+            CONF_SECRET_KEY: "test_sk",
+            CONF_DEVICES: [device],
+        }
+        unique_id = "test_ak"
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="EcoFlow Energy",
+        data=data,
+        unique_id=unique_id,
+    )
+
+
+def _report(
+    coordinator: EcoFlowDeviceCoordinator, payload: bytes, sn: str | None = None
+) -> None:
+    """Push one bundle through the ingest loop and the real apply path."""
+    topic = GET_REPLY if sn is None else f"/app/user123/{sn}/thing/property/get_reply"
+    parsed = coordinator._parse_message(topic, _bundle(payload))
+    if parsed:
+        coordinator._apply_data(parsed)
+
+
+async def _setup(
+    hass: HomeAssistant,
+    payload: bytes | None = None,
+    enhanced: bool = True,
+    delivers: bool = True,
+    sn: str | None = None,
+) -> tuple[EcoFlowDeviceCoordinator, list[Any], list[Any], FakeMqtt]:
+    """Replay one task-list frame, then run both control platforms over it."""
+    device = POWEROCEAN_DEVICE if sn is None else {**POWEROCEAN_DEVICE, "sn": sn}
+    entry = _entry(enhanced, device)
+    entry.add_to_hass(hass)
+    coordinator = EcoFlowDeviceCoordinator(hass, entry, device)
+    mqtt = FakeMqtt(delivers=delivers)
+    coordinator._mqtt_client = mqtt
+    if payload is not None:
+        _report(coordinator, payload, sn)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {device["sn"]: coordinator}
+
+    switches: list[Any] = []
+    numbers: list[Any] = []
+    await switch_setup(hass, entry, switches.extend)
+    await number_setup(hass, entry, numbers.extend)
+    return coordinator, switches, numbers, mqtt
+
+
+def _schedule_keys(entities: list[Any]) -> set[str]:
     return {
-        definition.key
-        for definition in definitions
-        if definition.key.startswith("schedule_")
+        entity._definition.key
+        for entity in entities
+        if hasattr(entity, "_definition")
+        and entity._definition.key.startswith("schedule_")
     }
 
 
-def test_only_device_reported_running_flags_are_exposed() -> None:
-    """Unverified configuration fields stay out of the HA entity surface."""
-    assert _schedule_keys(POWEROCEAN_SENSORS) == set()
-    assert _schedule_keys(POWEROCEAN_NUMBERS) == set()
-    assert _schedule_keys(POWEROCEAN_SWITCHES) == set()
-    assert _schedule_keys(POWEROCEAN_BINARY_SENSORS) == {
-        f"schedule_{index}_running"
-        for index in range(1, SCHEDULE_MAX_INDEX + 1)
-    }
+def _by_key(entities: list[Any], key: str) -> Any:
+    return next(
+        entity
+        for entity in entities
+        if getattr(entity, "_definition", None) is not None
+        and entity._definition.key == key
+    )
 
 
-def test_schedule_writes_have_no_coordinator_entrypoint() -> None:
-    """A broker acknowledgement cannot be surfaced as schedule success."""
-    assert not hasattr(
-        EcoFlowDeviceCoordinator, "async_set_powerocean_schedule_armed"
+def _prepare(entity: Any, hass: HomeAssistant) -> Any:
+    """Give an entity the wiring a service call would have given it.
+
+    The state write is stubbed because these entities are built directly
+    rather than through an entity platform, which is also the only thing the
+    real write needs. The value under test is read back off the entity
+    property, not off the state machine.
+    """
+    entity.hass = hass
+    entity.entity_id = f"domain.{entity._definition.key}"
+    entity.async_write_ha_state = MagicMock()
+    return entity
+
+
+def _fields(payload: bytes) -> dict[int, Any]:
+    """Decode the written body into {field number: value}.
+
+    Hand-parsed rather than run through a message definition, because what
+    matters here is which fields are present at all: the enable flag is
+    expressed by its own absence, and a decoder that fills in defaults would
+    hide exactly the thing under test.
+    """
+    body = pdata_of(payload)
+    out: dict[int, Any] = {}
+    pos = 0
+    while pos < len(body):
+        key, pos = _varint(body, pos)
+        field, wire = key >> 3, key & 0x07
+        if wire == 0:
+            value, pos = _varint(body, pos)
+        elif wire == 2:
+            length, pos = _varint(body, pos)
+            value = body[pos : pos + length]
+            pos += length
+        else:  # pragma: no cover - the builder emits no other wire types
+            raise AssertionError(f"unexpected wire type {wire}")
+        out[field] = value
+    return out
+
+
+def _varint(data: bytes, pos: int) -> tuple[int, int]:
+    result = 0
+    shift = 0
+    while True:
+        byte = data[pos]
+        pos += 1
+        result |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return result, pos
+        shift += 7
+
+
+class TestTheSwitch:
+    async def test_only_the_reported_slot_becomes_a_switch(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Slot 1 exists, slots 2 to 8 do not."""
+        _, switches, _, _ = await _setup(hass, LIST_ARMED_1500W)
+
+        assert _schedule_keys(switches) == {"schedule_1_enabled"}
+
+    async def test_the_switch_reads_the_devices_own_arming(
+        self, hass: HomeAssistant
+    ) -> None:
+        _, armed_switches, _, _ = await _setup(hass, LIST_ARMED_1500W)
+        assert _by_key(armed_switches, "schedule_1_enabled").is_on is True
+
+    async def test_a_disarmed_schedule_reads_off(self, hass: HomeAssistant) -> None:
+        """An absent enable flag is disarmed, not unknown."""
+        _, switches, _, _ = await _setup(hass, LIST_DISARMED_1500W)
+
+        assert _by_key(switches, "schedule_1_enabled").is_on is False
+
+    async def test_arming_sends_the_short_enable_frame(
+        self, hass: HomeAssistant
+    ) -> None:
+        _, switches, _, mqtt = await _setup(hass, LIST_DISARMED_1500W)
+        switch = _prepare(_by_key(switches, "schedule_1_enabled"), hass)
+
+        await switch.async_turn_on()
+
+        assert len(mqtt.sent) == 1
+        fields = _fields(mqtt.sent[0])
+        assert fields == {2: 2, 3: 1, 4: 1}
+        assert switch.is_on is True
+
+    async def test_disarming_omits_the_enable_field_entirely(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A false bool is not serialised, and an explicit 4=0 is a no-op that
+        would leave the schedule armed while the switch showed off."""
+        _, switches, _, mqtt = await _setup(hass, LIST_ARMED_1500W)
+        switch = _prepare(_by_key(switches, "schedule_1_enabled"), hass)
+
+        await switch.async_turn_off()
+
+        fields = _fields(mqtt.sent[0])
+        assert fields == {2: 2, 3: 1}
+        assert 4 not in fields
+        assert switch.is_on is False
+
+    async def test_the_arming_a_power_write_carries_comes_from_the_switch(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Arm, then change the power inside the same window. The power frame
+        has to carry the flag the switch just sent, not the one the last
+        report held, or the write would disarm what was just armed."""
+        _, switches, numbers, mqtt = await _setup(hass, LIST_DISARMED_1500W)
+        switch = _prepare(_by_key(switches, "schedule_1_enabled"), hass)
+        number = _prepare(_by_key(numbers, "schedule_1_power_w"), hass)
+
+        await switch.async_turn_on()
+        await number.async_set_native_value(1200)
+
+        assert _fields(mqtt.sent[1])[4] == 1
+
+    async def test_a_rejected_arm_leaves_the_stored_flag_alone(
+        self, hass: HomeAssistant
+    ) -> None:
+        """The seed goes in before the send so a power write in the same lock
+        window sees it. A send that fails has to take it back out again."""
+        coordinator, switches, _, _ = await _setup(
+            hass, LIST_DISARMED_1500W, delivers=False
+        )
+        switch = _prepare(_by_key(switches, "schedule_1_enabled"), hass)
+
+        with pytest.raises(HomeAssistantError):
+            await switch.async_turn_on()
+
+        assert coordinator.device_data["schedule_1_enabled"] is False
+
+    async def test_the_unique_id_carries_the_slot_number(
+        self, hass: HomeAssistant
+    ) -> None:
+        _, switches, numbers, _ = await _setup(hass, LIST_ARMED_1500W)
+        serial = POWEROCEAN_DEVICE["sn"]
+
+        assert (
+            _by_key(switches, "schedule_1_enabled").unique_id
+            == f"{serial}_schedule_1_enabled"
+        )
+        assert (
+            _by_key(numbers, "schedule_1_power_w").unique_id
+            == f"{serial}_schedule_1_power_w"
+        )
+
+
+class TestTheNumber:
+    async def test_only_the_reported_slot_becomes_a_number(
+        self, hass: HomeAssistant
+    ) -> None:
+        _, _, numbers, _ = await _setup(hass, LIST_ARMED_1500W)
+
+        assert _schedule_keys(numbers) == {"schedule_1_power_w"}
+
+    async def test_the_number_reads_the_reported_power(
+        self, hass: HomeAssistant
+    ) -> None:
+        _, _, numbers, _ = await _setup(hass, LIST_ARMED_1000W)
+
+        assert _by_key(numbers, "schedule_1_power_w").native_value == 1000
+
+    async def test_writing_the_power_keeps_the_schedule_armed(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Measured on hardware: the combined frame changes the watts and the
+        device's own task list still reports the task as armed afterwards."""
+        _, _, numbers, mqtt = await _setup(hass, LIST_ARMED_1000W)
+        number = _prepare(_by_key(numbers, "schedule_1_power_w"), hass)
+
+        await number.async_set_native_value(1500)
+
+        fields = _fields(mqtt.sent[0])
+        assert fields[7] == 1500
+        assert fields[4] == 1
+        assert number.native_value == 1500
+
+    async def test_a_disarmed_schedule_stays_disarmed_through_a_power_write(
+        self, hass: HomeAssistant
+    ) -> None:
+        """The flag travels as it was read. Sending 4=1 here would arm a
+        schedule the owner had switched off."""
+        _, _, numbers, mqtt = await _setup(hass, LIST_DISARMED_1500W)
+        number = _prepare(_by_key(numbers, "schedule_1_power_w"), hass)
+
+        await number.async_set_native_value(1200)
+
+        assert 4 not in _fields(mqtt.sent[0])
+
+    async def test_the_echoed_fields_go_out_as_the_device_reported_them(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Task type, repeat kind, repeat parameter and the window block all
+        belong to the device. A write hands them straight back."""
+        _, _, numbers, mqtt = await _setup(hass, LIST_ARMED_1000W)
+        number = _prepare(_by_key(numbers, "schedule_1_power_w"), hass)
+
+        await number.async_set_native_value(1500)
+
+        fields = _fields(mqtt.sent[0])
+        assert fields[6] == 1
+        assert fields[8] == 68
+        assert fields[9] == 1037597
+        assert fields[10] == bytes.fromhex("b089b826")
+
+    async def test_a_failed_send_puts_the_stored_power_back(
+        self, hass: HomeAssistant
+    ) -> None:
+        coordinator, _, numbers, _ = await _setup(
+            hass, LIST_ARMED_1000W, delivers=False
+        )
+        number = _prepare(_by_key(numbers, "schedule_1_power_w"), hass)
+
+        with pytest.raises(HomeAssistantError):
+            await number.async_set_native_value(1500)
+
+        assert coordinator.device_data["schedule_1_power_w"] == 1000
+
+    async def test_the_range_is_the_one_the_app_offers(
+        self, hass: HomeAssistant
+    ) -> None:
+        """The floor is 100 W per online pack, the ceiling comes from the
+        model, and the step is the 100 W grid every value on file sits on."""
+        coordinator, _, numbers, _ = await _setup(hass, LIST_ARMED_1000W)
+        number = _by_key(numbers, "schedule_1_power_w")
+
+        assert number.native_min_value == 100
+        assert number.native_step == 100
+        assert number.native_unit_of_measurement == "W"
+
+        coordinator._apply_data({"bp_online_sum": 2})
+        assert number.native_min_value == 200
+
+        # HJ31, and the whole point is that the ceiling is not the builder's
+        # 30000 W guard.
+        assert number.native_max_value == 10000
+
+    async def test_a_pack_count_the_device_has_not_sent_keeps_the_one_pack_floor(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Never zero: the app cannot send it and no device was ever asked."""
+        coordinator, _, numbers, _ = await _setup(hass, LIST_ARMED_1000W)
+        number = _by_key(numbers, "schedule_1_power_w")
+
+        assert "bp_online_sum" not in coordinator.device_data
+        assert number.native_min_value == 100
+
+    @pytest.mark.parametrize(
+        ("sn", "ceiling"),
+        [
+            ("HJ31TEST00000001", 10000),
+            ("J329TEST00000001", 6000),
+            ("R372TEST00000001", 29900),
+            # A three-phase prefix nobody has mapped falls back to what its
+            # family carries, not to the builder's guard.
+            ("HJ39TEST00000001", 10000),
+        ],
     )
-    assert not hasattr(
-        EcoFlowDeviceCoordinator, "async_set_powerocean_schedule_power"
-    )
+    async def test_the_ceiling_follows_the_model(
+        self, hass: HomeAssistant, sn: str, ceiling: int
+    ) -> None:
+        _, _, numbers, _ = await _setup(hass, LIST_ARMED_1000W, sn=sn)
+        number = _by_key(numbers, "schedule_1_power_w")
+
+        assert number.native_max_value == ceiling
+
+    async def test_a_value_off_the_hundred_watt_grid_is_refused(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Refused rather than rounded. The app rounds because its slider
+        cannot leave the grid; a service call can, and quietly moving the
+        number would put a setpoint on the wire nobody asked for."""
+        coordinator, _, numbers, mqtt = await _setup(hass, LIST_ARMED_1000W)
+        number = _prepare(_by_key(numbers, "schedule_1_power_w"), hass)
+
+        with pytest.raises(HomeAssistantError):
+            await number.async_set_native_value(1234)
+
+        assert mqtt.sent == []
+        assert coordinator.device_data["schedule_1_power_w"] == 1000
+
+        await number.async_set_native_value(1500)
+        assert len(mqtt.sent) == 1
+        assert coordinator.device_data["schedule_1_power_w"] == 1500
+
+    async def test_a_value_outside_the_models_range_is_refused(
+        self, hass: HomeAssistant
+    ) -> None:
+        coordinator, _, numbers, mqtt = await _setup(
+            hass, LIST_ARMED_1000W, sn="J329TEST00000001"
+        )
+        number = _prepare(_by_key(numbers, "schedule_1_power_w"), hass)
+
+        with pytest.raises(HomeAssistantError):
+            await number.async_set_native_value(6100)
+
+        assert mqtt.sent == []
+        assert coordinator.device_data["schedule_1_power_w"] == 1000
+
+
+@pytest.mark.parametrize(
+    "missing",
+    ["schedule_1_type", "schedule_1_time_mode", "schedule_1_time_param",
+     "schedule_1_time_table"],
+)
+async def test_a_slot_missing_an_echo_field_refuses_the_write(
+    hass: HomeAssistant, missing: str
+) -> None:
+    """The refusal is the whole design. Every one of these four is part of the
+    task the device owns, and a value composed here would go back as though
+    the owner had set it."""
+    coordinator, _, numbers, mqtt = await _setup(hass, LIST_ARMED_1000W)
+    number = _prepare(_by_key(numbers, "schedule_1_power_w"), hass)
+    coordinator.device_data[missing] = None
+
+    with pytest.raises(HomeAssistantError):
+        await number.async_set_native_value(1500)
+
+    assert mqtt.sent == []
+    assert coordinator.device_data["schedule_1_power_w"] == 1000
+
+
+class TestNoSchedule:
+    async def test_a_powerocean_without_a_schedule_gets_no_controls(
+        self, hass: HomeAssistant
+    ) -> None:
+        """The majority case, and the reason the controls are gated at all."""
+        _, switches, numbers, _ = await _setup(hass)
+
+        assert _schedule_keys(switches) == set()
+        assert _schedule_keys(numbers) == set()
+
+    async def test_an_empty_task_list_is_still_no_controls(
+        self, hass: HomeAssistant
+    ) -> None:
+        _, switches, numbers, _ = await _setup(hass, LIST_EMPTY)
+
+        assert _schedule_keys(switches) == set()
+        assert _schedule_keys(numbers) == set()
+
+    async def test_the_other_powerocean_controls_are_unaffected(
+        self, hass: HomeAssistant
+    ) -> None:
+        _, _, numbers, _ = await _setup(hass)
+        keys = {
+            entity._definition.key
+            for entity in numbers
+            if hasattr(entity, "_definition")
+        }
+
+        assert "backup_reserve" in keys
+        assert "solar_surplus_threshold" in keys
+
+    async def test_a_schedule_created_later_gets_its_controls(
+        self, hass: HomeAssistant
+    ) -> None:
+        """An owner can make a schedule in the app while Home Assistant runs,
+        so the platforms keep watching instead of deciding once at startup."""
+        added: list[Any] = []
+        entry = _entry()
+        entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(hass, entry, POWEROCEAN_DEVICE)
+        coordinator._mqtt_client = FakeMqtt()
+        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+            POWEROCEAN_DEVICE["sn"]: coordinator
+        }
+        await switch_setup(hass, entry, added.extend)
+        await number_setup(hass, entry, added.extend)
+        assert _schedule_keys(added) == set()
+
+        _report(coordinator, LIST_ARMED_1500W)
+        await hass.async_block_till_done()
+
+        assert _schedule_keys(added) == {
+            "schedule_1_enabled",
+            "schedule_1_power_w",
+        }
+
+
+class TestStandardMode:
+    async def test_developer_keys_get_no_schedule_controls(
+        self, hass: HomeAssistant
+    ) -> None:
+        """The command travels on the app channel, so on developer keys these
+        could only ever fail. The keys are seeded on purpose: absence of data
+        would pass this test on its own and prove nothing about the filter."""
+        entry = _entry(enhanced=False)
+        entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(hass, entry, POWEROCEAN_DEVICE)
+        coordinator.set_device_value("schedule_1_enabled", True)
+        coordinator.set_device_value("schedule_1_power_w", 1500)
+        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+            POWEROCEAN_DEVICE["sn"]: coordinator
+        }
+
+        switches: list[Any] = []
+        numbers: list[Any] = []
+        await switch_setup(hass, entry, switches.extend)
+        await number_setup(hass, entry, numbers.extend)
+
+        assert _schedule_keys(switches) == set()
+        assert _schedule_keys(numbers) == set()
+
+
+class TestADeletedSlot:
+    """What happens after the owner deletes the schedule in the app.
+
+    The device stops listing the task, and the parser retracts every key of
+    that slot to None. That does not take the controls away: a key that is
+    present and None still counts as a reading, so the switch and the number
+    stay where they are. Both therefore have to refuse rather than send, or
+    the switch would name a slot the device no longer holds and then show a
+    deleted schedule as armed. The reporter's own capture on #328 ends with a
+    deletion, so this is the ordinary end of a schedule's life.
+    """
+
+    async def test_the_switch_refuses_a_slot_the_device_dropped(
+        self, hass: HomeAssistant
+    ) -> None:
+        coordinator, switches, _, mqtt = await _setup(hass, LIST_ARMED_1500W)
+        switch = _prepare(_by_key(switches, "schedule_1_enabled"), hass)
+
+        _report(coordinator, LIST_EMPTY)
+        assert coordinator.device_data["schedule_1_enabled"] is None
+
+        with pytest.raises(HomeAssistantError):
+            await switch.async_turn_on()
+
+        assert mqtt.sent == []
+        assert coordinator.device_data["schedule_1_enabled"] is None
+
+    async def test_the_number_refuses_a_slot_the_device_dropped(
+        self, hass: HomeAssistant
+    ) -> None:
+        """The same for the power write, asserted rather than left to fall out
+        of the echo fields being retracted alongside the flag."""
+        coordinator, _, numbers, mqtt = await _setup(hass, LIST_ARMED_1000W)
+        number = _prepare(_by_key(numbers, "schedule_1_power_w"), hass)
+
+        _report(coordinator, LIST_EMPTY)
+
+        with pytest.raises(HomeAssistantError):
+            await number.async_set_native_value(1500)
+
+        assert mqtt.sent == []
+
+    async def test_the_number_says_gone_rather_than_try_again(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A deleted schedule and an unreported one need different words.
+
+        Both refuse through the same exception, so the wording is the only
+        thing that tells an owner whether waiting helps. A schedule the device
+        has stopped reporting will not come back on its own, and the retry
+        message would send its owner to watch an entity that stays empty.
+        """
+        coordinator, _, numbers, _ = await _setup(hass, LIST_ARMED_1000W)
+        number = _prepare(_by_key(numbers, "schedule_1_power_w"), hass)
+
+        _report(coordinator, LIST_EMPTY)
+
+        with pytest.raises(HomeAssistantError) as raised:
+            await number.async_set_native_value(1500)
+
+        assert raised.value.translation_key == "set_command_gone"
+
+    async def test_a_failed_power_write_does_not_invent_the_reading(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Rolling back to a value that was never there has to leave the key
+        absent. Putting it back as a present None would build the control for
+        a slot the device has never described, and nothing retracts it again.
+        """
+        coordinator, _, numbers, _ = await _setup(
+            hass, LIST_ARMED_1000W, delivers=False
+        )
+        number = _prepare(_by_key(numbers, "schedule_1_power_w"), hass)
+        del coordinator.device_data["schedule_1_power_w"]
+        coordinator.data.pop("schedule_1_power_w", None)
+
+        with pytest.raises(HomeAssistantError):
+            await number.async_set_native_value(1500)
+
+        assert "schedule_1_power_w" not in coordinator.device_data
+        assert "schedule_1_power_w" not in (coordinator.data or {})
+
+
+class TestTheArmingHold:
+    """A frame that was already in flight must not undo the write it crossed.
+
+    The power write reads the arming flag out of the store and carries it as
+    field 4. So a device report that lands between an arming write and the
+    next power change does more than blink the switch: it feeds the old flag
+    straight back onto the wire, re-arming a schedule the owner just switched
+    off. The hold is short because the device acknowledges in about 0.2 s and
+    its task list already carries the change - only a frame that left before
+    the write arrived can still disagree.
+    """
+
+    async def test_a_stale_report_cannot_revert_a_flag_just_written(
+        self, hass: HomeAssistant
+    ) -> None:
+        coordinator, switches, numbers, mqtt = await _setup(
+            hass, LIST_ARMED_1500W
+        )
+        switch = _prepare(_by_key(switches, "schedule_1_enabled"), hass)
+        number = _prepare(_by_key(numbers, "schedule_1_power_w"), hass)
+
+        await switch.async_turn_off()
+        _report(coordinator, LIST_ARMED_1500W)
+        await number.async_set_native_value(1200)
+
+        assert coordinator.device_data["schedule_1_enabled"] is False
+        assert 4 not in _fields(mqtt.sent[1])
+
+    async def test_a_report_that_agrees_ends_the_hold(
+        self, hass: HomeAssistant
+    ) -> None:
+        """The device confirming the write is the end of it, not the clock."""
+        coordinator, switches, _, _ = await _setup(hass, LIST_DISARMED_1500W)
+        switch = _prepare(_by_key(switches, "schedule_1_enabled"), hass)
+
+        await switch.async_turn_on()
+        assert coordinator._schedule_armed_latch
+
+        _report(coordinator, LIST_ARMED_1500W)
+
+        assert coordinator._schedule_armed_latch == {}
+        assert coordinator.device_data["schedule_1_enabled"] is True
+
+    async def test_the_device_wins_once_the_hold_is_over(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A schedule the owner arms in the app afterwards has to show up."""
+        coordinator, switches, _, _ = await _setup(hass, LIST_DISARMED_1500W)
+        switch = _prepare(_by_key(switches, "schedule_1_enabled"), hass)
+
+        await switch.async_turn_on()
+        coordinator._schedule_armed_latch["schedule_1_enabled"] = (True, 0.0)
+        _report(coordinator, LIST_DISARMED_1500W)
+
+        assert coordinator.device_data["schedule_1_enabled"] is False
+        assert coordinator._schedule_armed_latch == {}

--- a/tests/ha/test_powerocean_schedule_entities.py
+++ b/tests/ha/test_powerocean_schedule_entities.py
@@ -1,26 +1,297 @@
-"""Entity checks for read-only PowerOcean schedule status."""
+"""Entities for a PowerOcean scheduled charge task (#328).
 
+A PowerOcean has a schedule only when its owner created one in the app, and
+most owners never do. The readings are therefore gated the same way the
+heating rod and the wallbox are: the definition exists for every slot the
+device can number, and the entity is created on the first report that carries
+that slot. What the platforms have to get right is the empty case, the
+Standard Mode case, and the schedule that disappears again - a deleted task
+must leave the entity unknown rather than frozen on the last window it had.
+
+The frames are the reporter's own, replayed through the ingest loop rather
+than hand-written, so the states asserted here are the ones the device sent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.ecoflow_energy.binary_sensor import (
+    async_setup_entry as binary_sensor_setup,
+)
 from custom_components.ecoflow_energy.const import (
-    POWEROCEAN_BINARY_SENSORS,
-    POWEROCEAN_SENSORS,
+    AUTH_METHOD_APP,
+    AUTH_METHOD_DEVELOPER,
+    CONF_ACCESS_KEY,
+    CONF_AUTH_METHOD,
+    CONF_DEVICES,
+    CONF_EMAIL,
+    CONF_MODE,
+    CONF_PASSWORD,
+    CONF_SECRET_KEY,
+    CONF_USER_ID,
+    DEVICE_TYPE_POWEROCEAN,
+    DOMAIN,
+    MODE_ENHANCED,
+    MODE_STANDARD,
+)
+from custom_components.ecoflow_energy.coordinator import EcoFlowDeviceCoordinator
+from custom_components.ecoflow_energy.sensor import async_setup_entry as sensor_setup
+
+from tests.test_powerocean_timer_task import (
+    LIST_ARMED_1000W,
+    LIST_ARMED_1500W,
+    LIST_EMPTY,
+    _header,
 )
 
+POWEROCEAN_DEVICE: dict[str, Any] = {
+    "sn": "HJ31TEST00000001",
+    "name": "PowerOcean",
+    "product_name": "PowerOcean",
+    "device_type": DEVICE_TYPE_POWEROCEAN,
+    "online": 1,
+}
 
-def test_schedule_running_is_accessory_gated_and_enhanced_only() -> None:
-    definitions = [
-        definition
-        for definition in POWEROCEAN_BINARY_SENSORS
-        if definition.key.startswith("schedule_")
-    ]
-
-    assert len(definitions) == 8
-    assert all(definition.key.endswith("_running") for definition in definitions)
-    assert all(definition.accessory for definition in definitions)
-    assert all(definition.enhanced_only for definition in definitions)
+GET_REPLY = f"/app/user123/{POWEROCEAN_DEVICE['sn']}/thing/property/get_reply"
 
 
-def test_schedule_window_is_not_an_entity() -> None:
-    assert not any(
-        definition.key.startswith("schedule_")
-        for definition in POWEROCEAN_SENSORS
+def _bundle(payload: bytes) -> bytes:
+    """The get-all reply carries the task list twice, as the device sends it."""
+    return _header(96, 10, payload) + _header(96, 10, payload)
+
+
+def _entry(enhanced: bool = True) -> MockConfigEntry:
+    if enhanced:
+        data = {
+            CONF_AUTH_METHOD: AUTH_METHOD_APP,
+            CONF_MODE: MODE_ENHANCED,
+            CONF_EMAIL: "test@example.com",
+            CONF_PASSWORD: "test_password",
+            CONF_USER_ID: "user123",
+            CONF_DEVICES: [POWEROCEAN_DEVICE],
+        }
+        unique_id = "test@example.com"
+    else:
+        data = {
+            CONF_AUTH_METHOD: AUTH_METHOD_DEVELOPER,
+            CONF_MODE: MODE_STANDARD,
+            CONF_ACCESS_KEY: "test_ak",
+            CONF_SECRET_KEY: "test_sk",
+            CONF_DEVICES: [POWEROCEAN_DEVICE],
+        }
+        unique_id = "test_ak"
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="EcoFlow Energy",
+        data=data,
+        unique_id=unique_id,
     )
+
+
+async def _setup(
+    hass: HomeAssistant,
+    payload: bytes | None = None,
+    enhanced: bool = True,
+) -> tuple[EcoFlowDeviceCoordinator, list[Any], list[Any]]:
+    """Replay one task-list frame, then run both platforms over the result."""
+    entry = _entry(enhanced)
+    entry.add_to_hass(hass)
+    coordinator = EcoFlowDeviceCoordinator(hass, entry, POWEROCEAN_DEVICE)
+    if payload is not None:
+        _report(coordinator, payload)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        POWEROCEAN_DEVICE["sn"]: coordinator
+    }
+
+    sensors: list[Any] = []
+    binary_sensors: list[Any] = []
+    await sensor_setup(hass, entry, sensors.extend)
+    await binary_sensor_setup(hass, entry, binary_sensors.extend)
+    return coordinator, sensors, binary_sensors
+
+
+def _report(coordinator: EcoFlowDeviceCoordinator, payload: bytes) -> None:
+    """Push one bundle through the ingest loop and the real apply path.
+
+    Deliberately not `set_device_value` followed by `async_set_updated_data`:
+    that reaches the same state by a route no message ever takes, and it skips
+    every step between the parse and the entity - the monotonic guard, the
+    value-change bookkeeping and the merge into the held data. Retracting a
+    key to None is exactly the case one of those could swallow, so the test
+    that asserts the retraction has to travel the path production travels.
+
+    `_apply_data` is what the MQTT thread hands the parsed frame to, and the
+    empty guard is the one the dispatcher applies before it.
+    """
+    parsed = coordinator._parse_message(GET_REPLY, _bundle(payload))
+    if parsed:
+        coordinator._apply_data(parsed)
+
+
+def _schedule_keys(entities: list[Any]) -> set[str]:
+    return {
+        entity._definition.key
+        for entity in entities
+        if hasattr(entity, "_definition")
+        and entity._definition.key.startswith("schedule_")
+    }
+
+
+def _by_key(entities: list[Any], key: str) -> Any:
+    return next(
+        entity
+        for entity in entities
+        if getattr(entity, "_definition", None) is not None
+        and entity._definition.key == key
+    )
+
+
+class TestOneReportedSchedule:
+    async def test_exactly_the_slot_the_device_reported_becomes_an_entity(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Slot 1 exists, slots 2 to 8 do not, so only slot 1 gets entities."""
+        _, sensors, binary_sensors = await _setup(hass, LIST_ARMED_1500W)
+
+        assert _schedule_keys(sensors) == {"schedule_1_window"}
+        assert _schedule_keys(binary_sensors) == {"schedule_1_running"}
+
+    async def test_the_window_reads_as_the_device_set_it(
+        self, hass: HomeAssistant
+    ) -> None:
+        _, sensors, _ = await _setup(hass, LIST_ARMED_1500W)
+
+        assert _by_key(sensors, "schedule_1_window").native_value == "20:00-20:30"
+
+    async def test_running_follows_the_devices_own_flag(
+        self, hass: HomeAssistant
+    ) -> None:
+        """The 19:06:32 frame: the window is open, so the task is running."""
+        _, _, binary_sensors = await _setup(hass, LIST_ARMED_1500W)
+
+        assert _by_key(binary_sensors, "schedule_1_running").is_on is True
+
+    async def test_an_armed_task_before_its_window_is_not_running(
+        self, hass: HomeAssistant
+    ) -> None:
+        """The 18:59:22 frame. Armed and running are two separate flags, and
+        a schedule that has not started yet must not read as charging."""
+        _, sensors, binary_sensors = await _setup(hass, LIST_ARMED_1000W)
+
+        assert _by_key(binary_sensors, "schedule_1_running").is_on is False
+        assert _by_key(sensors, "schedule_1_window").native_value == "20:00-20:30"
+
+    async def test_the_unique_id_carries_the_slot_number(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Two schedules would otherwise share one identity."""
+        _, sensors, binary_sensors = await _setup(hass, LIST_ARMED_1500W)
+        serial = POWEROCEAN_DEVICE["sn"]
+
+        assert (
+            _by_key(sensors, "schedule_1_window").unique_id
+            == f"{serial}_schedule_1_window"
+        )
+        assert (
+            _by_key(binary_sensors, "schedule_1_running").unique_id
+            == f"{serial}_schedule_1_running"
+        )
+
+
+class TestNoSchedule:
+    async def test_a_powerocean_without_a_schedule_gets_no_schedule_entities(
+        self, hass: HomeAssistant
+    ) -> None:
+        """The majority case, and the reason the readings are gated at all."""
+        _, sensors, binary_sensors = await _setup(hass)
+
+        assert _schedule_keys(sensors) == set()
+        assert _schedule_keys(binary_sensors) == set()
+
+    async def test_an_empty_task_list_is_still_no_entities(
+        self, hass: HomeAssistant
+    ) -> None:
+        """An empty list is a report, not a silence, and it names no slot."""
+        _, sensors, binary_sensors = await _setup(hass, LIST_EMPTY)
+
+        assert _schedule_keys(sensors) == set()
+        assert _schedule_keys(binary_sensors) == set()
+
+    async def test_the_other_powerocean_readings_are_unaffected(
+        self, hass: HomeAssistant
+    ) -> None:
+        _, sensors, _ = await _setup(hass)
+        keys = {
+            entity._definition.key
+            for entity in sensors
+            if hasattr(entity, "_definition")
+        }
+
+        assert "soc_pct" in keys
+        assert "mppt_pv1_power_w" in keys
+
+
+class TestStandardMode:
+    async def test_developer_keys_get_no_schedule_entities(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Both the task list and the command that changes it live on the app
+        channel, so with developer keys these could only ever read unknown.
+        The keys are seeded here on purpose: absence of data would pass this
+        test on its own and prove nothing about the mode filter."""
+        entry = _entry(enhanced=False)
+        entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(hass, entry, POWEROCEAN_DEVICE)
+        coordinator.set_device_value("schedule_1_window", "20:00-20:30")
+        coordinator.set_device_value("schedule_1_running", True)
+        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+            POWEROCEAN_DEVICE["sn"]: coordinator
+        }
+
+        sensors: list[Any] = []
+        binary_sensors: list[Any] = []
+        await sensor_setup(hass, entry, sensors.extend)
+        await binary_sensor_setup(hass, entry, binary_sensors.extend)
+
+        assert coordinator.enhanced_mode is False
+        assert _schedule_keys(sensors) == set()
+        assert _schedule_keys(binary_sensors) == set()
+
+
+class TestScheduleAppearsAndDisappears:
+    async def test_a_schedule_created_later_adds_its_entities(
+        self, hass: HomeAssistant
+    ) -> None:
+        """The owner creates the task while Home Assistant is running. Without
+        the watcher on each platform the entities would only show up after a
+        reload."""
+        coordinator, sensors, binary_sensors = await _setup(hass, LIST_EMPTY)
+        assert _schedule_keys(sensors) == set()
+
+        _report(coordinator, LIST_ARMED_1500W)
+        await hass.async_block_till_done()
+
+        assert _schedule_keys(sensors) == {"schedule_1_window"}
+        assert _schedule_keys(binary_sensors) == {"schedule_1_running"}
+        assert _by_key(sensors, "schedule_1_window").native_value == "20:00-20:30"
+
+    async def test_a_deleted_schedule_reads_unknown_rather_than_stale(
+        self, hass: HomeAssistant
+    ) -> None:
+        """The device stops mentioning a task it no longer holds, so nothing
+        retracts the window unless the read path does. Leave it standing and
+        the entity keeps advertising a charge window that no longer exists."""
+        coordinator, sensors, binary_sensors = await _setup(hass, LIST_ARMED_1500W)
+        window = _by_key(sensors, "schedule_1_window")
+        running = _by_key(binary_sensors, "schedule_1_running")
+        assert window.native_value == "20:00-20:30"
+
+        _report(coordinator, LIST_EMPTY)
+
+        assert window.native_value is None
+        assert running.is_on is None

--- a/tests/ha/test_withdrawn_entities.py
+++ b/tests/ha/test_withdrawn_entities.py
@@ -124,41 +124,35 @@ class TestRemoval:
 
         assert set(keep) <= _ids(hass)
 
-    def test_schedule_cleanup_is_exact_and_entry_scoped(
+    def test_removal_is_scoped_to_this_entry_and_this_integration(
         self, hass: HomeAssistant, entry: MockConfigEntry
     ) -> None:
-        registry = er.async_get(hass)
-        stale = {
-            _register(hass, entry, "switch", f"{SERIAL}_schedule_1_enabled"),
-            _register(hass, entry, "number", f"{SERIAL}_schedule_2_power_w"),
-            _register(hass, entry, "sensor", f"{SERIAL}_schedule_3_window"),
-        }
-        running = _register(
-            hass, entry, "binary_sensor", f"{SERIAL}_schedule_1_running"
-        )
-        registry.async_update_entity(running, name="Morning charge running")
+        """The sweep walks a registry every integration writes into.
+
+        Two rows can carry the same unique id without being ours: one that
+        belongs to another config entry, and one another integration created
+        under its own platform. Removing either would delete a stranger's
+        entity, so both have to survive a sweep that removes our own.
+        """
+        stale = _register(hass, entry, "select", f"{SERIAL}_ac_charge_mode")
 
         other_entry = MockConfigEntry(domain=DOMAIN, data={})
         other_entry.add_to_hass(hass)
         foreign_entry = _register(
-            hass,
-            other_entry,
-            "switch",
-            f"{OTHER_SERIAL}_schedule_1_enabled",
+            hass, other_entry, "select", f"{OTHER_SERIAL}_ac_charge_mode"
         )
         foreign_platform = _register(
             hass,
             entry,
-            "switch",
-            f"{SERIAL}_schedule_4_enabled",
+            "select",
+            f"{SERIAL}_other_ac_charge_mode",
             integration="example",
         )
 
         _async_remove_withdrawn_entities(hass, entry)
 
-        assert not (stale & _ids(hass))
-        assert {running, foreign_entry, foreign_platform} <= _ids(hass)
-        assert registry.async_get(running).name == "Morning charge running"
+        assert stale not in _ids(hass)
+        assert {foreign_entry, foreign_platform} <= _ids(hass)
 
     def test_a_longer_key_ending_in_the_same_word_survives(
         self, hass: HomeAssistant, entry: MockConfigEntry

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -34,6 +34,7 @@ from ecoflow_energy.const import (
     RAW_FRAME_LOG_PER_KEY_MAX,
     RAW_FRAME_MAX_BYTES,
     RAW_FRAME_PER_KEY_MAX,
+    SCHEDULE_MAX_INDEX,
     get_device_name,
     get_device_type,
     get_delta_profile,
@@ -450,8 +451,9 @@ class TestPowerOceanSensors:
     def test_existing_sensors_count(self):
         """Core sensor count, excluding optional Plus and extended EMS fields.
 
-        Includes the heating-rod and wallbox accessory readings. Schedule
-        configuration is withheld from the sensor platform.
+        Includes the accessory readings (heating rod, wallbox, and the eight
+        scheduled-charge slots): they are defined on the PowerOcean and gated
+        at entity creation, not here.
         """
         keys = _extract_sensor_keys("POWEROCEAN_SENSORS")
         non_pack = [k for k in keys if not k.startswith("pack")]
@@ -464,7 +466,7 @@ class TestPowerOceanSensors:
         original = [
             k for k in non_pack if k not in ems_extended and k not in mppt_plus
         ]
-        assert len(original) == 73, f"Expected 73 core sensors, got {len(original)}"
+        assert len(original) == 81, f"Expected 81 core sensors, got {len(original)}"
 
     def test_mppt_plus_sensor_count(self):
         """6 PowerOcean Plus MPPT sensors (strings 3 and 4)."""
@@ -495,9 +497,9 @@ class TestPowerOceanSensors:
         assert len(found) == 28, f"Expected 28 EMS extended sensors, got {len(found)}"
 
     def test_total_sensor_count(self):
-        """Total excludes the eight withheld schedule window sensors."""
+        """Total PowerOcean sensors = 81 + 6 + 120 + 28 = 235."""
         keys = _extract_sensor_keys("POWEROCEAN_SENSORS")
-        assert len(keys) == 227, f"Expected 227 total sensors, got {len(keys)}"
+        assert len(keys) == 235, f"Expected 235 total sensors, got {len(keys)}"
 
 
     def test_only_soc_has_battery_device_class(self):
@@ -781,6 +783,19 @@ _PRECISION_WAIVED = {
         "to round - the charger sends '653', not 653"
     ),
 }
+
+# One waiver per schedule slot the device can report. The window is a text
+# reading built from the two edges of the task, so there is no number to
+# round; the slots are generated from the same cap the parser uses.
+_PRECISION_WAIVED.update(
+    {
+        f"schedule_{_index}_window": (
+            "the charge window is text, 'HH:MM-HH:MM', so there is no number "
+            "to round"
+        )
+        for _index in range(1, SCHEDULE_MAX_INDEX + 1)
+    }
+)
 
 # Key endings that can only ever name a whole number: a fault or error code, a
 # cycle counter, a cell count, a number of packs. None of them has a fractional
@@ -1171,3 +1186,51 @@ class TestFrameCaptureFootprint:
         assert RAW_FRAME_BUNDLE_MAX_BYTES >= widest, (
             f"{offender} holds a {widest} B frame the cap would cut"
         )
+
+
+class TestTheScheduleChargePowerCeiling:
+    """The table mirrors the app's own prompt, so a prefix that moves model
+    changes what the slider offers. Nothing on the wire carries this range."""
+
+    def test_every_mapped_prefix_gets_its_own_ceiling(self) -> None:
+        from ecoflow_energy.ecoflow.const import schedule_power_max_w
+
+        assert schedule_power_max_w("HJ31TEST00000001") == 10000
+        assert schedule_power_max_w("HJ35TEST00000001") == 6000
+        assert schedule_power_max_w("HJ36TEST00000001") == 8000
+        assert schedule_power_max_w("HJ37TEST00000001") == 12000
+        assert schedule_power_max_w("J329TEST00000001") == 6000
+        assert schedule_power_max_w("J32DTEST00000001") == 6000
+        assert schedule_power_max_w("R372TEST00000001") == 29900
+
+    def test_an_unmapped_prefix_falls_back_to_its_family(self) -> None:
+        """A new PowerOcean prefix lands on what its family carries rather
+        than on the builder's guard, which is three times the largest ceiling
+        any model has."""
+        from ecoflow_energy.ecoflow.const import schedule_power_max_w
+
+        assert schedule_power_max_w("HJ39TEST00000001") == 10000
+        assert schedule_power_max_w("J32XTEST00000001") == 6000
+        assert schedule_power_max_w("R379TEST00000001") == 29900
+        assert schedule_power_max_w("ZZZZTEST00000001") == 10000
+        assert schedule_power_max_w("") == 10000
+
+    def test_the_lookup_ignores_serial_case(self) -> None:
+        from ecoflow_energy.ecoflow.const import schedule_power_max_w
+
+        assert schedule_power_max_w("hj37test00000001") == 12000
+
+    def test_the_floor_is_a_hundred_watts_per_online_pack(self) -> None:
+        from ecoflow_energy.ecoflow.const import schedule_power_min_w
+
+        assert schedule_power_min_w(1) == 100
+        assert schedule_power_min_w(2) == 200
+        assert schedule_power_min_w(6) == 600
+
+    def test_an_unreported_pack_count_never_yields_zero(self) -> None:
+        """The app cannot send 0 W, so what the device does with it has never
+        been seen."""
+        from ecoflow_energy.ecoflow.const import schedule_power_min_w
+
+        assert schedule_power_min_w(None) == 100
+        assert schedule_power_min_w(0) == 100


### PR DESCRIPTION
## Summary

Restores the PowerOcean scheduled charge controls that 1.18.1 withheld (enable switch, charge-power number, time-window sensor) and gives the charge-power number the bounds the EcoFlow app itself applies.

Ref #328

## Why

The 1.18.1 withdrawal had no new measurement behind it. The write path was verified on real hardware before it first shipped: power 1000 -> 1500 -> 1000, each read back from the device's own task list on a later independent read, the task staying armed; arm and disarm each verified across a real state change. Every other fix of 1.18.1 stays; the two restored write methods carry the same shutdown guard those fixes introduced.

## Bounds

From the app's own schedule prompt: steps of 100 W, a minimum of 100 W per online battery pack (already parsed), a maximum per model from a prefix table with a family fallback (single-phase 6 kW models 6000 W per unit, HJ31 10000 W, the R37x family 29900 W). A value outside the range or off the 100 W grid is refused rather than rounded. The builder keeps its 30000 W hard ceiling. Whether the device enforces anything beyond the app's rule has not been observed; no rejected write is on record.

## Tests

- `./scripts/dev/run_tests.sh`: 3018 passed (restored 956 lines of schedule tests unmodified from the original implementation, plus bounds tests with a mutation control: changing one table value fails two named tests).
- Registry sweep no longer lists the schedule suffixes; the scoping test for the sweep was re-pointed at a suffix that is still withdrawn.
