### PR TITLE
chore: date the 1.19.0 changelog block to its release day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.19.0] - 2026-09-01
+## [1.19.0] - 2026-09-03
 
 ### Fixed
 


### PR DESCRIPTION
The `[1.19.0]` block was written on 2026-09-01, while the cycle was still running through beta.1 to beta.3. The full release goes out on 2026-09-03 and the release notes are generated from this heading, so the date is corrected before the tag rather than after it.

No content change: the four entries and their references are untouched.
