### PR TITLE
fix(stream): keep the battery SoC when a unit reports no system figure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [1.19.0] - 2026-09-01
 
+### Fixed
+
+- A Stream unit that is part of a linked system no longer reads 0% Battery SOC. Versions 1.18.0 and 1.18.1 made the system charge, the combined figure the app shows for units cabled together, the source of the battery sensor, which was right for the flapping reported in #323 but rested on the assumption that every unit in a system reports it. Not all of them do. In a two-unit recording the Stream Ultra X reported the system charge throughout, while the Stream AC Pro next to it sent that field as a flat zero on every frame that carried it, its own battery meanwhile going from 24% to 92%. The sensor took the zero, kept it, and no later reading could pull it back, so the unit read empty while it was charging. The system charge is the average across the units, and an average cannot be zero while one of the units is above zero, so a zero arriving next to a unit reading that contradicts it is now treated as what it is, a unit that does not calculate the figure, and the unit's own reading is shown instead. A battery that really is empty is unaffected, because then both readings are zero and there is nothing to contradict. Units that do report the system charge keep it exactly as before. Reported by @OB73-gif on three of four Stream AC Pro, and identified from the diagnostics @c-bren84 attached to #323. (Ref #336)
+
 ### Changed
 
 - PowerOcean scheduled charge tasks expose their enable switch, charge-power number and time-window sensor again in Enhanced Mode (beta.2). Version 1.18.1 had withheld them; the write path was verified on real hardware before it first shipped, with the device's own task list as the read-back. The charge-power number now follows the app's own limits: steps of 100 W, a minimum of 100 W per online battery pack and a maximum per model, and a value outside them is refused rather than rounded. (Ref #328)

--- a/custom_components/ecoflow_energy/coordinator/state_apply.py
+++ b/custom_components/ecoflow_energy/coordinator/state_apply.py
@@ -35,10 +35,32 @@ class StateApplyMixin:
         pair latches onto the system figure the moment it arrives and a
         BMS-only frame can no longer pull the sensor back to one unit's
         reading (#323).
+
+        Not every member of a linked system computes that figure. In a
+        two-unit capture the Stream Ultra X reported it tracking its own BMS
+        across a full charge, while the Stream AC Pro beside it sent the
+        field present and zero on all twelve frames that carried it, its own
+        BMS meanwhile moving between 24% and 92%. A system figure is the mean
+        over the members, and a mean cannot read zero while one member is
+        above zero, so a zero arriving next to a positive unit figure is not
+        this system's charge - it is a unit that does not calculate one. Such
+        a frame yields to the unit's own reading and does not latch, which
+        also lets a later BMS-only frame still stand in (#336).
+
+        A genuinely empty battery is untouched: then the unit figure reads
+        zero as well and nothing contradicts the system figure.
         """
         fallback = parsed.pop(SOC_FALLBACK_KEY, None)
         if "soc_pct" in parsed:
-            self._soc_from_system = True
+            if parsed["soc_pct"]:
+                self._soc_from_system = True
+                return
+            # A zero never latches. Where the unit's own reading contradicts
+            # it, that reading wins; where it does not, the zero stands but
+            # stays open to a later frame that carries a figure.
+            unit = parsed.get("unit_soc_pct")
+            if unit:
+                parsed["soc_pct"] = unit
             return
         if fallback is not None and not self._soc_from_system:
             parsed["soc_pct"] = fallback

--- a/custom_components/ecoflow_energy/coordinator/state_apply.py
+++ b/custom_components/ecoflow_energy/coordinator/state_apply.py
@@ -49,6 +49,14 @@ class StateApplyMixin:
 
         A genuinely empty battery is untouched: then the unit figure reads
         zero as well and nothing contradicts the system figure.
+
+        The contradicting reading is looked up in the accumulated state, not
+        only in the message at hand. `254/21` is an incremental container, so
+        a frame may carry the system figure while the unit figure it
+        contradicts arrived in an earlier one. Two frames of the capture
+        carried 242 without 262 and none the other way round, but the
+        container permits it, and reading only the current message would drop
+        the sensor to zero until the next frame carrying both.
         """
         fallback = parsed.pop(SOC_FALLBACK_KEY, None)
         if "soc_pct" in parsed:
@@ -58,7 +66,7 @@ class StateApplyMixin:
             # A zero never latches. Where the unit's own reading contradicts
             # it, that reading wins; where it does not, the zero stands but
             # stays open to a later frame that carries a figure.
-            unit = parsed.get("unit_soc_pct")
+            unit = parsed.get("unit_soc_pct") or self._device_data.get("unit_soc_pct")
             if unit:
                 parsed["soc_pct"] = unit
             return

--- a/tests/ha/test_coordinator.py
+++ b/tests/ha/test_coordinator.py
@@ -7810,6 +7810,41 @@ class TestStreamSocLatch:
         coordinator._apply_data({"soc_pct": 0, "unit_soc_pct": 92})
         assert coordinator.data["soc_pct"] == 92
 
+    async def test_a_lone_zero_yields_to_the_unit_figure_already_known(
+        self, hass: HomeAssistant, enhanced_config_entry: MockConfigEntry
+    ) -> None:
+        """The contradicting reading may have arrived in an earlier frame.
+
+        `254/21` is incremental, so a frame can carry the system figure while
+        the unit figure it contradicts came before it. Reading only the
+        message at hand would drop the sensor to zero until the next frame
+        carrying both. Unobserved in the #323 capture, which had two frames
+        with 242 alone and none with 262 alone, but the container permits it.
+        """
+        coordinator = self._coordinator(hass, enhanced_config_entry)
+
+        coordinator._apply_data({"unit_soc_pct": 70, "_soc_pct_fallback": 70})
+        assert coordinator.data["soc_pct"] == 70
+
+        coordinator._apply_data({"soc_pct": 0})
+
+        assert coordinator.data["soc_pct"] == 70
+
+    async def test_an_empty_battery_keeps_its_zero_from_state_too(
+        self, hass: HomeAssistant, enhanced_config_entry: MockConfigEntry
+    ) -> None:
+        """The state lookup must not resurrect a value an empty pack lost.
+
+        With both readings at zero nothing contradicts the system figure, so
+        the sensor reads zero, which is the truth for an empty battery.
+        """
+        coordinator = self._coordinator(hass, enhanced_config_entry)
+
+        coordinator._apply_data({"unit_soc_pct": 0, "_soc_pct_fallback": 0})
+        coordinator._apply_data({"soc_pct": 0})
+
+        assert coordinator.data["soc_pct"] == 0
+
     async def test_a_real_system_figure_still_wins_after_a_zero(
         self, hass: HomeAssistant, enhanced_config_entry: MockConfigEntry
     ) -> None:

--- a/tests/ha/test_coordinator.py
+++ b/tests/ha/test_coordinator.py
@@ -7773,29 +7773,68 @@ class TestStreamSocLatch:
         coordinator._apply_data({"_soc_pct_fallback": 40})
         assert "_soc_pct_fallback" not in coordinator.data
 
-    async def test_a_zero_system_figure_latches_like_any_other(
+    async def test_a_zero_system_figure_does_not_latch(
         self, hass: HomeAssistant, standard_config_entry: MockConfigEntry
     ) -> None:
-        """A system figure of zero currently claims the sensor for good.
+        """A zero must not claim the sensor for good.
 
-        This pins current behaviour, not desired behaviour. The first HTTP
-        poll of a Stream carries the system figure, so a zero there latches
-        before any push arrives, and from then on the unit's own reading is
-        offered and dropped on every frame. The battery sensor stays at 0
-        while the unit itself reports a full battery.
-
-        Whether a zero should be allowed to latch is open: an empty battery
-        legitimately reads zero, and a single message carries nothing that
-        separates that from a unit reporting no usable system figure. Change
-        this test deliberately, not in passing.
+        The first HTTP poll of a Stream carries the system figure, so a zero
+        there used to latch before any push arrived, and from then on the
+        unit's own reading was offered and dropped on every frame. Nothing
+        could pull the sensor back.
         """
         coordinator = self._coordinator(hass, standard_config_entry)
 
         await self._http_update(coordinator, {"cmsBattSoc": 0})
         coordinator._apply_data({"unit_soc_pct": 94, "_soc_pct_fallback": 94})
 
-        assert coordinator.data["soc_pct"] == 0
+        assert coordinator.data["soc_pct"] == 94
         assert coordinator.data["unit_soc_pct"] == 94
+
+    async def test_a_paired_unit_that_reports_no_system_figure(
+        self, hass: HomeAssistant, enhanced_config_entry: MockConfigEntry
+    ) -> None:
+        """The #336 shape: both figures in one frame, the system one zero.
+
+        Taken from the two-unit diagnostics on #323, where the Stream AC Pro
+        sent field 262 present and zero on all twelve frames that carried it
+        while its own BMS moved from 24% to 92%. A mean over the members
+        cannot read zero while one member is above it, so the unit's own
+        reading wins and the sensor keeps following it.
+        """
+        coordinator = self._coordinator(hass, enhanced_config_entry)
+
+        coordinator._apply_data({"soc_pct": 0, "unit_soc_pct": 24})
+        assert coordinator.data["soc_pct"] == 24
+
+        coordinator._apply_data({"soc_pct": 0, "unit_soc_pct": 92})
+        assert coordinator.data["soc_pct"] == 92
+
+    async def test_a_real_system_figure_still_wins_after_a_zero(
+        self, hass: HomeAssistant, enhanced_config_entry: MockConfigEntry
+    ) -> None:
+        """Yielding to the unit figure must not cost the system figure.
+
+        A pair whose figure genuinely arrives has to keep latching, or #323
+        comes back.
+        """
+        coordinator = self._coordinator(hass, enhanced_config_entry)
+
+        coordinator._apply_data({"soc_pct": 0, "unit_soc_pct": 40})
+        coordinator._apply_data({"soc_pct": 55, "unit_soc_pct": 40})
+        coordinator._apply_data({"unit_soc_pct": 41, "_soc_pct_fallback": 41})
+
+        assert coordinator.data["soc_pct"] == 55
+
+    async def test_an_empty_linked_battery_still_reads_zero(
+        self, hass: HomeAssistant, enhanced_config_entry: MockConfigEntry
+    ) -> None:
+        """Nothing contradicts the zero when the unit reads zero too."""
+        coordinator = self._coordinator(hass, enhanced_config_entry)
+
+        coordinator._apply_data({"soc_pct": 0, "unit_soc_pct": 0})
+
+        assert coordinator.data["soc_pct"] == 0
 
     async def test_a_zero_unit_figure_still_reaches_the_sensor(
         self, hass: HomeAssistant, standard_config_entry: MockConfigEntry


### PR DESCRIPTION
Ref #336

## Root cause, verified

A linked Stream system elects one unit to compute the system state of charge. Every other member sends field 262 present and hard zero. v1.18.0 made that field authoritative for the Battery SOC sensor, so those units published the zero and latched on it.

The evidence was already on #323: the diagnostics @c-bren84 attached on 2026-08-29, a linked Ultra X plus AC Pro pair.

| Unit | field 242 (own BMS) | field 262 (system) |
|---|---|---|
| Stream Ultra X | 18 -> 100 -> 68 | tracks 242, +-2 |
| Stream AC Pro | 24 -> 92 -> 70 | 0.0 in all twelve frames carrying it |

The AC Pro moved across 68 percentage points over eleven hours while its system field never left zero. @OB73-gif has four AC Pro and one plausible reading, which is the same shape.

This also answered both questions the issue was waiting on the reporter for. The field is present-and-zero rather than absent, and the mean model holds on BK-series hardware: near-simultaneous frames read Ultra 18, AC Pro 24, system 20.

## Consequence for #323

That pair was reported fixed on the strength of the Ultra X sensor alone. The AC Pro in the same system was reading 0% at the time and nobody looked at it.

## The fix

A system figure of zero no longer latches, and yields to the unit's own reading where that contradicts it. A mean over the members cannot read zero while one member is above zero, so a zero next to a positive unit figure is not the system's charge, it is a unit that does not calculate one.

An empty battery is unaffected: both readings are then zero and nothing contradicts. Units that do compute the figure keep it, so #323 stays fixed.

The second commit takes the contradicting reading from the accumulated state rather than only from the message at hand. The telemetry container is incremental, so a frame can carry the system figure while the unit figure arrived earlier. That shape did not occur in the capture, twelve of fourteen frames carried both and two the unit figure alone, but the container permits it and the sensor would otherwise drop to zero until the next frame carrying both.

## Verification

- Full suite: 3031 passed.
- Both directions pinned: without the fix two tests fail, with an overcorrection six fail including the #323 guard. The state lookup has its own mutation check, which fails on `assert 0 == 70`.
- The characterisation test from #338 is deliberately inverted here, which is what that test was written for.

## Still open

If a linked AC Pro in Standard Mode returns `cmsBattSoc` without `soc`, there is no contradicting reading in the frame and none in state either. Unobserved in both directions. Not latching limits the damage to a single reading.
