### PR TITLE
feat(wave3): add the EcoFlow WAVE 3 (AC71) as a read-only Enhanced Mode device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.20.0] - 2026-09-07
+
+### Added
+
+- The EcoFlow WAVE 3 portable air conditioner is now supported. An owner gets 24 sensors and 6 binary sensors: the room the unit is working on, the mode and setpoint it is running at, the fan step, the temperatures inside the refrigerant loop, the mains supply figures, and whether it is running, faulted or draining. It is available with the EcoFlow account sign-in only. The Developer API lists the unit but refuses every reading from it with error 1006, so an entry made with developer keys cannot select it and its entities would never fill. Nothing is polled: the device sends its full status every 120 seconds and a runtime block with the loop temperatures and the firmware every 300 seconds, and while it runs it adds its input power roughly every 2 seconds. One of the 24 is a lifetime energy counter integrated from that input power, ready for the Energy Dashboard. The four battery entities and the battery communication alarm are disabled by default, because the add-on battery is optional and a unit without one still reports those fields: the charge arrives as zero, which reads as a flat battery rather than as an absent one, and the alarm arrives as on. The 2 second rate was measured with the EcoFlow app open and it is not yet settled whether it holds with the app closed, so the 120 second standby rate is the one to count on when judging how closely the energy counter tracks a short cooling run. Read-only in this release: mode, setpoint, fan speed and the settings follow once a write from Home Assistant has been confirmed on the hardware, and the commands the app sends have already been recorded, so their shape is known. Only one unit is on record, so owners of the other AC71 variants are asked to report what reads differently. (Ref #161)
+
 ## [1.19.0] - 2026-09-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 | **STREAM 5000** | `ES21` | Enhanced only | 56 + 2 binary | 2 switches · 7 numbers · 1 select | 4 + 1 optional | ~2 s |
 | **Smart Meter** | `BK21` | Enhanced only | 18 + 3 binary | none, read-only | 2 | ~3 s |
 | **Solar Tracker** | `HZ31` `S02F` | Enhanced only | 6 | none, read-only for now | none | ~3 s |
+| **WAVE 3** | `AC71` | Enhanced only | 24 + 6 binary | none, read-only for now | 1 | ~2 s / 120 s |
 
 > **Connection.** Standard Mode reads through the IoT Developer API with your access and secret key; Enhanced Mode signs in with the EcoFlow account and receives pushes at the faster rate. **Enhanced only** means the serial prefix cannot currently be linked to a Developer API key, so Standard Mode reports error 1006 and the entities stay unavailable; the three starred PowerOcean prefixes are in the same position. This is an EcoFlow API limitation, not a configuration problem. Controls marked Enhanced exist only with the account sign-in. The Energy Dashboard column counts the sensors made for it; optional ones are disabled by default and depend on the installation, see the device notes below and the [Energy Dashboard](#energy-dashboard) section.
 >
@@ -185,7 +186,7 @@ Download the [latest release](https://github.com/shuette42/ecoflow-energy-ha/rel
 |:---|:---|:---|
 | **Connection** | EcoFlow cloud (HTTPS polling + MQTT) | EcoFlow cloud (WSS MQTT) |
 | **Credentials** | Access Key + Secret Key ([Developer Portal](https://developer.ecoflow.com)) | EcoFlow email + password (same as mobile app) |
-| **Devices** | All except the Enhanced-only serials (`J327`, `J32D`, `J32E`, `R371`, `R372`, `R374`, `HJ3C`, `BK01`, `ES21`, `ES22`) | All supported devices |
+| **Devices** | All except the Enhanced-only serials (`J327`, `J32D`, `J32E`, `R371`, `R372`, `R374`, `HJ3C`, `BK01`, `BK21`, `ES21`, `ES22`, `HZ31`, `S02F`, `AC71`) | All supported devices |
 | **Update rate** | ~30 s HTTP polling (+ MQTT push for Delta/Smart Plug) | ~2-4 s real-time via WSS MQTT |
 | **Delta 2 Max / Smart Plug controls** | All switches and numbers | All switches and numbers |
 | **Delta 3 controls** | Switches and most numbers; the screen and idle shutdowns and the AC charge power need Enhanced Mode | All switches, numbers and selects |

--- a/custom_components/ecoflow_energy/binary_sensor.py
+++ b/custom_components/ecoflow_energy/binary_sensor.py
@@ -23,6 +23,7 @@ from .const import (
     DEVICE_TYPE_SMARTPLUG,
     DEVICE_TYPE_STREAM,
     DEVICE_TYPE_STREAM_AC5000,
+    DEVICE_TYPE_WAVE3,
     DOMAIN,
     EcoFlowBinarySensorDef,
     filter_defs_for_serial,
@@ -31,6 +32,7 @@ from .const import (
     SMARTPLUG_BINARY_SENSORS,
     STREAM_BINARY_SENSORS,
     STREAMAC5000_BINARY_SENSORS,
+    WAVE3_BINARY_SENSORS,
 )
 from .coordinator import EcoFlowDeviceCoordinator
 from .entity import EcoFlowWriteGateMixin, reading_reported
@@ -180,4 +182,6 @@ def _get_binary_sensor_defs(
         return STREAMAC5000_BINARY_SENSORS
     if device_type == DEVICE_TYPE_SMART_METER:
         return SMARTMETER_BINARY_SENSORS
+    if device_type == DEVICE_TYPE_WAVE3:
+        return WAVE3_BINARY_SENSORS
     return []

--- a/custom_components/ecoflow_energy/const.py
+++ b/custom_components/ecoflow_energy/const.py
@@ -21,6 +21,7 @@ from .ecoflow.const import (  # noqa: E402
     DEVICE_TYPE_STREAM,
     DEVICE_TYPE_STREAM_AC5000,
     DEVICE_TYPE_UNKNOWN,
+    DEVICE_TYPE_WAVE3,
     POWEROCEAN_SCHEDULE_POWER_MAX_DEFAULT_W,
     POWEROCEAN_SCHEDULE_POWER_MIN_W,
     POWEROCEAN_SCHEDULE_POWER_STEP_W,
@@ -283,6 +284,7 @@ DEVICE_TYPE_DISPLAY_NAMES: dict[str, str] = {
     DEVICE_TYPE_POWERSTREAM: "PowerStream",
     DEVICE_TYPE_SMART_METER: "Smart Meter",
     DEVICE_TYPE_SOLAR_TRACKER: "Solar Tracker",
+    DEVICE_TYPE_WAVE3: "WAVE 3",
 }
 
 # Device types that only report over the account channel (app-auth WSS).
@@ -293,6 +295,7 @@ ENHANCED_ONLY_DEVICE_TYPES: frozenset[str] = frozenset(
     {
         DEVICE_TYPE_SMART_METER,
         DEVICE_TYPE_SOLAR_TRACKER,
+        DEVICE_TYPE_WAVE3,
     }
 )
 
@@ -1840,6 +1843,61 @@ SOLARTRACKER_SENSORS: list[EcoFlowSensorDef] = [
     EcoFlowSensorDef("battery_pct", "Battery", "%", "battery", "measurement", "mdi:battery", suggested_display_precision=0),
 ]
 
+# =====================================================================
+# WAVE 3 sensor definitions
+# =====================================================================
+
+# WAVE 3 portable AC (AC71, #161, PLAN-047 Phase A). Account-channel only -
+# no serial prefix can be bound to a Developer Key (error 1006), so every
+# entity below is enhanced_only. See
+# custom_components/ecoflow_energy/ecoflow/parsers/wave3_proto.py for the
+# field notes behind the enums and the optional add-on battery.
+WAVE3_SENSORS: list[EcoFlowSensorDef] = [
+    EcoFlowSensorDef("temp_ambient_c", "Ambient Temperature", "°C", "temperature", "measurement", "mdi:thermometer", suggested_display_precision=1),
+    EcoFlowSensorDef("humi_ambient_pct", "Ambient Humidity", "%", "humidity", "measurement", "mdi:water-percent", suggested_display_precision=0),
+    EcoFlowSensorDef("operating_mode", "Operating Mode", None, "enum", None, "mdi:air-conditioner", options=["cooling", "heating", "fan", "dehumidify", "constant_temp"]),
+    EcoFlowSensorDef("target_temp_c", "Target Temperature", "°C", "temperature", "measurement", "mdi:thermostat", suggested_display_precision=1),
+    EcoFlowSensorDef("airflow_speed_pct", "Fan Speed", "%", None, "measurement", "mdi:fan", suggested_display_precision=0),
+    EcoFlowSensorDef("ac_input_power_w", "AC Input Power", "W", "power", "measurement", "mdi:flash", suggested_display_precision=0),
+    EcoFlowSensorDef("temp_outdoor_ambient_c", "Outdoor Temperature", "°C", "temperature", "measurement", "mdi:thermometer", suggested_display_precision=1),
+    EcoFlowSensorDef("ac_input_energy_kwh", "AC Input Energy", "kWh", "energy", "total_increasing", "mdi:lightning-bolt", suggested_display_precision=2),
+    # --- Diagnostics ---
+    EcoFlowSensorDef("temp_indoor_supply_air_c", "Supply Air Temperature", "°C", "temperature", "measurement", "mdi:thermometer-chevron-up", "diagnostic", suggested_display_precision=1),
+    EcoFlowSensorDef("temp_indoor_return_air_c", "Return Air Temperature", "°C", "temperature", "measurement", "mdi:thermometer-chevron-down", "diagnostic", suggested_display_precision=1),
+    EcoFlowSensorDef("operating_submode", "Operating Submode", None, "enum", None, "mdi:cog-outline", "diagnostic", options=["none", "normal", "max", "sleep", "eco"]),
+    EcoFlowSensorDef("ac_input_voltage_v", "AC Input Voltage", "V", "voltage", "measurement", "mdi:sine-wave", "diagnostic", suggested_display_precision=1),
+    EcoFlowSensorDef("ac_input_current_a", "AC Input Current", "A", "current", "measurement", "mdi:current-ac", "diagnostic", suggested_display_precision=2),
+    # `temp_condenser_c`, `temp_evaporator_c`, `temp_compressor_discharge_c`, `target_humidity_pct`
+    # and `screen_brightness_pct` are disabled by default: internal refrigeration-cycle and
+    # display readings, useful for diagnostics but not something most users watch daily.
+    EcoFlowSensorDef("temp_condenser_c", "Condenser Temperature", "°C", "temperature", "measurement", "mdi:thermometer-high", "diagnostic", suggested_display_precision=1, disabled_by_default=True),
+    EcoFlowSensorDef("temp_evaporator_c", "Evaporator Temperature", "°C", "temperature", "measurement", "mdi:thermometer-low", "diagnostic", suggested_display_precision=1, disabled_by_default=True),
+    EcoFlowSensorDef("temp_compressor_discharge_c", "Compressor Discharge Temperature", "°C", "temperature", "measurement", "mdi:thermometer-alert", "diagnostic", suggested_display_precision=1, disabled_by_default=True),
+    EcoFlowSensorDef("target_humidity_pct", "Target Humidity", "%", "humidity", "measurement", "mdi:water-percent", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    EcoFlowSensorDef("screen_brightness_pct", "Screen Brightness", "%", None, "measurement", "mdi:brightness-6", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    # --- Optional add-on battery: disabled by default, reads 0 on units without one ---
+    EcoFlowSensorDef("battery_soc_pct", "Battery", "%", "battery", "measurement", "mdi:battery", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    EcoFlowSensorDef("battery_voltage_v", "Battery Voltage", "V", "voltage", "measurement", "mdi:flash-triangle", "diagnostic", suggested_display_precision=2, disabled_by_default=True),
+    EcoFlowSensorDef("battery_current_a", "Battery Current", "A", "current", "measurement", "mdi:current-dc", "diagnostic", suggested_display_precision=2, disabled_by_default=True),
+    EcoFlowSensorDef("battery_power_w", "Battery Power", "W", "power", "measurement", "mdi:battery", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    # Not the add-on battery group above: no non-zero value has been observed
+    # yet on the one unit on record, so it stays off until one is (#161).
+    EcoFlowSensorDef("pv_input_power_w", "PV Input Power", "W", "power", "measurement", "mdi:solar-power", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+    # Not the add-on battery group above: unit is unknown, the capture only
+    # ever showed 0.0 for this key, so it stays off until a unit is known.
+    EcoFlowSensorDef("condensate_water_level", "Condensate Water Level", None, None, "measurement", "mdi:water", "diagnostic", suggested_display_precision=0, disabled_by_default=True),
+]
+
+WAVE3_BINARY_SENSORS: list[EcoFlowBinarySensorDef] = [
+    EcoFlowBinarySensorDef("running", "Running", "running", "mdi:power", None),
+    EcoFlowBinarySensorDef("ac_input_connected", "AC Input Connected", "plug", "mdi:power-plug", "diagnostic"),
+    EcoFlowBinarySensorDef("fault", "Fault", "problem", "mdi:alert-circle", "diagnostic"),
+    EcoFlowBinarySensorDef("draining", "Draining", None, "mdi:water", "diagnostic"),
+    EcoFlowBinarySensorDef("pet_care_alarm", "Pet Care Alarm", "problem", "mdi:paw", "diagnostic", disabled_by_default=True),
+    # Reads true on every unit without an add-on battery fitted.
+    EcoFlowBinarySensorDef("bms_communication_error", "Battery Communication Error", "problem", "mdi:battery-alert", "diagnostic", disabled_by_default=True),
+]
+
 
 # =====================================================================
 # Power → Energy mappings (Riemann sum integration per device type)
@@ -1931,6 +1989,14 @@ POWERSTREAM_POWER_TO_ENERGY: dict[str, str] = {
 }
 
 POWERSTREAM_ENERGY_FROM_API: list[tuple[str, str]] = []
+
+# The Riemann sum samples every frame carrying the power reading: about 2s
+# while the unit runs, 120s in standby (WAVE3's push cadence).
+WAVE3_POWER_TO_ENERGY: dict[str, str] = {
+    "ac_input_power_w": "ac_input_energy_kwh",
+}
+
+WAVE3_ENERGY_FROM_API: list[tuple[str, str]] = []
 
 
 # ===========================================================================

--- a/custom_components/ecoflow_energy/coordinator/core.py
+++ b/custom_components/ecoflow_energy/coordinator/core.py
@@ -44,6 +44,7 @@ from ..const import (
     DEVICE_TYPE_STREAM,
     DEVICE_TYPE_STREAM_AC5000,
     DEVICE_TYPE_UNKNOWN,
+    DEVICE_TYPE_WAVE3,
     DOMAIN,
     HTTP_FALLBACK_INTERVAL_S,
     POWEROCEAN_ENERGY_FROM_API,
@@ -61,6 +62,8 @@ from ..const import (
     STREAMAC5000_POWER_TO_ENERGY,
     UNKNOWN_FIELD_CMDS_MAX,
     UNKNOWN_FIELD_NUMBERS_MAX,
+    WAVE3_ENERGY_FROM_API,
+    WAVE3_POWER_TO_ENERGY,
     device_log_tag,
     get_delta_profile,
     get_device_name,
@@ -418,6 +421,9 @@ class EcoFlowDeviceCoordinator(
         elif self.device_type == DEVICE_TYPE_POWERSTREAM:
             self._power_to_energy = POWERSTREAM_POWER_TO_ENERGY
             self._energy_from_api = POWERSTREAM_ENERGY_FROM_API
+        elif self.device_type == DEVICE_TYPE_WAVE3:
+            self._power_to_energy = WAVE3_POWER_TO_ENERGY
+            self._energy_from_api = WAVE3_ENERGY_FROM_API
         else:
             self._power_to_energy = {}
             self._energy_from_api = []

--- a/custom_components/ecoflow_energy/coordinator/mqtt_ingest.py
+++ b/custom_components/ecoflow_energy/coordinator/mqtt_ingest.py
@@ -17,6 +17,7 @@ from ..const import (
     DEVICE_TYPE_SOLAR_TRACKER,
     DEVICE_TYPE_STREAM,
     DEVICE_TYPE_STREAM_AC5000,
+    DEVICE_TYPE_WAVE3,
     RAW_FRAME_BUNDLE_HARD_CAP,
     RAW_FRAME_BUNDLE_MAX_BYTES,
     RAW_FRAME_MAX_BYTES,
@@ -47,6 +48,7 @@ from ..ecoflow.parsers.smartplug import (
     parse_smartplug_report,
 )
 from ..ecoflow.parsers.solar_tracker_proto import parse_solar_tracker_message
+from ..ecoflow.parsers.wave3_proto import parse_wave3_message
 from ..ecoflow.parsers.stream_ac5000_proto import parse_stream_ac5000_message
 from ..ecoflow.parsers.powerstream_http import parse_powerstream_quota
 from ..ecoflow.parsers.stream_http import parse_stream_quota
@@ -447,6 +449,11 @@ class MqttIngestMixin:
                     return parse_smart_meter_message(payload)
                 if self.device_type == DEVICE_TYPE_SOLAR_TRACKER:
                     return parse_solar_tracker_message(payload)
+                # The WAVE 3 shares (254, 21)/(254, 22) with the Smart Meter
+                # and the Stream AC Pro and means different fields by them,
+                # so it routes by device type before the registry lookup.
+                if self.device_type == DEVICE_TYPE_WAVE3:
+                    return parse_wave3_message(payload)
                 return self._parse_proto_device_data(payload)
             return None
 
@@ -552,6 +559,12 @@ class MqttIngestMixin:
                 # device type for the same reason as the meter above.
                 if self.device_type == DEVICE_TYPE_SOLAR_TRACKER:
                     return parse_solar_tracker_message(payload)
+                # WAVE 3 (#161): shares (254, 21)/(254, 22) with the Smart
+                # Meter and the Stream AC Pro and means different fields by
+                # them, so it routes by device type for the same reason as
+                # the meter above.
+                if self.device_type == DEVICE_TYPE_WAVE3:
+                    return parse_wave3_message(payload)
                 if self.device_type == DEVICE_TYPE_POWEROCEAN:
                     return self._parse_powerocean_proto_frame(payload)
 

--- a/custom_components/ecoflow_energy/coordinator/state_apply.py
+++ b/custom_components/ecoflow_energy/coordinator/state_apply.py
@@ -6,14 +6,22 @@ import logging
 import time
 from typing import Any
 
+from homeassistant.helpers import device_registry as dr
+
 from ..const import (
     APP_SURPLUS_SYNC_MIN_INTERVAL_S,
     APP_SURPLUS_SYNC_USER_GRACE_S,
     DEVICE_TYPE_POWEROCEAN,
+    DEVICE_TYPE_WAVE3,
+    DOMAIN,
     POWEROCEAN_SCHEDULE_ARMED_LATCH_S,
 )
 from ..ecoflow.parsers.stream_ac5000_proto import UNIT_POWER_BY_SN_KEY
 from ..ecoflow.parsers.stream_proto import SOC_FALLBACK_KEY
+from ..ecoflow.parsers.wave3_proto import (
+    WAVE3_ACTIVE_MODE_INPUTS,
+    resolve_active_mode,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -183,8 +191,48 @@ class StateApplyMixin:
         self._resolve_unit_power(parsed)
         self._resolve_soc(parsed)
         self._resolve_schedule_armed(parsed)
+
+        # WAVE 3 (#161): the RuntimePropertyUpload carries its own firmware
+        # revision, the first device in this integration to report one over
+        # MQTT rather than only through the HTTP quota. Surface it the same
+        # way the quota path does (self._firmware, read by diagnostics) and
+        # push it to the device registry so the HA device page shows it.
+        # Popped (and scoped to this device type) before `_note_value_change`
+        # runs below, so a repeated firmware value is not itself counted as
+        # a device-carried change, and the key is not swallowed for whatever
+        # future parser next emits it (PLAN-047 review F1, F4).
+        if self.device_type == DEVICE_TYPE_WAVE3:
+            firmware = parsed.pop("firmware_version", None)
+            if isinstance(firmware, str) and firmware:
+                self._sw_version = firmware
+                self._firmware["pd_firm_ver"] = {"decoded": firmware}
+                registry = dr.async_get(self.hass)
+                device = registry.async_get_device(
+                    identifiers={(DOMAIN, self.device_sn)}
+                )
+                # The registry's own state is the comparison (PLAN-047
+                # review F2), not `_sw_version`: the device registry entry
+                # is created when the platforms add their entities, which
+                # can land after the first firmware frame. Gating on
+                # `_sw_version` alone would then never retry for the life
+                # of the config entry once that first race was lost.
+                if device is not None and device.sw_version != firmware:
+                    registry.async_update_device(device.id, sw_version=firmware)
+
         self._note_value_change(parsed)
+
         self._device_data.update(parsed)
+
+        # WAVE 3 (#161): re-derive the four generic active-mode keys from
+        # accumulated state, not from this message alone. A 2s incremental
+        # frame can carry a mode switch without that mode's per-mode list
+        # (the device only resends `514` on a full upload), so deriving from
+        # `parsed` would leave the previous mode's setpoint standing for up
+        # to 120s, the WAVE 3's idle push cadence.
+        if self.device_type == DEVICE_TYPE_WAVE3 and (
+            parsed.keys() & WAVE3_ACTIVE_MODE_INPUTS
+        ):
+            self._device_data.update(resolve_active_mode(self._device_data))
 
         # Re-aggregate bp_remain_watth from accumulated device_data (#10).
         # Each proto heartbeat may only contain a subset of battery packs.

--- a/custom_components/ecoflow_energy/ecoflow/const.py
+++ b/custom_components/ecoflow_energy/ecoflow/const.py
@@ -52,6 +52,12 @@ DEVICE_TYPE_SMART_METER = "smart_meter"
 # ships under, `HZ31` and `S02F`: same product id (7937), same productType
 # (31), same report message (32/1). Reported in #339.
 DEVICE_TYPE_SOLAR_TRACKER = "solar_tracker"
+# WAVE 3 portable air conditioner (`AC71`, app productType 44, internal
+# family AC517). Enhanced mode only: the Developer API lists the unit with
+# an empty product name and refuses every quota read with error 1006, and
+# the app channel carries no product name either, so the type is reached
+# through the serial prefix below and never through a keyword (#161).
+DEVICE_TYPE_WAVE3 = "wave3"
 DEVICE_TYPE_UNKNOWN = "unknown"
 
 # Keywords used to classify devices from productName strings.
@@ -234,6 +240,12 @@ _SN_PREFIX_MAP = {
     # by name alone and skipped as unsupported.
     "HZ31": DEVICE_TYPE_SOLAR_TRACKER,
     "S02F": DEVICE_TYPE_SOLAR_TRACKER,
+    # WAVE 3 (#161): productType 44, family AC517. The Developer API lists
+    # it (`productName` empty) and refuses its quota with 1006, the app API
+    # lists it without any product name, so without this entry the unit is
+    # classified by name alone and skipped as unsupported. Further `AC71*`
+    # regional variants join here as owners report them, like the BK series.
+    "AC71": DEVICE_TYPE_WAVE3,
 }
 
 _SN_PREFIX_DISPLAY_NAMES: dict[str, str] = {
@@ -253,6 +265,9 @@ _SN_PREFIX_DISPLAY_NAMES: dict[str, str] = {
     "BK21": "Smart Meter",
     "HZ31": "Solar Tracker",
     "S02F": "Solar Tracker",
+    # WAVE 3: the app names it "WAVE 3-<tail>", neither channel gives a
+    # product name, so `get_device_name` renders "WAVE 3 (0052)" from here.
+    "AC71": "WAVE 3",
 }
 
 # --- Scheduled charge task: the charge power range the app offers ---
@@ -355,13 +370,13 @@ def get_device_type(product_name: str, sn: str = "") -> str:
     Returns DEVICE_TYPE_POWEROCEAN, DEVICE_TYPE_DELTA, DEVICE_TYPE_DELTA3,
     DEVICE_TYPE_SMARTPLUG, DEVICE_TYPE_STREAM, DEVICE_TYPE_STREAM_AC5000,
     DEVICE_TYPE_POWERSTREAM, DEVICE_TYPE_SMART_METER,
-    DEVICE_TYPE_SOLAR_TRACKER, or DEVICE_TYPE_UNKNOWN.
+    DEVICE_TYPE_SOLAR_TRACKER, DEVICE_TYPE_WAVE3, or DEVICE_TYPE_UNKNOWN.
 
-    The Smart Meter and the Solar Tracker have no keyword of their own:
-    both are reached by their serial prefix only. Neither name matches any
-    keyword list below, and the app API reports an empty product name for
-    both, so a keyword would be an assumption about a string no capture has
-    ever shown.
+    The Smart Meter, the Solar Tracker and the WAVE 3 have no keyword of
+    their own: all three are reached by their serial prefix only. None of
+    their names matches any keyword list below, and the app API reports an
+    empty product name for each, so a keyword would be an assumption about
+    a string no capture has ever shown.
     """
     # The prefix is exact evidence, the product name a substring guess, so
     # the prefix wins. Every prefix mapped before this ordering existed

--- a/custom_components/ecoflow_energy/ecoflow/parsers/wave3_proto.py
+++ b/custom_components/ecoflow_energy/ecoflow/parsers/wave3_proto.py
@@ -1,0 +1,450 @@
+"""Protobuf telemetry parser for the EcoFlow WAVE 3 (AC71) portable AC unit.
+
+Derived from a 24-hour listen-only capture of a live AC71 in app-auth MQTT
+mode (PLAN-047, issue #161), spanning standby, a running cycle and a sleep
+transition. The device is a portable air conditioner with a small battery
+and PV input, not a power station: it reports climate readings (indoor and
+outdoor temperature, humidity, condensate level) alongside the power and
+battery figures a Stream-family device would carry.
+
+The envelope is the BK-series one, so everything that unwraps a frame is
+imported from `stream_proto.py`: the header decode, the per-header XOR mask
+keyed on the low byte of the sequence number, the one-level field walk and
+the scalar decoder.
+
+Two message types carry readings, both under cmd_func 254:
+
+- `21` DisplayPropertyUpload, the telemetry frame. Three shapes were
+  observed: a small incremental (one or two fields, most often the AC input
+  power), a sleep-state flip (field 212 alone), and a full upload of ~50
+  fields including the two nested records below.
+- `22` RuntimePropertyUpload, the temperature and firmware frame - the
+  indoor/outdoor sensor readings the `21` full upload does not carry, plus
+  the packed firmware version.
+
+A third message, `23` DevRequest, carries no reading fields at all and is
+left out of the map entirely, the same way the Smart Meter parser leaves its
+own upload-period message unmapped.
+
+Both nested records live inside the `21` full upload:
+
+- `514` wave_mode_info is the per-mode configuration list: five entries, one
+  per operating mode, each holding that mode's fan speed, target
+  temperature or humidity, and (for cooling/heating) its submode. The
+  entry's position in the list is the mode value itself (`operating_mode`
+  1-5 select entries 1-5; entry 0 carries nothing). A present `514` is
+  always treated as the complete list - all thirteen keys across the five
+  modes are published, `None` where an entry or a field inside it is
+  absent - so a caller reading the currently active mode never has to
+  guess whether a missing key means "not sent" or "cleared".
+- `627` dev_errcode_list holds one packed repeated error-code field; it
+  collapses to a single `fault` flag (any code non-zero), because no
+  captured frame ever carried a non-zero code to name.
+
+Field notes:
+
+- `53` pow_get_ac and `777` pow_get_self_consume are byte-identical in
+  every captured frame. `777` is left unmapped rather than aliased to the
+  same sensor key, on the same reasoning `stream_proto.py` applies to its
+  own duplicate led fields: two sources for one entity flap the moment they
+  diverge, and nothing in this capture proves they always agree.
+- `212` dev_sleep_state is the device's own idle flag, not a power state:
+  it flips to 1 while otherwise sending nothing but that one field, which
+  is the "incremental sleep" shape above. `running` is its inversion.
+- `176` pd_firm_ver packs the firmware revision the way `firmware.py`
+  already decodes for other devices (`decode_version`); it is only
+  published when non-zero, so a `22` upload that has not yet reported it
+  does not overwrite a previously known version with an empty string.
+- Field names above are the AC71's own message definition
+  (Ac517AplComm.proto): `lcd_light`, `pow_get_ac`, `bms_batt_soc`,
+  `wave_operating_mode`, `wave_mode_info`, `dev_errcode_list`, and so on.
+
+Deliberately not mapped: cmd `23` (DevRequest, no reading fields at all) and
+field `777` (see above). Values are published unrounded, as in
+`stream_proto.py`.
+
+Three enum label maps (`automatic_drainage`, `mood_light_mode`,
+`display_temperature_source`) have no proto enum to read from; the labels
+rest on the vendor app's own option lists and drainage toggle handler, and
+the capture showed each field at one value only. No entity is built on any
+of the three yet - reading them back is Phase B work.
+"""
+
+from __future__ import annotations
+
+from math import isfinite
+from typing import Any, Mapping
+
+from ..firmware import decode_version
+from ..proto.decoder import _read_varint, decode_header_message
+from .stream_proto import (
+    _FLOAT_ZERO_EPS,
+    _TYPE_FLOAT,
+    _TYPE_INT,
+    _decode_scalar,
+    _iter_fields,
+    _pdata_candidates,
+)
+
+# The two nested records inside the `254/21` full upload. Neither is a flat
+# scalar, so both are pulled out of the generic field loop in
+# `_decode_mapped_fields` and handed to their own decoders.
+_MODE_INFO_FIELD = 514
+_ERRCODE_LIST_FIELD = 627
+
+# cmd_func/cmd_id -> field_number -> (sensor_key, scalar_type)
+_WAVE3_FIELD_MAP: dict[tuple[int, int], dict[int, tuple[str, str]]] = {
+    (254, 21): {
+        5: ("screen_brightness_pct", _TYPE_INT),
+        18: ("screen_off_time_s", _TYPE_INT),
+        53: ("ac_input_power_w", _TYPE_FLOAT),
+        61: ("_ac_input_connected_raw", _TYPE_INT),
+        158: ("battery_power_w", _TYPE_FLOAT),
+        195: ("_beep_enabled_raw", _TYPE_INT),
+        212: ("_dev_sleep_state_raw", _TYPE_INT),
+        242: ("battery_soc_pct", _TYPE_FLOAT),
+        361: ("pv_input_power_w", _TYPE_FLOAT),
+        484: ("temp_ambient_c", _TYPE_FLOAT),
+        485: ("humi_ambient_pct", _TYPE_FLOAT),
+        486: ("_operating_mode_raw", _TYPE_INT),
+        494: ("temp_indoor_supply_air_c", _TYPE_FLOAT),
+        504: ("condensate_water_level", _TYPE_FLOAT),
+        505: ("_draining_raw", _TYPE_INT),
+        506: ("_drainage_mode_raw", _TYPE_INT),
+        507: ("_mood_light_mode_raw", _TYPE_INT),
+        508: ("_display_temperature_source_raw", _TYPE_INT),
+        509: ("_pet_care_enabled_raw", _TYPE_INT),
+        510: ("pet_care_warning_temp_c", _TYPE_FLOAT),
+        513: ("_pet_care_alarm_raw", _TYPE_INT),
+        # 514 and 627 are nested records; see _decode_mapped_fields.
+    },
+    (254, 22): {
+        68: ("ac_input_voltage_v", _TYPE_FLOAT),
+        174: ("_bms_communication_error_raw", _TYPE_INT),
+        176: ("_pd_firm_ver_raw", _TYPE_INT),
+        223: ("ac_input_current_a", _TYPE_FLOAT),
+        244: ("battery_voltage_v", _TYPE_FLOAT),
+        245: ("battery_current_a", _TYPE_FLOAT),
+        493: ("temp_indoor_return_air_c", _TYPE_FLOAT),
+        495: ("temp_outdoor_ambient_c", _TYPE_FLOAT),
+        496: ("temp_condenser_c", _TYPE_FLOAT),
+        499: ("temp_evaporator_c", _TYPE_FLOAT),
+        503: ("temp_compressor_discharge_c", _TYPE_FLOAT),
+    },
+}
+
+# wave_mode_info (field 514) sub-records, keyed by the entry's position in
+# the repeated list - which is the operating-mode value that entry belongs
+# to (1 cooling .. 5 constant_temp; position 0 carries nothing). Sub-field 1
+# is the submode, 2 the fan speed, 3 the target temperature, 4 the target
+# humidity, 5/6 the constant-temp upper/lower limit.
+_MODE_INFO_ENTRY_FIELDS: dict[int, dict[int, tuple[str, str]]] = {
+    1: {  # cooling
+        1: ("cooling_submode", _TYPE_INT),
+        2: ("cooling_fan_speed_pct", _TYPE_INT),
+        3: ("cooling_target_temp_c", _TYPE_FLOAT),
+    },
+    2: {  # heating
+        1: ("heating_submode", _TYPE_INT),
+        2: ("heating_fan_speed_pct", _TYPE_INT),
+        3: ("heating_target_temp_c", _TYPE_FLOAT),
+    },
+    3: {  # fan only
+        2: ("fan_only_fan_speed_pct", _TYPE_INT),
+    },
+    4: {  # dehumidify
+        2: ("dehumidify_fan_speed_pct", _TYPE_INT),
+        4: ("dehumidify_target_humidity_pct", _TYPE_FLOAT),
+    },
+    5: {  # constant temp
+        2: ("constant_temp_fan_speed_pct", _TYPE_INT),
+        3: ("constant_temp_target_temp_c", _TYPE_FLOAT),
+        5: ("constant_temp_upper_limit_c", _TYPE_FLOAT),
+        6: ("constant_temp_lower_limit_c", _TYPE_FLOAT),
+    },
+}
+
+# All thirteen keys a present 514 publishes, so a caller can tell "not
+# reported this message" (key absent, e.g. a message that carries no 514 at
+# all) from "reported and cleared" (key present, value None).
+_MODE_INFO_ALL_KEYS: tuple[str, ...] = tuple(
+    key for fields in _MODE_INFO_ENTRY_FIELDS.values() for key, _ in fields.values()
+)
+
+# The device always sends exactly this many entries: position 0 (empty) plus
+# one per mode 1-5. Measured in all 12 full 514 records of the capture
+# (PLAN-047 review, finding A3). A record with a different count is a shape
+# this map cannot label without risking a wrong mode under a right name, so
+# `_decode_mode_info` refuses to guess and publishes the all-None dict.
+_MODE_INFO_ENTRY_COUNT = 6
+
+_SUBMODE_NAMES: dict[int, str] = {0: "none", 1: "normal", 2: "max", 3: "sleep", 4: "eco"}
+_SUBMODE_KEYS = frozenset({"cooling_submode", "heating_submode"})
+
+_OPERATING_MODE_NAMES: dict[int, str] = {
+    1: "cooling",
+    2: "heating",
+    3: "fan",
+    4: "dehumidify",
+    5: "constant_temp",
+}
+_MOOD_LIGHT_MODE_NAMES: dict[int, str] = {0: "off", 1: "on", 2: "screen_time"}
+_DISPLAY_TEMPERATURE_SOURCE_NAMES: dict[int, str] = {0: "ambient", 1: "outlet"}
+_AUTOMATIC_DRAINAGE_NAMES: dict[int, bool] = {0: False, 1: True}
+
+# Plain boolean raw fields: 0/1 on the wire, a bool in the published state.
+_BOOL_RAW_KEYS: dict[str, str] = {
+    "_ac_input_connected_raw": "ac_input_connected",
+    "_beep_enabled_raw": "beep_enabled",
+    "_draining_raw": "draining",
+    "_pet_care_enabled_raw": "pet_care_enabled",
+    "_pet_care_alarm_raw": "pet_care_alarm",
+    "_bms_communication_error_raw": "bms_communication_error",
+}
+
+# The four keys `resolve_active_mode` fills for each operating mode. `None`
+# means that mode has no reading for that generic slot (fan mode has no
+# target temperature or humidity, for instance).
+_ACTIVE_MODE_KEYS: dict[str, dict[str, str | None]] = {
+    "cooling": {
+        "target_temp_c": "cooling_target_temp_c",
+        "airflow_speed_pct": "cooling_fan_speed_pct",
+        "target_humidity_pct": None,
+        "operating_submode": "cooling_submode",
+    },
+    "heating": {
+        "target_temp_c": "heating_target_temp_c",
+        "airflow_speed_pct": "heating_fan_speed_pct",
+        "target_humidity_pct": None,
+        "operating_submode": "heating_submode",
+    },
+    "fan": {
+        "target_temp_c": None,
+        "airflow_speed_pct": "fan_only_fan_speed_pct",
+        "target_humidity_pct": None,
+        "operating_submode": None,
+    },
+    "dehumidify": {
+        "target_temp_c": None,
+        "airflow_speed_pct": "dehumidify_fan_speed_pct",
+        "target_humidity_pct": "dehumidify_target_humidity_pct",
+        "operating_submode": None,
+    },
+    "constant_temp": {
+        "target_temp_c": "constant_temp_target_temp_c",
+        "airflow_speed_pct": "constant_temp_fan_speed_pct",
+        "target_humidity_pct": None,
+        "operating_submode": None,
+    },
+}
+
+# Every accumulated-state key `resolve_active_mode` can read: every non-None
+# source key across `_ACTIVE_MODE_KEYS` plus `operating_mode`, which selects
+# the mode before any source key is read. Exported so the HA layer can guard
+# its own accumulated-state passthrough against this table instead of
+# hand-copying it (PLAN-047 review, finding item 5).
+WAVE3_ACTIVE_MODE_INPUTS: frozenset[str] = frozenset(
+    {"operating_mode"}
+    | {
+        source_key
+        for key_map in _ACTIVE_MODE_KEYS.values()
+        for source_key in key_map.values()
+        if source_key is not None
+    }
+)
+
+_ACTIVE_MODE_EMPTY: dict[str, Any] = {
+    "target_temp_c": None,
+    "airflow_speed_pct": None,
+    "target_humidity_pct": None,
+    "operating_submode": None,
+}
+
+
+def _decode_mode_info(raw: bytes) -> dict[str, Any]:
+    """Decode wave_mode_info (field 514) into its thirteen keys.
+
+    Every key is initialized to `None` before the walk, so a mode entry
+    that is present but empty (position 0 in every capture) or a field
+    missing from an otherwise-present entry both come out as an explicit
+    `None`, never a missing key.
+
+    The entry's position - not its ordinal among every field the record
+    holds - is what selects the mode, so the counter only advances on an
+    accepted entry (field 1, wire type 2); a stray field before the list
+    no longer shifts every mode by one (PLAN-047 review, finding A2). And
+    a record whose entry count is not exactly `_MODE_INFO_ENTRY_COUNT` is
+    a list this map was not built for, so it is left unlabelled rather
+    than guessed at (finding A3).
+    """
+    result: dict[str, Any] = dict.fromkeys(_MODE_INFO_ALL_KEYS)
+
+    entries: list[bytes] = [
+        item for field_num, wire_type, item in _iter_fields(raw) if field_num == 1 and wire_type == 2
+    ]
+    if len(entries) != _MODE_INFO_ENTRY_COUNT:
+        return result
+
+    for position, item in enumerate(entries):
+        entry_fields = _MODE_INFO_ENTRY_FIELDS.get(position)
+        if entry_fields is None:
+            continue
+        for sub_num, sub_wire, sub_raw in _iter_fields(item):
+            mapping = entry_fields.get(sub_num)
+            if mapping is None:
+                continue
+            key, scalar_type = mapping
+            value = _decode_scalar(sub_wire, sub_raw, scalar_type)
+            if value is None:
+                continue
+            if key in _SUBMODE_KEYS:
+                result[key] = _SUBMODE_NAMES.get(int(value))
+            else:
+                result[key] = value
+
+    return result
+
+
+def _decode_errcode_list(raw: bytes) -> bool:
+    """Decode dev_errcode_list (field 627) into a single `fault` flag.
+
+    Field 1 inside the record is a packed repeated uint32 error-code list;
+    `fault` is true when any code in it is non-zero.
+    """
+    for field_num, _wire_type, packed in _iter_fields(raw):
+        if field_num != 1:
+            continue
+        mv = memoryview(packed)
+        pos = 0
+        while pos < len(mv):
+            value, pos = _read_varint(mv, pos)
+            if value is None:
+                break
+            if value:
+                return True
+    return False
+
+
+def _decode_mapped_fields(
+    pdata: bytes,
+    field_map: dict[int, tuple[str, str]],
+) -> dict[str, Any]:
+    """Decode the mapped scalars plus the two nested records at 514/627."""
+    result: dict[str, Any] = {}
+
+    for field_num, wire_type, raw in _iter_fields(pdata):
+        if field_num == _MODE_INFO_FIELD and wire_type == 2:
+            result.update(_decode_mode_info(raw))
+            continue
+        if field_num == _ERRCODE_LIST_FIELD and wire_type == 2:
+            result["fault"] = _decode_errcode_list(raw)
+            continue
+
+        mapping = field_map.get(field_num)
+        if mapping is None:
+            continue
+
+        sensor_key, scalar_type = mapping
+        value = _decode_scalar(wire_type, raw, scalar_type)
+        if value is not None:
+            result[sensor_key] = value
+
+    return result
+
+
+def _finalize(parsed: dict[str, Any]) -> dict[str, Any]:
+    """Normalize near-zero floats and resolve the raw enum/boolean fields."""
+    result = dict(parsed)
+
+    for key, value in list(result.items()):
+        if isinstance(value, float) and isfinite(value) and abs(value) < _FLOAT_ZERO_EPS:
+            result[key] = 0.0
+
+    sleep_raw = result.pop("_dev_sleep_state_raw", None)
+    if isinstance(sleep_raw, int):
+        result["running"] = not bool(sleep_raw)
+
+    for raw_key, sensor_key in _BOOL_RAW_KEYS.items():
+        raw_value = result.pop(raw_key, None)
+        if isinstance(raw_value, int):
+            result[sensor_key] = bool(raw_value)
+
+    mode_raw = result.pop("_operating_mode_raw", None)
+    if isinstance(mode_raw, int):
+        result["operating_mode"] = _OPERATING_MODE_NAMES.get(mode_raw)
+
+    mood_raw = result.pop("_mood_light_mode_raw", None)
+    if isinstance(mood_raw, int):
+        result["mood_light_mode"] = _MOOD_LIGHT_MODE_NAMES.get(mood_raw)
+
+    display_raw = result.pop("_display_temperature_source_raw", None)
+    if isinstance(display_raw, int):
+        result["display_temperature_source"] = _DISPLAY_TEMPERATURE_SOURCE_NAMES.get(display_raw)
+
+    drainage_raw = result.pop("_drainage_mode_raw", None)
+    if isinstance(drainage_raw, int):
+        result["automatic_drainage"] = _AUTOMATIC_DRAINAGE_NAMES.get(drainage_raw)
+
+    firmware_raw = result.pop("_pd_firm_ver_raw", None)
+    if isinstance(firmware_raw, int) and firmware_raw:
+        result["firmware_version"] = decode_version(firmware_raw)
+
+    return result
+
+
+def parse_wave3_message(payload: bytes) -> dict[str, Any] | None:
+    """Parse a WAVE 3 (AC71) protobuf frame into flat sensor keys."""
+    try:
+        headers, _ = decode_header_message(payload)
+        if not headers:
+            return None
+
+        merged: dict[str, Any] = {}
+        for header in headers:
+            cmd_key = (int(header.get("cmd_func", -1)), int(header.get("cmd_id", -1)))
+            field_map = _WAVE3_FIELD_MAP.get(cmd_key)
+            if field_map is None:
+                continue
+            for pdata in _pdata_candidates(header):
+                try:
+                    decoded = _decode_mapped_fields(pdata, field_map)
+                except (IndexError, ValueError):
+                    # Only a payload that is not valid protobuf falls through
+                    # to the next candidate; a clean decode ends the attempt,
+                    # empty or not (see _pdata_candidates).
+                    continue
+                merged.update(decoded)
+                break
+    except Exception:
+        return None
+    if not merged:
+        return None
+
+    finalized = _finalize(merged)
+    return finalized or None
+
+
+def resolve_active_mode(state: Mapping[str, Any]) -> dict[str, Any]:
+    """Resolve the four generic active-mode keys from accumulated device state.
+
+    The device always sends the full per-mode configuration in `514`, so
+    `state` carries all five modes' settings at once; `operating_mode`
+    selects which group is the one currently in effect. Pure and HA-free:
+    the coordinator/sensor layer is expected to call this with the merged
+    device state, never a single message's fields.
+    """
+    if "operating_mode" not in state:
+        return {}
+
+    mode = state["operating_mode"]
+    if mode is None:
+        return dict(_ACTIVE_MODE_EMPTY)
+
+    key_map = _ACTIVE_MODE_KEYS.get(mode)
+    if key_map is None:
+        return dict(_ACTIVE_MODE_EMPTY)
+
+    return {
+        out_key: (state.get(source_key) if source_key is not None else None)
+        for out_key, source_key in key_map.items()
+    }

--- a/custom_components/ecoflow_energy/manifest.json
+++ b/custom_components/ecoflow_energy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/shuette42/ecoflow-energy-ha/issues",
   "requirements": [],
-  "version": "1.19.0"
+  "version": "1.20.0"
 }

--- a/custom_components/ecoflow_energy/sensor.py
+++ b/custom_components/ecoflow_energy/sensor.py
@@ -26,6 +26,7 @@ from .const import (
     DEVICE_TYPE_SOLAR_TRACKER,
     DEVICE_TYPE_STREAM,
     DEVICE_TYPE_STREAM_AC5000,
+    DEVICE_TYPE_WAVE3,
     DOMAIN,
     DELTA2MAX_SENSORS,
     DELTA3_SENSORS,
@@ -38,6 +39,7 @@ from .const import (
     SOLARTRACKER_SENSORS,
     STREAM_SENSORS,
     STREAMAC5000_SENSORS,
+    WAVE3_SENSORS,
 )
 from .coordinator import EcoFlowDeviceCoordinator
 from .entity import EcoFlowWriteGateMixin, reading_reported
@@ -327,4 +329,6 @@ def _get_sensor_defs(device_type: str) -> list[EcoFlowSensorDef]:
         return SMARTMETER_SENSORS
     if device_type == DEVICE_TYPE_SOLAR_TRACKER:
         return SOLARTRACKER_SENSORS
+    if device_type == DEVICE_TYPE_WAVE3:
+        return WAVE3_SENSORS
     return []

--- a/custom_components/ecoflow_energy/strings.json
+++ b/custom_components/ecoflow_energy/strings.json
@@ -1480,6 +1480,92 @@
       },
       "grid_power_factor": {
         "name": "Power Factor"
+      },
+      "temp_ambient_c": {
+        "name": "Ambient Temperature"
+      },
+      "humi_ambient_pct": {
+        "name": "Ambient Humidity"
+      },
+      "operating_mode": {
+        "name": "Operating Mode",
+        "state": {
+          "cooling": "Cooling",
+          "heating": "Heating",
+          "fan": "Fan",
+          "dehumidify": "Dehumidify",
+          "constant_temp": "Constant Temperature"
+        }
+      },
+      "target_temp_c": {
+        "name": "Target Temperature"
+      },
+      "airflow_speed_pct": {
+        "name": "Fan Speed"
+      },
+      "ac_input_power_w": {
+        "name": "AC Input Power"
+      },
+      "temp_outdoor_ambient_c": {
+        "name": "Outdoor Temperature"
+      },
+      "ac_input_energy_kwh": {
+        "name": "AC Input Energy"
+      },
+      "temp_indoor_supply_air_c": {
+        "name": "Supply Air Temperature"
+      },
+      "temp_indoor_return_air_c": {
+        "name": "Return Air Temperature"
+      },
+      "operating_submode": {
+        "name": "Operating Submode",
+        "state": {
+          "none": "None",
+          "normal": "Normal",
+          "max": "Max",
+          "sleep": "Sleep",
+          "eco": "Eco"
+        }
+      },
+      "ac_input_voltage_v": {
+        "name": "AC Input Voltage"
+      },
+      "ac_input_current_a": {
+        "name": "AC Input Current"
+      },
+      "temp_condenser_c": {
+        "name": "Condenser Temperature"
+      },
+      "temp_evaporator_c": {
+        "name": "Evaporator Temperature"
+      },
+      "temp_compressor_discharge_c": {
+        "name": "Compressor Discharge Temperature"
+      },
+      "target_humidity_pct": {
+        "name": "Target Humidity"
+      },
+      "screen_brightness_pct": {
+        "name": "Screen Brightness"
+      },
+      "battery_soc_pct": {
+        "name": "Battery"
+      },
+      "battery_voltage_v": {
+        "name": "Battery Voltage"
+      },
+      "battery_current_a": {
+        "name": "Battery Current"
+      },
+      "battery_power_w": {
+        "name": "Battery Power"
+      },
+      "pv_input_power_w": {
+        "name": "PV Input Power"
+      },
+      "condensate_water_level": {
+        "name": "Condensate Water Level"
       }
     },
     "binary_sensor": {
@@ -1533,6 +1619,24 @@
       },
       "grid_l3_connected": {
         "name": "Phase C Connected"
+      },
+      "running": {
+        "name": "Running"
+      },
+      "ac_input_connected": {
+        "name": "AC Input Connected"
+      },
+      "fault": {
+        "name": "Fault"
+      },
+      "draining": {
+        "name": "Draining"
+      },
+      "pet_care_alarm": {
+        "name": "Pet Care Alarm"
+      },
+      "bms_communication_error": {
+        "name": "Battery Communication Error"
       }
     },
     "switch": {

--- a/custom_components/ecoflow_energy/translations/de.json
+++ b/custom_components/ecoflow_energy/translations/de.json
@@ -1614,6 +1614,92 @@
           "manual": "Manuell",
           "auto": "Automatik"
         }
+      },
+      "temp_ambient_c": {
+        "name": "Umgebungstemperatur"
+      },
+      "humi_ambient_pct": {
+        "name": "Luftfeuchtigkeit"
+      },
+      "operating_mode": {
+        "name": "Betriebsmodus",
+        "state": {
+          "cooling": "Kühlen",
+          "heating": "Heizen",
+          "fan": "Lüften",
+          "dehumidify": "Entfeuchten",
+          "constant_temp": "Konstante Temperatur"
+        }
+      },
+      "target_temp_c": {
+        "name": "Zieltemperatur"
+      },
+      "airflow_speed_pct": {
+        "name": "Lüfterstufe"
+      },
+      "ac_input_power_w": {
+        "name": "AC-Eingangsleistung"
+      },
+      "temp_outdoor_ambient_c": {
+        "name": "Außentemperatur"
+      },
+      "ac_input_energy_kwh": {
+        "name": "AC-Eingangsenergie"
+      },
+      "temp_indoor_supply_air_c": {
+        "name": "Zulufttemperatur"
+      },
+      "temp_indoor_return_air_c": {
+        "name": "Ablufttemperatur"
+      },
+      "operating_submode": {
+        "name": "Untermodus",
+        "state": {
+          "none": "Keiner",
+          "normal": "Normal",
+          "max": "Max",
+          "sleep": "Schlaf",
+          "eco": "Eco"
+        }
+      },
+      "ac_input_voltage_v": {
+        "name": "AC-Eingangsspannung"
+      },
+      "ac_input_current_a": {
+        "name": "AC-Eingangsstrom"
+      },
+      "temp_condenser_c": {
+        "name": "Kondensatortemperatur"
+      },
+      "temp_evaporator_c": {
+        "name": "Verdampfertemperatur"
+      },
+      "temp_compressor_discharge_c": {
+        "name": "Verdichter-Austrittstemperatur"
+      },
+      "target_humidity_pct": {
+        "name": "Zielfeuchtigkeit"
+      },
+      "screen_brightness_pct": {
+        "name": "Bildschirmhelligkeit"
+      },
+      "battery_soc_pct": {
+        "name": "Batterie"
+      },
+      "battery_voltage_v": {
+        "name": "Batteriespannung"
+      },
+      "battery_current_a": {
+        "name": "Batteriestrom"
+      },
+      "battery_power_w": {
+        "name": "Batterieleistung"
+      },
+      "pv_input_power_w": {
+        "name": "PV-Eingangsleistung"
+      },
+      "condensate_water_level": {
+        "name": "Kondenswasserstand"
       }
     },
     "binary_sensor": {
@@ -1694,6 +1780,24 @@
       },
       "grid_l3_connected": {
         "name": "Phase C verbunden"
+      },
+      "running": {
+        "name": "Läuft"
+      },
+      "ac_input_connected": {
+        "name": "AC-Eingang verbunden"
+      },
+      "fault": {
+        "name": "Störung"
+      },
+      "draining": {
+        "name": "Entwässerung läuft"
+      },
+      "pet_care_alarm": {
+        "name": "Haustier-Alarm"
+      },
+      "bms_communication_error": {
+        "name": "Batterie-Kommunikationsfehler"
       }
     },
     "switch": {

--- a/custom_components/ecoflow_energy/translations/en.json
+++ b/custom_components/ecoflow_energy/translations/en.json
@@ -1614,6 +1614,92 @@
           "manual": "Manual",
           "auto": "Automatic"
         }
+      },
+      "temp_ambient_c": {
+        "name": "Ambient Temperature"
+      },
+      "humi_ambient_pct": {
+        "name": "Ambient Humidity"
+      },
+      "operating_mode": {
+        "name": "Operating Mode",
+        "state": {
+          "cooling": "Cooling",
+          "heating": "Heating",
+          "fan": "Fan",
+          "dehumidify": "Dehumidify",
+          "constant_temp": "Constant Temperature"
+        }
+      },
+      "target_temp_c": {
+        "name": "Target Temperature"
+      },
+      "airflow_speed_pct": {
+        "name": "Fan Speed"
+      },
+      "ac_input_power_w": {
+        "name": "AC Input Power"
+      },
+      "temp_outdoor_ambient_c": {
+        "name": "Outdoor Temperature"
+      },
+      "ac_input_energy_kwh": {
+        "name": "AC Input Energy"
+      },
+      "temp_indoor_supply_air_c": {
+        "name": "Supply Air Temperature"
+      },
+      "temp_indoor_return_air_c": {
+        "name": "Return Air Temperature"
+      },
+      "operating_submode": {
+        "name": "Operating Submode",
+        "state": {
+          "none": "None",
+          "normal": "Normal",
+          "max": "Max",
+          "sleep": "Sleep",
+          "eco": "Eco"
+        }
+      },
+      "ac_input_voltage_v": {
+        "name": "AC Input Voltage"
+      },
+      "ac_input_current_a": {
+        "name": "AC Input Current"
+      },
+      "temp_condenser_c": {
+        "name": "Condenser Temperature"
+      },
+      "temp_evaporator_c": {
+        "name": "Evaporator Temperature"
+      },
+      "temp_compressor_discharge_c": {
+        "name": "Compressor Discharge Temperature"
+      },
+      "target_humidity_pct": {
+        "name": "Target Humidity"
+      },
+      "screen_brightness_pct": {
+        "name": "Screen Brightness"
+      },
+      "battery_soc_pct": {
+        "name": "Battery"
+      },
+      "battery_voltage_v": {
+        "name": "Battery Voltage"
+      },
+      "battery_current_a": {
+        "name": "Battery Current"
+      },
+      "battery_power_w": {
+        "name": "Battery Power"
+      },
+      "pv_input_power_w": {
+        "name": "PV Input Power"
+      },
+      "condensate_water_level": {
+        "name": "Condensate Water Level"
       }
     },
     "binary_sensor": {
@@ -1694,6 +1780,24 @@
       },
       "grid_l3_connected": {
         "name": "Phase C Connected"
+      },
+      "running": {
+        "name": "Running"
+      },
+      "ac_input_connected": {
+        "name": "AC Input Connected"
+      },
+      "fault": {
+        "name": "Fault"
+      },
+      "draining": {
+        "name": "Draining"
+      },
+      "pet_care_alarm": {
+        "name": "Pet Care Alarm"
+      },
+      "bms_communication_error": {
+        "name": "Battery Communication Error"
       }
     },
     "switch": {

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -19,5 +19,6 @@ Complete list of all sensors, switches, numbers, and binary sensors per device:
 - [STREAM AC 5000](entities/stream-ac-5000.md) - 56 sensors, 2 binary sensors, 2 switches, 7 numbers, 1 select (`ES22` and `ES21`) - shares the Stream name but not the Stream protocol, so it has its own parser and entity set
 - [Smart Meter](entities/smart-meter.md) - 18 sensors, 3 binary sensors (`BK21`) - a grid meter, read-only, Enhanced Mode only
 - [Solar Tracker](entities/solar-tracker.md) - 6 sensors (`HZ31` and `S02F`) - one product under two serial prefixes, read-only in this release, Enhanced Mode only
+- [WAVE 3](entities/wave-3.md) - 24 sensors, 6 binary sensors (`AC71`) - a portable air conditioner, read-only in this release, Enhanced Mode only
 
 Counts are the device-specific entity definitions. Every device additionally exposes 2 universal diagnostic sensors (connection status and active mode) that are not included above.

--- a/documentation/entities/wave-3.md
+++ b/documentation/entities/wave-3.md
@@ -1,0 +1,75 @@
+# WAVE 3 - Entity Reference
+
+Full list of all entities created for the EcoFlow WAVE 3 portable air conditioner.
+
+**Totals:** 24 sensors, 6 binary sensors
+
+The WAVE 3 reports through the account connection only, so it needs **Enhanced Mode**. The Developer API lists the unit but refuses every reading from it with error 1006, which means a Standard Mode entry cannot select it and its entities would never fill.
+
+Nothing is polled. The device sends two messages by itself: the full status every 120 seconds, and a runtime block every 300 seconds carrying the temperatures inside the refrigerant loop, the supply voltage and current, and the firmware. While the unit is running it also pushes its input power roughly every 2 seconds.
+
+Read-only in this release. Mode, setpoint, fan speed and the settings follow once a write from Home Assistant has been confirmed on the hardware; the app's own commands have been recorded, so the shape is known.
+
+---
+
+## Sensors
+
+| Entity | Unit | Category | Default | Description |
+|:---|:---:|:---:|:---:|:---|
+| Ambient Temperature | °C | - | enabled | The room temperature the unit measures |
+| Ambient Humidity | % | - | enabled | The room humidity the unit measures |
+| Operating Mode | - | - | enabled | `cooling`, `heating`, `fan`, `dehumidify` or `constant temperature` |
+| Target Temperature | °C | - | enabled | The setpoint of the mode currently running |
+| Fan Speed | % | - | enabled | 20, 40, 60, 80 or 100, the five steps the app offers |
+| AC Input Power | W | - | enabled | What the unit draws from the mains right now |
+| Outdoor Temperature | °C | - | enabled | The temperature on the exhaust side |
+| AC Input Energy | kWh | - | enabled | Lifetime energy taken from the mains, integrated from the input power. Ready for the Energy Dashboard |
+| Supply Air Temperature | °C | diagnostic | enabled | The air leaving the unit |
+| Return Air Temperature | °C | diagnostic | enabled | The air entering the unit |
+| Operating Submode | - | diagnostic | enabled | `none`, `normal`, `max`, `sleep` or `eco`. Only cooling and heating have one |
+| AC Input Voltage | V | diagnostic | enabled | Mains voltage at the unit |
+| AC Input Current | A | diagnostic | enabled | Mains current at the unit |
+| Condenser Temperature | °C | diagnostic | disabled | Inside the refrigerant loop |
+| Evaporator Temperature | °C | diagnostic | disabled | Inside the refrigerant loop |
+| Compressor Discharge Temperature | °C | diagnostic | disabled | Inside the refrigerant loop |
+| Target Humidity | % | diagnostic | disabled | The setpoint used in dehumidify mode |
+| Screen Brightness | % | diagnostic | disabled | Brightness of the unit's own display |
+| Battery | % | diagnostic | disabled | Charge of the add-on battery. See the note below on why it is off by default |
+| Battery Voltage | V | diagnostic | disabled | Add-on battery |
+| Battery Current | A | diagnostic | disabled | Add-on battery |
+| Battery Power | W | diagnostic | disabled | Add-on battery |
+| PV Input Power | W | diagnostic | disabled | Solar going into the unit |
+| Condensate Water Level | - | diagnostic | disabled | Carries no unit. The only value ever observed is 0 |
+
+---
+
+## Binary Sensors
+
+| Entity | Category | Default | Description |
+|:---|:---:|:---:|:---|
+| Running | - | enabled | Whether the unit is working or idle |
+| AC Input Connected | diagnostic | enabled | Whether it is plugged into the mains |
+| Fault | diagnostic | enabled | The unit reports a fault |
+| Draining | diagnostic | enabled | The unit is pumping out condensate |
+| Pet Care Alarm | diagnostic | disabled | The pet care alarm has triggered |
+| Battery Communication Error | diagnostic | disabled | Reads on for every unit without an add-on battery, which is why it is off by default |
+
+---
+
+## Notes
+
+### Four of the values belong to the mode that is running
+
+Target Temperature, Fan Speed, Target Humidity and Operating Submode are the values of the currently active mode. The device keeps a separate set for each mode, so switching from cooling to heating in the app changes all four at once, and Home Assistant follows within one push. A setpoint you saw in cooling is not lost when you switch away; it simply is not the one being reported any more.
+
+### What the energy counter samples
+
+AC Input Energy is integrated from AC Input Power at whatever rate the device sends that power. That is roughly every 2 seconds while the unit runs, and every 120 seconds in standby, where the draw is under a watt. The 2 second rate was measured with the EcoFlow app open, and it is not yet settled whether it holds with the app closed, so the 120 second rate is the one to count on when judging how closely the counter tracks a short cooling run.
+
+### Why the battery entities are off by default
+
+The add-on battery is optional. A unit without one still reports the battery fields, and reports them as zero, which reads as a flat battery rather than as an absent one. The battery communication alarm on the same unit reads on for the same reason. All five stay disabled by default; if your unit has the battery, enable them under **Settings > Devices & services > Entities**.
+
+### One unit on record
+
+Everything here was measured on a single WAVE 3. If you own one of the other AC71 variants and something reads differently, or an entity stays empty that should not, please say so on [#161](https://github.com/shuette42/ecoflow-energy-ha/issues/161).

--- a/tests/fixtures/wave3/ac71_frames_plan046.json
+++ b/tests/fixtures/wave3/ac71_frames_plan046.json
@@ -1,0 +1,393 @@
+{
+  "note": "EcoFlow WAVE 3 (AC71) frames from the maintainer's own unit, listen-only captures of 2026-07-27 (issue #161). Property pushes are XOR-masked with the low byte of their sequence number, the get_reply bundle is not. The owner's timezone id inside every display upload is replaced by a same-length placeholder under the same key; every other byte is as the device sent it. Built by a script from the captures, never edited by hand.",
+  "source_topics": [
+    "/app/device/property/{sn}",
+    "/app/{uid}/{sn}/thing/property/get_reply"
+  ],
+  "timezone_placeholder": "Fixture/TZone",
+  "frames": [
+    {
+      "tag": "standby_full",
+      "t": 83.789,
+      "ts_iso": "2026-07-27T08:57:52",
+      "topic": "property",
+      "size": 316,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0ab9020a9502115db13805a938953b943ab107b407d13a38bb3f3b3138cb3e399131f1388b31347f50414d4c4b5c166d6356575c813139cc3039393939a13538993438ac3639393939f93639c93639c13639a92939a129398c2939393939c92939c12939a12839f12839f42f39393939e92f39e12f39e92339e12339d92339b322399c2771d8957894270433457b89273acc2771d88178fc2639393939f12639e92639e12638d92639d12639cc263939197bb91938b11939ab19013339333031382911243939e9783330313a292d2439398178333b2911333e295d1c3939717b33282911245f5fa578145f5f95780c5f5fb578d11b39a31e31333f393939393939f409b107b407e90939e10939eb773229c6c6c6c63621d5b0a93410421820200128013001380340fe01481550950270b9ee4f788158800103880101"
+    },
+    {
+      "tag": "runtime_full",
+      "t": 125.592,
+      "ts_iso": "2026-07-27T08:58:34",
+      "topic": "property",
+      "size": 265,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 22
+        }
+      ],
+      "hex": "0a86020ae20110c4c5c5c5c518c4c5c5c5c560c1c5c5ab8608cfc5c5c5c525cfc42dcfc535cfc43dcfc545ce2d4541cd4dce2d4541cd55cec55dcec538c8c5c5c5c54dcac560cac5c5c5c568cac5c5c5c575cac57dcac50dcac515cac51dcac525cac52dcac545d5c54dd5c500d5c5c5c5c508d5c5c5c5c510d5c5c5c5c518d5c5c5c5c565d4c56dd4c575d4c57dd4c505d4c55dd7c565d7c56dd7056cc275d715ca7dd72562d705d72511c618d2c5c5c5c520d2c5c5c5c528d2c5c5c5c518dec5c5c5c540d9c5c5c5c528db06307d8438dbf6f6628440da6b82628458da61b5628478da24bf758410421820200128013001380340fe01481650e20170c5ef4f788158800103880101"
+    },
+    {
+      "tag": "dev_request",
+      "t": 143.909,
+      "ts_iso": "2026-07-27T08:58:52",
+      "topic": "property",
+      "size": 49,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 23
+        }
+      ],
+      "hex": "0a2f0a0d0bc6809fd0051603034b402b0210421820200128013001380340fe014817500d7083f04f788158800103880101"
+    },
+    {
+      "tag": "standby_full",
+      "t": 203.804,
+      "ts_iso": "2026-07-27T08:59:52",
+      "topic": "property",
+      "size": 316,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0ab9020a9502feb25ed7ea46d77ad47bd566d61ee83ed5d754d0d4ded724d1d67ede1ed764dedb90bfaea2a3a4b3f9828cb9b8b36eded623dfd6d6d6d64edad776dbd743d9d6d6d6d616d9d626d9d62ed9d646c6d64ec6d663c6d6d6d6d626c6d62ec6d64ec7d61ec7d61bc0d6d6d6d606c0d60ec0d606ccd60eccd636ccd65ccdd673c89e377a977bc8d6d6aa9466c8d523c89e376e9713c9d6d6d6d61ec9d606c9d60ec9d736c9d63ec9d623c9d6d6f69456f6d75ef6d644f6eedcd6dcdfded7c6fecbd6d60697dcdfded5c6c2cbd6d66e97dcd4c6fedcd1c6b2f3d6d69e94dcc7c6fecbb0b04a97fbb0b07a97e3b0b05a973ef4d64cf1dedcd0d6d6d6d6d6d61be666d61ee806e6d60ee6d60498ddc629292929d9ce3a5f46db10421820200128013001380340fe01481550950270d6f14f788158800103880101"
+    },
+    {
+      "tag": "standby_full",
+      "t": 323.844,
+      "ts_iso": "2026-07-27T09:01:52",
+      "topic": "property",
+      "size": 316,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0ab9020a9502430fe36a57fb6ac769c668c7a43b5483686ae96d69636a996c6bc363a36ad963662d02131f1e190e443f3104050ed3636b9e626b6b6b6bf3676acb666afe646b6b6b6bab646b9b646b93646bfb7b6bf37b6bde7b6b6b6b6b9b7b6b937b6bf37a6ba37a6ba67d6b6b6b6bbb7d6bb37d6bbb716bb3716b8b716be1706bce75a89ec72ac675d3751729db75689e75238ad32aae746b6b6b6ba3746bbb746bb3746a8b746b83746b9e746b6b4b29eb4b6ae34b6bf94b53616b6162636a7b43766b6bbb2a616263687b7f766b6bd32a61697b43616c7b0f4e6b6b2329617a7b43760d0df72a460d0dc72a5e0d0de72a83496bf14c63616d6b6b6b6b6b6ba65bc7a43b54bb5b6bb35b6bb925607b94949494647387e2fb6610421820200128013001380340fe01481550950270ebf44f788158800103880101"
+    },
+    {
+      "tag": "runtime_full",
+      "t": 425.649,
+      "ts_iso": "2026-07-27T09:03:34",
+      "topic": "property",
+      "size": 265,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 22
+        }
+      ],
+      "hex": "0a86020ae2016bbfbebebebe63bfbebebebe1bbabebed3fd73b4bebebebe5eb4bf56b4be4eb4bf46b4be3eb5563e3ab636b5563e3ab62eb5be26b5be43b3bebebebe36b1be1bb1bebebebe13b1bebebebe0eb1be06b1be76b1be6eb1be66b1be5eb1be56b1be3eaebe36aebe7baebebebebe73aebebebebe6baebebebebe63aebebebebe1eafbe16afbe0eafbe06afbe7eafbe26acbe1eacbe16ac7e17b90eac6eb106ac5e19ac7eac5e6abd63a9bebebebe5ba9bebebebe53a9bebebebe63a5bebebebe3ba2bebebebe53a07d4b06ff43a006a019ff3ba110f919ff23a1a13b19ff03a15fc40eff10421820200128013001380340fe01481650e20170bef74f788158800103880101"
+    },
+    {
+      "tag": "standby_full",
+      "t": 443.944,
+      "ts_iso": "2026-07-27T09:03:52",
+      "topic": "property",
+      "size": 316,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0ab9020a9502d59975fcc16dfc51ff50fe0d1dc4c315fefc7ffbfff5fc0ffafd55f535fc4ff5f0bb948589888f98d2a9a792939845f5fd08f4fdfdfdfd65f1fc5df0fc68f2fdfdfdfd3df2fd0df2fd05f2fd6dedfd65edfd48edfdfdfdfd0dedfd05edfd65ecfd35ecfd30ebfdfdfdfd2debfd25ebfd2de7fd25e7fd1de7fd77e6fd58e3c0f750bc50e3c0f781bf4de3fe08e3303145bc38e2fdfdfdfd35e2fd2de2fd25e2fc1de2fd15e2fd08e2fdfdddbf7dddfc75ddfd6fddc5f7fdf7f4f5fcedd5e0fdfd2dbcf7f4f5feede9e0fdfd45bcf7ffedd5f7faed99d8fdfdb5bff7ecedd5e09b9b61bcd09b9b51bcc89b9b71bc15dffd67daf5f7fbfdfdfdfdfdfd30cd0d1dc4c32dcdfd25cdfd2fb3f6ed02020202f2e511746df010421820200128013001380340fe01481550950270fdf74f788158800103880101"
+    },
+    {
+      "tag": "standby_full",
+      "t": 563.949,
+      "ts_iso": "2026-07-27T09:05:52",
+      "topic": "property",
+      "size": 316,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0ab9020a9502a6ea068fb21e8f228c238dfe1889b0668d8f0c888c868f7c898e2686468f3c8683c8e7f6fafbfceba1dad4e1e0eb36868e7b878e8e8e8e16828f2e838f1b818e8e8e8e4e818e7e818e76818e1e9e8e169e8e3b9e8e8e8e8e7e9e8e769e8e169f8e469f8e43988e8e8e8e5e988e56988e5e948e56948e6e948e04958e2b904d7b22cf23900b65f5cc3e908d7b90c66f36cf4b918e8e8e8e46918e5e918e56918f6e918e66918e7b918e8eaecc0eae8f06ae8e1caeb6848e8487868f9ea6938e8e5ecf8487868d9e9a938e8e36cf848c9ea684899eeaab8e8ec6cc849f9ea693e8e812cfa3e8e822cfbbe8e802cf66ac8e14a98684888e8e8e8e8e8e43befe1889b05ebe8e56be8e5cc0859e71717171819662071e8310421820200128013001380340fe014815509502708efb4f788158800103880101"
+    },
+    {
+      "tag": "standby_full",
+      "t": 683.994,
+      "ts_iso": "2026-07-27T09:07:52",
+      "topic": "property",
+      "size": 316,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0ab9020a95020a46aa231eb2238e208f216a68201dca2123a024202a23d025228a2aea23902a2f644b5a565750470d76784d4c479a2a22d72b22222222ba2e23822f23b72d22222222e22d22d22d22da2d22b23222ba3222973222222222d23222da3222ba3322ea3322ef3422222222f23422fa3422f23822fa3822c23822a83922873c6ac38e638f3c6ac35960923c21d73ce1d79a63e73d22222222ea3d22f23d22fa3d23c23d22ca3d22d73d22220260a20223aa0222b0021a2822282b2a23320a3f2222f263282b2a2132363f22229a632820320a282532460722226a602833320a3f4444be630f44448e63174444ae63ca0022b8052a2824222222222222ef126a68201df21222fa1222f06c2932dddddddd2d3aceabb22f10421820200128013001380340fe01481550950270a2fe4f788158800103880101"
+    },
+    {
+      "tag": "runtime_full",
+      "t": 725.742,
+      "ts_iso": "2026-07-27T09:08:34",
+      "topic": "property",
+      "size": 265,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 22
+        }
+      ],
+      "hex": "0a86020ae20165b1b0b0b0b06db1b0b0b0b015b4b0b0def37dbab0b0b0b050bab158bab040bab148bab030bb583034b838bb583034b820bbb028bbb04dbdb0b0b0b038bfb015bfb0b0b0b01dbfb0b0b0b000bfb008bfb078bfb060bfb068bfb050bfb058bfb030a0b038a0b075a0b0b0b0b07da0b0b0b0b065a0b0b0b0b06da0b0b0b0b010a1b018a1b000a1b008a1b070a1b028a2b010a2b018a27019b700a260bf08a25017a270a25064b36da7b0b0b0b055a7b0b0b0b05da7b0b0b0b06dabb0b0b0b035acb0b0b0b05dae734508f14dae838317f135af1ef717f12daf14c017f10daf51ca00f110421820200128013001380340fe01481650e20170b0ff4f788158800103880101"
+    },
+    {
+      "tag": "standby_full",
+      "t": 804.093,
+      "ts_iso": "2026-07-27T09:09:53",
+      "topic": "property",
+      "size": 316,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0ab9020a950292de32bb862abb16b817b962e5ec8552b9bb38bcb8b2bb48bdba12b272bb08b2b7fcd3c2cecfc8df95eee0d5d4df02b2ba4fb3babababa22b6bb1ab7bb2fb5babababa7ab5ba4ab5ba42b5ba2aaaba22aaba0faababababa4aaaba42aaba22abba72abba77acbabababa6aacba62acba6aa0ba62a0ba5aa0ba30a1ba1fa487b017fb17a4babac6f80aa4b94fa4794f02fb7fa5babababa72a5ba6aa5ba62a5bb5aa5ba52a5ba4fa5baba9af83a9abb329aba289a82b0bab0b3b2bbaa92a7baba6afbb0b3b2b9aaaea7baba02fbb0b8aa92b0bdaade9fbabaf2f8b0abaa92a7dcdc26fb97dcdc16fb8fdcdc36fb5298ba209db2b0bcbabababababa778a62e5ec856a8aba628aba68f4b1aa45454545b5a256332ab710421820200128013001380340fe01481550950270ba8150788158800103880101"
+    },
+    {
+      "tag": "get_reply_bundle",
+      "t": 275.781,
+      "ts_iso": "2026-07-27T09:59:39",
+      "topic": "get_reply",
+      "size": 711,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 23
+        },
+        {
+          "cmd_func": 254,
+          "cmd_id": 22
+        },
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a190a0d08d69f9cd30615000048432801104240fe014817709a010aef010ae201d50100000000dd0100000000a50400006b43cd0a00000000e00a01e80a00f00a01f80a00800be8808408880be8808408900b00980b00fd0d00000000880f00a50f00000000ad0f00000000b00f00b80f00c80f00d00f00d80f00e00f00e80f00801000881000c51000000000cd1000000000d51000000000dd1000000000a01100a81100b01100b81100c01100981200a01200a812c0a907b012d00fb812e0a712c012e0d403dd1700000000e51700000000ed1700000000dd1b00000000851c00000000ed1ec3f5b841fd1e3333a741851fae47a7419d1f1f85a741bd1f5c8fb041104240fe014816709a010ab7030aaa0308001d00000000250000000028644d000000005d000000006800780088013c9001ac02f00100e80200f80200ad038849cb3eb50300000000e80301f003008206020801f20700a808c801b2080d466978747572652f545a6f6e65b80800e00800c00900c80900f50900000000980c01d00c00880d00a00d01a80d00f00e00950f000000009d0f00000000c00f00f00f00f80f00901000981000a01000a81000b51000000000bd1000000000e01000e81000f01000f81000981100c81100d01100e81100f01100a01600c01600cd1600000000d01600d81600e01600e81600f01600c21800b81a00c01a00cd1a00000000d01a00d81a00e01a00f81a00821b008a1b00901b00981b00a01b00b01b00d01c00a51eb81ead41ad1e00007c42b01e03f51e3d0ab941c51f00000000c81f00d01f00d81f01e01f00e81f00f51f000020428020018820009220380a000a09080110281d0000d0410a09080310141d0000b8410a0210280a07106425000048420a1110281d66669c412d6666ac413566668c41e822009a27080a06000000000000cd308849cb3ed03000d83000d24e0b10ffffffff0f18ec89900d104240fe014815709a01"
+    },
+    {
+      "tag": "incremental_sleep",
+      "t": 289.869,
+      "ts_iso": "2026-07-27T09:59:53",
+      "topic": "property",
+      "size": 39,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a250a039d303d1042182020013001380340fe0148155003580170bdd050788158800103880101"
+    },
+    {
+      "tag": "running_full",
+      "t": 290.279,
+      "ts_iso": "2026-07-27T09:59:54",
+      "topic": "property",
+      "size": 316,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0ab9020a95026a26ca437ed243ee40ef41166e4403aa4143c044404a43b04542ea4a8a43f04a4f042b3a363730276d16182d2c27fa4a42b74b42424242da4e43e24f42d74d42424242824d42b24d42ba4d42d25242da5242f75242424242b25242ba5242da53428a53428f54424242429254429a54429258429a5842a25842c85942e75c7f48ef03ef5cb46a3e00f25c41b75c7f48fb03875d424242428a5d42925d429a5d43a25d42aa5d42b75d42426200c26243ca6242d0627a4842484b4a43526a5f42429203484b4a4152565f4242fa034840526a484552266742420a004853526a5f2424de036f2424ee03772424ce03aa6042d8654a48444242424242428f72166e44039272429a7242900c4952bdbdbdbd4d5aaecbd24f10421820200128013001380340fe01481550950270c2d050788158800103880101"
+    },
+    {
+      "tag": "incremental_power",
+      "t": 291.857,
+      "ts_iso": "2026-07-27T09:59:55",
+      "topic": "property",
+      "size": 48,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a2e0a0ce7496374250b877a6374250b1042182020013001380340fe014815500c580170cad050788158800103880101"
+    },
+    {
+      "tag": "incremental_power",
+      "t": 293.965,
+      "ts_iso": "2026-07-27T09:59:57",
+      "topic": "property",
+      "size": 48,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a2e0a0cfe509789b1129e639789b1121042182020013001380340fe014815500c580170d3d050788158800103880101"
+    },
+    {
+      "tag": "incremental_power",
+      "t": 296.017,
+      "ts_iso": "2026-07-27T09:59:59",
+      "topic": "property",
+      "size": 48,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a2e0a0cf25c0365a01e926f0365a01e1042182020013001380340fe014815500c580170dfd050788158800103880101"
+    },
+    {
+      "tag": "incremental_power",
+      "t": 298.163,
+      "ts_iso": "2026-07-27T10:00:02",
+      "topic": "property",
+      "size": 48,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a2e0a0cca64e3326d25aa57e3326d251042182020013001380340fe014815500c580170e7d050788158800103880101"
+    },
+    {
+      "tag": "incremental_both",
+      "t": 300.211,
+      "ts_iso": "2026-07-27T10:00:04",
+      "topic": "property",
+      "size": 51,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a310a0fc06e4b587e2fcd606ca05d4b587e2f1042182020013001380340fe014815500f580170edd050788158800103880101"
+    },
+    {
+      "tag": "incremental_power",
+      "t": 302.289,
+      "ts_iso": "2026-07-27T10:00:06",
+      "topic": "property",
+      "size": 48,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a2e0a0cd47aad29743bb449ad29743b1042182020013001380340fe014815500c580170f9d050788158800103880101"
+    },
+    {
+      "tag": "incremental_power",
+      "t": 308.6,
+      "ts_iso": "2026-07-27T10:00:12",
+      "topic": "property",
+      "size": 48,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a2e0a0c3d9305e996d25da005e996d21042182020013001380340fe014815500c58017090d150788158800103880101"
+    },
+    {
+      "tag": "incremental_power",
+      "t": 314.879,
+      "ts_iso": "2026-07-27T10:00:18",
+      "topic": "property",
+      "size": 48,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a2e0a0c08a61d687fe468951d687fe41042182020013001380340fe014815500c580170a5d150788158800103880101"
+    },
+    {
+      "tag": "incremental_power",
+      "t": 316.983,
+      "ts_iso": "2026-07-27T10:00:20",
+      "topic": "property",
+      "size": 48,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a2e0a0c01af8a3a2ced619c8a3a2ced1042182020013001380340fe014815500c580170acd150788158800103880101"
+    },
+    {
+      "tag": "incremental_power",
+      "t": 319.133,
+      "ts_iso": "2026-07-27T10:00:23",
+      "topic": "property",
+      "size": 48,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a2e0a0c1bb5c655e6f67b86c655e6f61042182020013001380340fe014815500c580170b6d150788158800103880101"
+    },
+    {
+      "tag": "incremental_power",
+      "t": 321.083,
+      "ts_iso": "2026-07-27T10:00:24",
+      "topic": "property",
+      "size": 48,
+      "format": "proto",
+      "cmds": [
+        {
+          "cmd_func": 254,
+          "cmd_id": 21
+        }
+      ],
+      "hex": "0a2e0a0c6dc380404cfe0df080404cfe1042182020013001380340fe014815500c580170c0d150788158800103880101"
+    }
+  ]
+}

--- a/tests/ha/test_config_flow.py
+++ b/tests/ha/test_config_flow.py
@@ -218,9 +218,17 @@ SOLAR_TRACKER_DEVICE = {
     "online": 1,
 }
 
+WAVE3_DEVICE = {
+    "sn": "AC71TEST00000001",
+    "name": "WAVE 3",
+    "product_name": "",
+    "device_type": "wave3",
+    "online": 1,
+}
+
 # One case per member of ENHANCED_ONLY_DEVICE_TYPES. A type dropped from
 # that set silently loses its guard coverage along with its parametrize
-# case, so this list is the thing to extend when a third type joins it.
+# case, so this list is the thing to extend when another type joins it.
 ENHANCED_ONLY_DEVICE_CASES = [
     pytest.param(
         SMART_METER_DEVICE,
@@ -231,6 +239,11 @@ ENHANCED_ONLY_DEVICE_CASES = [
         SOLAR_TRACKER_DEVICE,
         "Solar Tracker (0001) (HZ31...0001) - requires Enhanced Mode",
         id="solar_tracker",
+    ),
+    pytest.param(
+        WAVE3_DEVICE,
+        "WAVE 3 (0001) (AC71...0001) - requires Enhanced Mode",
+        id="wave3",
     ),
 ]
 

--- a/tests/ha/test_wave3_entities.py
+++ b/tests/ha/test_wave3_entities.py
@@ -1,0 +1,390 @@
+"""Entity-set tests for the EcoFlow WAVE 3 (AC71) portable AC unit.
+
+The parser tests (PLAN-047) prove the field map against a 24-hour capture.
+These run frames from the same fixture through the coordinator, because the
+wiring this phase adds - the device type, the two mqtt_ingest dispatch
+branches, the sensor/binary_sensor blocks, and the WAVE3-specific state_apply
+handling (active-mode re-derivation, firmware-to-registry, energy
+integration) - is exactly the part a parser test cannot cover on its own.
+"""
+
+from __future__ import annotations
+
+import binascii
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.ecoflow_energy.binary_sensor import (
+    async_setup_entry as binary_sensor_setup,
+)
+from custom_components.ecoflow_energy.const import (
+    AUTH_METHOD_APP,
+    CONF_AUTH_METHOD,
+    CONF_DEVICES,
+    CONF_EMAIL,
+    CONF_MODE,
+    CONF_PASSWORD,
+    CONF_USER_ID,
+    DEVICE_TYPE_WAVE3,
+    DOMAIN,
+    MODE_ENHANCED,
+    WAVE3_BINARY_SENSORS,
+    WAVE3_SENSORS,
+)
+from custom_components.ecoflow_energy.coordinator import EcoFlowDeviceCoordinator
+from custom_components.ecoflow_energy.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+from custom_components.ecoflow_energy.ecoflow.const import (
+    get_device_name,
+    get_device_type,
+)
+from custom_components.ecoflow_energy.ecoflow.proto_encoding import (
+    encode_field_bytes,
+    encode_field_varint,
+)
+from custom_components.ecoflow_energy.sensor import async_setup_entry as sensor_setup
+
+CAPTURE = (
+    Path(__file__).parent.parent
+    / "fixtures"
+    / "wave3"
+    / "ac71_frames_plan046.json"
+)
+
+# One index per shape from the 24h capture (PLAN-047):
+FULL_DISPLAY_INDEX = 0  # 254/21, masked, full field dump incl. mode_info
+RUNTIME_UPLOAD_INDEX = 1  # 254/22, firmware + outdoor temperature
+SLEEP_INCREMENTAL_INDEX = 12  # 254/21, field 212 only (sleep-state flip)
+AC_POWER_INCREMENTAL_INDEX = 14  # 254/21, field 53 only (ac_input_power_w)
+
+_CLOCK = "custom_components.ecoflow_energy.coordinator.time.monotonic"
+
+WAVE3_DEVICE: dict[str, Any] = {
+    "sn": "AC71TEST00000052",
+    "name": "",
+    "product_name": "",
+    "device_type": DEVICE_TYPE_WAVE3,
+    "online": 1,
+}
+
+
+def _entry(device: dict[str, Any]) -> MockConfigEntry:
+    """Build an Enhanced-mode entry for one device."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="EcoFlow Energy",
+        data={
+            CONF_AUTH_METHOD: AUTH_METHOD_APP,
+            CONF_MODE: MODE_ENHANCED,
+            CONF_EMAIL: "test@example.com",
+            CONF_PASSWORD: "test_password",
+            CONF_USER_ID: "user123",
+            CONF_DEVICES: [device],
+        },
+        unique_id="test@example.com",
+    )
+
+
+async def _setup_entities(
+    hass: HomeAssistant,
+    platform_setup,
+    device: dict[str, Any],
+    reported: dict[str, Any] | None = None,
+) -> list[Any]:
+    """Run one platform's setup and return the definition-driven entities."""
+    entry = _entry(device)
+    entry.add_to_hass(hass)
+    coordinator = EcoFlowDeviceCoordinator(hass, entry, device)
+    if reported:
+        coordinator.async_set_updated_data(dict(reported))
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {device["sn"]: coordinator}
+
+    created: list[Any] = []
+    await platform_setup(hass, entry, created.extend)
+    return [entity for entity in created if hasattr(entity, "_definition")]
+
+
+def _frame(index: int) -> bytes:
+    frames = json.loads(CAPTURE.read_text())["frames"]
+    return binascii.unhexlify(frames[index]["hex"])
+
+
+def _mode_change_frame(field_number: int, value: int) -> bytes:
+    """Build a synthetic, unmasked 254/21 frame carrying one scalar field.
+
+    A real incremental DisplayPropertyUpload that reports a bare mode switch
+    looks like this: one field, no envelope masking. Field 6 (enc_type) is
+    left absent, which `_pdata_candidates` in stream_proto.py already treats
+    as "not masked" - no seq/xor construction needed.
+    """
+    pdata = encode_field_varint(field_number, value)
+    header = (
+        encode_field_bytes(1, pdata)
+        + encode_field_varint(8, 254)
+        + encode_field_varint(9, 21)
+    )
+    return encode_field_bytes(1, header)
+
+
+class TestWave3Routing:
+    def test_ac71_is_its_own_device_type(self) -> None:
+        assert get_device_type("", "AC71TEST00000052") == DEVICE_TYPE_WAVE3
+
+    def test_display_name_is_wave_3(self) -> None:
+        assert get_device_name("", "AC71TEST00000052") == "WAVE 3 (0052)"
+
+
+class TestWave3EntitySet:
+    async def test_the_wave3_gets_its_24_sensors_and_6_binary_sensors(
+        self, hass: HomeAssistant
+    ) -> None:
+        entities = await _setup_entities(hass, sensor_setup, WAVE3_DEVICE)
+        keys = {entity._definition.key for entity in entities}
+        assert len(entities) == 24
+        assert keys == {sensor.key for sensor in WAVE3_SENSORS}
+
+        binary_entities = await _setup_entities(
+            hass, binary_sensor_setup, WAVE3_DEVICE
+        )
+        binary_keys = {entity._definition.key for entity in binary_entities}
+        assert len(binary_entities) == 6
+        assert binary_keys == {sensor.key for sensor in WAVE3_BINARY_SENSORS}
+
+
+class TestTheCaptureReachesTheEntities:
+    """The point of the whole phase: a frame the AC71 sent, in, and Home
+    Assistant states out - including the WAVE3-only state_apply handling."""
+
+    async def test_a_full_upload_fills_the_sensors(
+        self, hass: HomeAssistant
+    ) -> None:
+        entry = _entry(WAVE3_DEVICE)
+        entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(hass, entry, WAVE3_DEVICE)
+
+        parsed = coordinator._parse_message(
+            f"/app/device/property/{WAVE3_DEVICE['sn']}", _frame(FULL_DISPLAY_INDEX)
+        )
+        assert parsed is not None
+        with patch(_CLOCK, return_value=1000.0):
+            coordinator._apply_data(parsed)
+
+        assert coordinator.data["temp_ambient_c"] == pytest.approx(21.61)
+        assert coordinator.data["operating_mode"] == "fan"
+        assert coordinator.data["airflow_speed_pct"] == 40
+        assert coordinator.data["target_temp_c"] is None
+        assert coordinator.data["running"] is False
+
+    async def test_a_mode_change_in_an_incremental_frame_moves_the_setpoints(
+        self, hass: HomeAssistant
+    ) -> None:
+        entry = _entry(WAVE3_DEVICE)
+        entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(hass, entry, WAVE3_DEVICE)
+
+        full = coordinator._parse_message(
+            f"/app/device/property/{WAVE3_DEVICE['sn']}", _frame(FULL_DISPLAY_INDEX)
+        )
+        assert full is not None
+        with patch(_CLOCK, return_value=1000.0):
+            coordinator._apply_data(full)
+
+        # field 486 = 1 -> _operating_mode_raw -> operating_mode "cooling".
+        # No other field is present, so only the accumulated state (from the
+        # frame above) can supply the cooling setpoints - proving the
+        # derivation reads _device_data, not this message alone.
+        mode_switch = coordinator._parse_message(
+            f"/app/device/property/{WAVE3_DEVICE['sn']}",
+            _mode_change_frame(486, 1),
+        )
+        assert mode_switch is not None
+        assert mode_switch == {"operating_mode": "cooling"}
+        with patch(_CLOCK, return_value=1002.0):
+            coordinator._apply_data(mode_switch)
+
+        assert coordinator.data["operating_mode"] == "cooling"
+        assert coordinator.data["target_temp_c"] == pytest.approx(26.0)
+        assert coordinator.data["operating_submode"] == "normal"
+        assert coordinator.data["airflow_speed_pct"] == 40
+
+    async def test_the_energy_sensor_integrates_from_ac_input_power(
+        self, hass: HomeAssistant
+    ) -> None:
+        entry = _entry(WAVE3_DEVICE)
+        entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(hass, entry, WAVE3_DEVICE)
+
+        parsed = coordinator._parse_message(
+            f"/app/device/property/{WAVE3_DEVICE['sn']}",
+            _frame(AC_POWER_INCREMENTAL_INDEX),
+        )
+        assert parsed is not None
+        assert parsed["ac_input_power_w"] == pytest.approx(14.95, abs=0.01)
+
+        # MAX_GAP_S caps one Riemann step at 420s, and the published sensor
+        # rounds to 2 decimals: a single 420s step at 14.95W (~0.0017 kWh)
+        # would round away to 0.00. Three steps clear the 0.005 kWh floor.
+        for t in (1000.0, 1420.0, 1840.0, 2260.0):
+            with patch(_CLOCK, return_value=t):
+                coordinator._apply_data(dict(parsed))
+
+        # The published value is rounded to 2 decimals (state_apply.py
+        # `_integrate_energy`), which a 1260s/14.95W total (~0.0052 kWh)
+        # rounds to - so the scale check reads the integrator directly,
+        # not the quantized published field.
+        assert coordinator.data["ac_input_energy_kwh"] == 0.01
+        raw_total = coordinator._energy_integrator.get_total(
+            "ac_input_energy_kwh"
+        )
+        assert raw_total == pytest.approx(0.00523, abs=0.0002)
+
+        energy_def = next(
+            d for d in WAVE3_SENSORS if d.key == "ac_input_energy_kwh"
+        )
+        assert energy_def.device_class == "energy"
+        assert energy_def.state_class == "total_increasing"
+        assert energy_def.unit == "kWh"
+
+    async def test_the_firmware_reaches_the_device_registry(
+        self, hass: HomeAssistant
+    ) -> None:
+        entry = _entry(WAVE3_DEVICE)
+        entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(hass, entry, WAVE3_DEVICE)
+        registry = dr.async_get(hass)
+        registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, WAVE3_DEVICE["sn"])},
+            name="WAVE 3 (0052)",
+        )
+
+        parsed = coordinator._parse_message(
+            f"/app/device/property/{WAVE3_DEVICE['sn']}",
+            _frame(RUNTIME_UPLOAD_INDEX),
+        )
+        assert parsed is not None
+        assert parsed["firmware_version"] == "v1.1.0.104"
+        with patch(_CLOCK, return_value=1000.0):
+            coordinator._apply_data(parsed)
+
+        device = registry.async_get_device(identifiers={(DOMAIN, WAVE3_DEVICE["sn"])})
+        assert device is not None
+        assert device.sw_version == "v1.1.0.104"
+        assert "firmware_version" not in coordinator.data
+
+    async def test_a_repeated_firmware_frame_does_not_reset_the_change_clock(
+        self, hass: HomeAssistant
+    ) -> None:
+        """PLAN-047 review F1: the firmware pop must run before
+        `_note_value_change`, or a byte-identical repeat of the runtime
+        frame - one every ~300s - looks like a value the device just sent
+        for the first time, and the staleness detector never fires."""
+        entry = _entry(WAVE3_DEVICE)
+        entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(hass, entry, WAVE3_DEVICE)
+
+        parsed = coordinator._parse_message(
+            f"/app/device/property/{WAVE3_DEVICE['sn']}",
+            _frame(RUNTIME_UPLOAD_INDEX),
+        )
+        assert parsed is not None
+
+        for t in (1000.0, 1300.0, 1600.0):
+            with patch(_CLOCK, return_value=t):
+                coordinator._apply_data(dict(parsed))
+
+        # Two of the three applications were byte-identical repeats.
+        assert coordinator.unchanged_updates == 2
+
+    async def test_the_registry_catches_up_after_a_late_registration(
+        self, hass: HomeAssistant
+    ) -> None:
+        """PLAN-047 review F2: `_apply_data` is driven by MQTT independently
+        of platform setup, so a firmware frame can beat device registration.
+        The registry write must not be gated on a one-shot `_sw_version`
+        comparison, or the miss is unrecoverable for the config entry's
+        lifetime."""
+        entry = _entry(WAVE3_DEVICE)
+        entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(hass, entry, WAVE3_DEVICE)
+
+        parsed = coordinator._parse_message(
+            f"/app/device/property/{WAVE3_DEVICE['sn']}",
+            _frame(RUNTIME_UPLOAD_INDEX),
+        )
+        assert parsed is not None
+
+        # The firmware frame arrives before the device is registered.
+        with patch(_CLOCK, return_value=1000.0):
+            coordinator._apply_data(dict(parsed))
+
+        registry = dr.async_get(hass)
+        assert (
+            registry.async_get_device(identifiers={(DOMAIN, WAVE3_DEVICE["sn"])})
+            is None
+        )
+
+        # Platform setup registers the device afterwards, as it does in
+        # real use.
+        registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, WAVE3_DEVICE["sn"])},
+            name="WAVE 3 (0052)",
+        )
+
+        with patch(_CLOCK, return_value=1300.0):
+            coordinator._apply_data(dict(parsed))
+
+        device = registry.async_get_device(identifiers={(DOMAIN, WAVE3_DEVICE["sn"])})
+        assert device is not None
+        assert device.sw_version == "v1.1.0.104"
+
+
+class TestWave3ActiveModeInputs:
+    """PLAN-047 review F3: the active-mode source keys must come from the
+    parser's own map, not a hand-copied frozenset that can drift out of
+    step with it."""
+
+    def test_state_apply_imports_the_parsers_active_mode_inputs(self) -> None:
+        from custom_components.ecoflow_energy.coordinator import state_apply
+        from custom_components.ecoflow_energy.ecoflow.parsers import wave3_proto
+
+        assert (
+            state_apply.WAVE3_ACTIVE_MODE_INPUTS
+            is wave3_proto.WAVE3_ACTIVE_MODE_INPUTS
+        )
+
+
+class TestWave3Diagnostics:
+    """A device that reports fine but shows up as skipped in a diagnostics
+    download sends every future reporter down the wrong path."""
+
+    async def test_the_wave3_is_a_device_not_a_skipped_one(
+        self, hass: HomeAssistant
+    ) -> None:
+        entry = _entry(WAVE3_DEVICE)
+        entry.add_to_hass(hass)
+        coordinator = EcoFlowDeviceCoordinator(hass, entry, WAVE3_DEVICE)
+        parsed = coordinator._parse_message(
+            f"/app/device/property/{WAVE3_DEVICE['sn']}", _frame(FULL_DISPLAY_INDEX)
+        )
+        assert parsed is not None
+        coordinator._device_data.update(parsed)
+        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+            WAVE3_DEVICE["sn"]: coordinator
+        }
+
+        diag = await async_get_config_entry_diagnostics(hass, entry)
+
+        assert diag["skipped_devices"] == []
+        assert len(diag["devices"]) == 1
+        assert diag["devices"][0]["device_sn"].startswith("AC71")

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -35,6 +35,9 @@ from ecoflow_energy.const import (
     RAW_FRAME_MAX_BYTES,
     RAW_FRAME_PER_KEY_MAX,
     SCHEDULE_MAX_INDEX,
+    WAVE3_SENSORS,
+    WAVE3_BINARY_SENSORS,
+    ENHANCED_ONLY_DEVICE_TYPES,
     get_device_name,
     get_device_type,
     get_delta_profile,
@@ -1290,3 +1293,36 @@ class TestDeviceLogTag:
 
         assert device_log_tag("R35") == "R35"
         assert device_log_tag("") == ""
+
+
+class TestWave3Sensors:
+    """WAVE 3 (AC71, #161, PLAN-047 Phase A) entity list shape."""
+
+    def test_counts_and_unique_keys(self) -> None:
+        assert len(WAVE3_SENSORS) == 24
+        assert len(WAVE3_BINARY_SENSORS) == 6
+
+        sensor_keys = [s.key for s in WAVE3_SENSORS]
+        assert len(sensor_keys) == len(set(sensor_keys))
+
+        binary_keys = [b.key for b in WAVE3_BINARY_SENSORS]
+        assert len(binary_keys) == len(set(binary_keys))
+
+    def test_only_battery_soc_has_battery_device_class(self) -> None:
+        battery_keys = {s.key for s in WAVE3_SENSORS if s.device_class == "battery"}
+        assert battery_keys == {"battery_soc_pct"}
+
+    def test_enum_options_match_the_parser(self) -> None:
+        from ecoflow_energy.ecoflow.parsers.wave3_proto import (
+            _OPERATING_MODE_NAMES,
+            _SUBMODE_NAMES,
+        )
+
+        by_key = {s.key: s for s in WAVE3_SENSORS}
+        assert set(by_key["operating_mode"].options) == set(_OPERATING_MODE_NAMES.values())
+        assert set(by_key["operating_submode"].options) == set(_SUBMODE_NAMES.values())
+
+    def test_wave3_is_enhanced_only_device_type(self) -> None:
+        from ecoflow_energy.ecoflow.const import DEVICE_TYPE_WAVE3
+
+        assert DEVICE_TYPE_WAVE3 in ENHANCED_ONLY_DEVICE_TYPES

--- a/tests/test_wave3_parser.py
+++ b/tests/test_wave3_parser.py
@@ -1,0 +1,620 @@
+"""Tests for the EcoFlow WAVE 3 (AC71) protobuf parser.
+
+Every expectation below is a number the captured unit put on the wire on
+2026-07-27 (PLAN-047, issue #161). They are written out per frame rather
+than recomputed from the parser, because a test that derives its
+expectation from the code under test holds for any field map.
+
+Two tests rebuild a captured frame with one field changed or removed, to
+exercise a path no captured frame reaches on its own (an unmapped mode
+value, a masked frame whose sequence number is missing). The rebuild always
+starts from a real header's own fields - seq, enc_type, cmd_func, cmd_id,
+pdata - so the untouched fields stay exactly what the device sent; only the
+one field under test is edited.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ecoflow_energy.ecoflow.parsers.stream_proto import _iter_fields, _pdata_candidates
+from ecoflow_energy.ecoflow.parsers.wave3_proto import (
+    _ERRCODE_LIST_FIELD,
+    _MODE_INFO_ALL_KEYS,
+    _MODE_INFO_FIELD,
+    WAVE3_ACTIVE_MODE_INPUTS,
+    parse_wave3_message,
+    resolve_active_mode,
+)
+from ecoflow_energy.ecoflow.proto.decoder import decode_header_message
+from ecoflow_energy.ecoflow.proto_encoding import (
+    encode_field_bytes,
+    encode_field_varint,
+    encode_varint,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "wave3" / "ac71_frames_plan046.json"
+
+# A different device's parser fixture, reused by one test only to prove the
+# WAVE 3 map does not accidentally match a Smart Meter frame's field numbers.
+_METER_FIXTURE = Path(__file__).parent / "fixtures" / "smart_meter" / "bk21_frames_issue331.json"
+
+_MASKED_TAGS = ("standby_full", "runtime_full")
+
+# test_a_masked_frame_without_its_seq_yields_nothing (below) covers only
+# _MASKED_TAGS - 10 frames. test_a_masked_frame_without_its_flag_yields_nothing
+# covers every masked full-upload tag, including running_full, 11 frames.
+_ALL_MASKED_FULL_TAGS = _MASKED_TAGS + ("running_full",)
+
+
+def _frames() -> list[dict[str, Any]]:
+    return json.loads(FIXTURE.read_text())["frames"]
+
+
+def _payload(index: int) -> bytes:
+    return bytes.fromhex(_frames()[index]["hex"])
+
+
+def _first_header(payload: bytes) -> dict[str, Any]:
+    headers, _ = decode_header_message(payload)
+    return headers[0]
+
+
+def _pdata_leaks(frames: list[dict[str, Any]]) -> bool:
+    """True if any frame's first de-masked candidate carries a string that
+    must never reach the public corpus: the reporter's timezone, or the
+    device's own model name.
+    """
+    for frame in frames:
+        payload = bytes.fromhex(frame["hex"])
+        headers, _ = decode_header_message(payload)
+        for header in headers:
+            candidates = _pdata_candidates(header)
+            if not candidates:
+                continue
+            first = candidates[0]
+            if b"Europe/" in first or b"AC71" in first:
+                return True
+    return False
+
+
+def _encode_fields(fields: list[tuple[int, int, bytes]]) -> bytes:
+    """Re-emit `_iter_fields` tuples back to protobuf wire bytes.
+
+    Wire types 0, 1 and 5 raw bytes are already the exact on-wire bytes
+    (`_iter_fields` slices them without decoding); only wire type 2 needs
+    its length prefix put back.
+    """
+    out = bytearray()
+    for field_num, wire_type, raw in fields:
+        out += encode_varint((field_num << 3) | wire_type)
+        if wire_type == 2:
+            out += encode_varint(len(raw)) + raw
+        else:
+            out += raw
+    return bytes(out)
+
+
+def _xor_mask(pdata: bytes, seq: int) -> bytes:
+    key = seq & 0xFF
+    return bytes(b ^ key for b in pdata)
+
+
+def _rebuild_frame(
+    header: dict[str, Any],
+    *,
+    pdata_override: bytes | None = None,
+    drop_seq: bool = False,
+) -> bytes:
+    """Rebuild a one-header frame from a decoded header, re-emitting only
+    the fields `parse_wave3_message` and `_pdata_candidates` read: pdata
+    (1), enc_type (6), cmd_func (8), cmd_id (9), seq (14).
+    """
+    pdata_hex = header.get("pdata", "")
+    pdata_bytes = bytes.fromhex(pdata_hex) if pdata_override is None else pdata_override
+
+    hdr = bytearray()
+    hdr += encode_field_bytes(1, pdata_bytes)
+    enc_type = header.get("enc_type")
+    if enc_type is not None:
+        hdr += encode_field_varint(6, enc_type)
+    hdr += encode_field_varint(8, header.get("cmd_func", 0))
+    hdr += encode_field_varint(9, header.get("cmd_id", 0))
+    if not drop_seq and header.get("seq") is not None:
+        hdr += encode_field_varint(14, header["seq"])
+    return encode_field_bytes(1, bytes(hdr))
+
+
+def _rebuild_with_varint_field(index: int, field_num: int, new_value: int) -> bytes:
+    """Rebuild frame `index`, replacing one masked varint field's value.
+
+    De-masks the captured pdata with its own sequence number, rewrites the
+    one field, re-masks with the same key (XOR is its own inverse), and
+    rebuilds the frame around it. Every other field is untouched.
+    """
+    header = _first_header(_payload(index))
+    seq = header["seq"]
+    masked = bytes.fromhex(header["pdata"])
+    unmasked = _xor_mask(masked, seq)
+
+    new_fields = []
+    for fn, wt, raw in _iter_fields(unmasked):
+        if fn == field_num and wt == 0:
+            new_fields.append((fn, 0, encode_varint(new_value)))
+        else:
+            new_fields.append((fn, wt, raw))
+    remasked = _xor_mask(_encode_fields(new_fields), seq)
+    return _rebuild_frame(header, pdata_override=remasked)
+
+
+def _rebuild_mode_info(index: int, transform: Any) -> bytes:
+    """Rebuild frame `index`'s masked pdata with the wave_mode_info (514)
+    record's own entry list edited by `transform`, everything else
+    byte-identical.
+
+    `transform` receives the `_iter_fields` tuples that make up the 514
+    record's raw entries and returns the new list to re-encode - the same
+    de-mask/edit/re-mask shape `_rebuild_with_varint_field` uses one level
+    up, applied one level deeper.
+    """
+    header = _first_header(_payload(index))
+    seq = header["seq"]
+    masked = bytes.fromhex(header["pdata"])
+    unmasked = _xor_mask(masked, seq)
+
+    new_top_fields = []
+    found = False
+    for fn, wt, raw in _iter_fields(unmasked):
+        if fn == _MODE_INFO_FIELD and wt == 2:
+            found = True
+            new_entries = transform(list(_iter_fields(raw)))
+            new_top_fields.append((fn, wt, _encode_fields(new_entries)))
+        else:
+            new_top_fields.append((fn, wt, raw))
+    assert found, "frame does not carry a wave_mode_info (514) record"
+    remasked = _xor_mask(_encode_fields(new_top_fields), seq)
+    return _rebuild_frame(header, pdata_override=remasked)
+
+
+def test_the_fixture_carries_the_capture_it_claims_to() -> None:
+    """Regression pin on the capture's shape - the exact tag counts and
+    frame count PLAN-047 measured - plus the check that a corpus meant for
+    a public repo carries neither the reporter's timezone string nor the
+    device's own model name in any de-masked payload.
+
+    The second half is a positive control on that check itself: an
+    in-memory copy of the fixture with the model name injected into one
+    frame must trip it, proving the check does not just pass because it
+    never looks anywhere the string could be.
+    """
+    frames = _frames()
+    assert len(frames) == 25
+
+    expected_tags = {
+        "standby_full": 7,
+        "runtime_full": 3,
+        "dev_request": 1,
+        "get_reply_bundle": 1,
+        "incremental_sleep": 1,
+        "running_full": 1,
+        "incremental_power": 10,
+        "incremental_both": 1,
+    }
+    counts: dict[str, int] = {}
+    for frame in frames:
+        counts[frame["tag"]] = counts.get(frame["tag"], 0) + 1
+    assert counts == expected_tags
+
+    assert not _pdata_leaks(frames)
+
+    tampered = copy.deepcopy(frames)
+    marker_pdata = b"AC71 test-marker payload bytes"
+    marker_header = (
+        encode_field_bytes(1, marker_pdata)
+        + encode_field_varint(8, 254)
+        + encode_field_varint(9, 21)
+    )
+    tampered[0] = dict(tampered[0])
+    tampered[0]["hex"] = encode_field_bytes(1, marker_header).hex()
+    assert _pdata_leaks(tampered)
+
+    # The same positive control for the other half of the check: a
+    # de-masked payload carrying the reporter's own timezone string must
+    # trip it too, not only the device model marker above.
+    tampered_tz = copy.deepcopy(frames)
+    tz_pdata = b"Europe/Lisbon test-marker payload bytes"
+    tz_header = (
+        encode_field_bytes(1, tz_pdata)
+        + encode_field_varint(8, 254)
+        + encode_field_varint(9, 21)
+    )
+    tampered_tz[0] = dict(tampered_tz[0])
+    tampered_tz[0]["hex"] = encode_field_bytes(1, tz_header).hex()
+    assert _pdata_leaks(tampered_tz)
+
+
+def test_a_standby_full_upload_decodes_the_criteria() -> None:
+    """Frame 0, a full `254/21` upload while idle: scalars, the enum
+    fields, the two booleans and the five wave_mode_info entries all come
+    off the wire in one decode, and no internal `_raw` key leaks out.
+    """
+    result = parse_wave3_message(_payload(0))
+    assert result is not None
+
+    assert result["temp_ambient_c"] == pytest.approx(21.61, abs=0.01)
+    assert result["humi_ambient_pct"] == pytest.approx(63.01, abs=0.01)
+    assert result["operating_mode"] == "fan"
+
+    # All 13 wave_mode_info keys, every mode's own entry (PLAN-047 review,
+    # finding A9 - most of these carried no literal assertion before).
+    assert result["cooling_submode"] == "normal"
+    assert result["cooling_fan_speed_pct"] == 40
+    assert result["cooling_target_temp_c"] == pytest.approx(26.0, abs=0.01)
+    assert result["heating_submode"] == "sleep"
+    assert result["heating_fan_speed_pct"] == 20
+    assert result["heating_target_temp_c"] == pytest.approx(23.0, abs=0.01)
+    assert result["fan_only_fan_speed_pct"] == 40
+    assert result["dehumidify_fan_speed_pct"] == 100
+    assert result["dehumidify_target_humidity_pct"] == pytest.approx(50.0, abs=0.01)
+    assert result["constant_temp_fan_speed_pct"] == 40
+    assert result["constant_temp_target_temp_c"] == pytest.approx(19.55, abs=0.01)
+    assert result["constant_temp_upper_limit_c"] == pytest.approx(21.55, abs=0.01)
+    assert result["constant_temp_lower_limit_c"] == pytest.approx(17.55, abs=0.01)
+
+    assert result["running"] is False
+    assert result["ac_input_connected"] is True
+    assert result["fault"] is False
+    assert result["screen_brightness_pct"] == 100
+    assert result["beep_enabled"] is True
+    assert result["automatic_drainage"] is False
+    assert result["mood_light_mode"] == "on"
+
+    assert not any(key.startswith("_") for key in result)
+
+
+def test_the_active_mode_resolves_from_accumulated_state() -> None:
+    """`resolve_active_mode` reads the per-mode keys out of accumulated
+    state, not out of a single message - the device sends all five modes'
+    settings in every full upload, and only `operating_mode` says which one
+    is live.
+    """
+    state = parse_wave3_message(_payload(0))
+    assert state is not None
+    assert state["operating_mode"] == "fan"
+
+    resolved_fan = resolve_active_mode(state)
+    assert resolved_fan == {
+        "target_temp_c": None,
+        "airflow_speed_pct": 40,
+        "target_humidity_pct": None,
+        "operating_submode": None,
+    }
+
+    cooling_state = dict(state)
+    cooling_state["operating_mode"] = "cooling"
+    resolved_cooling = resolve_active_mode(cooling_state)
+    assert resolved_cooling == {
+        "target_temp_c": pytest.approx(26.0, abs=0.01),
+        "airflow_speed_pct": 40,
+        "target_humidity_pct": None,
+        "operating_submode": "normal",
+    }
+
+    no_mode_state = {k: v for k, v in state.items() if k != "operating_mode"}
+    assert resolve_active_mode(no_mode_state) == {}
+
+
+def test_resolve_active_mode_never_reads_outside_its_declared_inputs() -> None:
+    """`WAVE3_ACTIVE_MODE_INPUTS` is exported so the HA layer can stop
+    hand-copying the set of keys `resolve_active_mode` reads (PLAN-047
+    review, finding item 5). Proved here by observation rather than by
+    re-deriving the set from the same table it is built from: every one
+    of the 13 wave_mode_info keys gets its own sentinel object, and every
+    non-`None` value `resolve_active_mode` hands back for any mode is
+    traced back to the sentinel's key and checked against the set - a
+    value it never returns can never be traced, so nothing outside the
+    set could pass unnoticed.
+    """
+    sentinels = {key: object() for key in _MODE_INFO_ALL_KEYS}
+    by_id = {id(value): key for key, value in sentinels.items()}
+    assert "operating_mode" in WAVE3_ACTIVE_MODE_INPUTS
+
+    for mode in ("cooling", "heating", "fan", "dehumidify", "constant_temp"):
+        state = dict(sentinels)
+        state["operating_mode"] = mode
+        resolved = resolve_active_mode(state)
+        assert resolved
+        for value in resolved.values():
+            if value is None:
+                continue
+            source_key = by_id.get(id(value))
+            assert source_key is not None, "value not traceable to a known state key"
+            assert source_key in WAVE3_ACTIVE_MODE_INPUTS
+
+
+def test_mode_zero_or_unmapped_reads_unknown() -> None:
+    """A `486` value of 0 or 9 (unmapped) must resolve to `operating_mode:
+    None`, not a synthetic label and not a missing key - the frame is
+    rebuilt from the real masked capture with only that one field changed.
+    """
+    for new_mode in (0, 9):
+        frame = _rebuild_with_varint_field(0, 486, new_mode)
+        result = parse_wave3_message(frame)
+        assert result is not None
+        assert "operating_mode" in result
+        assert result["operating_mode"] is None
+
+
+def test_a_stray_field_before_the_mode_list_does_not_shift_the_modes() -> None:
+    """A `514` entry's mode comes from its position among *accepted*
+    entries (field 1, wire type 2), not its ordinal among every field the
+    record holds: a stray field 2 varint prepended ahead of the six real
+    entries must not shift cooling's setpoint onto heating's key
+    (PLAN-047 review, finding A2).
+    """
+
+    def _prepend_stray(entries: list[tuple[int, int, bytes]]) -> list[tuple[int, int, bytes]]:
+        return [(2, 0, encode_varint(1))] + entries
+
+    frame = _rebuild_mode_info(0, _prepend_stray)
+    result = parse_wave3_message(frame)
+    assert result is not None
+    assert result["cooling_target_temp_c"] == pytest.approx(26.0, abs=0.01)
+    assert result["heating_target_temp_c"] == pytest.approx(23.0, abs=0.01)
+
+
+def test_a_mode_list_with_the_wrong_entry_count_publishes_no_mode_data() -> None:
+    """A `514` record with anything other than the six entries this map was
+    built for (PLAN-047 review, finding A3) must not guess at a mapping -
+    all thirteen per-mode keys come back `None`, and every other key of
+    the frame is untouched.
+    """
+    baseline = parse_wave3_message(_payload(0))
+    assert baseline is not None
+
+    def _drop_entry_zero(entries: list[tuple[int, int, bytes]]) -> list[tuple[int, int, bytes]]:
+        return entries[1:]
+
+    frame = _rebuild_mode_info(0, _drop_entry_zero)
+    result = parse_wave3_message(frame)
+    assert result is not None
+
+    for key in _MODE_INFO_ALL_KEYS:
+        assert key in result
+        assert result[key] is None
+
+    for key in set(baseline) - set(_MODE_INFO_ALL_KEYS):
+        assert result[key] == baseline[key]
+
+
+def test_the_runtime_upload_decodes_temperatures_and_firmware() -> None:
+    """Frame 1, a full `254/22` upload: the sensor temperatures the `21`
+    message does not carry, plus the packed firmware revision.
+    """
+    result = parse_wave3_message(_payload(1))
+    assert result is not None
+
+    assert result["temp_outdoor_ambient_c"] == pytest.approx(20.90, abs=0.01)
+    assert result["ac_input_voltage_v"] == pytest.approx(238.0, abs=0.01)
+    assert result["bms_communication_error"] is True
+    assert result["firmware_version"] == "v1.1.0.104"
+    assert result["temp_compressor_discharge_c"] == pytest.approx(22.06, abs=0.01)
+
+    assert not any(key.startswith("_") for key in result)
+
+
+def test_a_zero_firmware_publishes_no_version() -> None:
+    """`176` (packed firmware revision) publishes nothing when zero: a `22`
+    upload that has not yet reported firmware must not overwrite a
+    previously known version with an empty string (see module docstring).
+    A second field (174, always-mapped) keeps the frame non-empty, since a
+    zero-only firmware field decodes to nothing at all and the parser
+    would otherwise return `None` for the whole frame rather than a dict
+    missing the key. Built as a synthetic unmasked `254/22` frame, since no
+    captured frame ever carried a zero firmware value to exercise this
+    with.
+    """
+    pdata = encode_field_varint(176, 0) + encode_field_varint(174, 0)
+    frame = _rebuild_frame({"cmd_func": 254, "cmd_id": 22}, pdata_override=pdata)
+    result = parse_wave3_message(frame)
+    assert result is not None
+    assert "firmware_version" not in result
+    assert result["bms_communication_error"] is False
+
+
+def test_an_incremental_power_frame_carries_only_power() -> None:
+    """Frame 14, a two-field incremental upload (power plus its unmapped
+    duplicate 777): the result carries exactly the one mapped key, nothing
+    inferred from a field's absence.
+    """
+    result = parse_wave3_message(_payload(14))
+    assert result == {"ac_input_power_w": pytest.approx(14.9527, abs=0.0001)}
+
+
+def test_an_incremental_sleep_frame_flips_running() -> None:
+    """Frame 12 carries only field 212 (dev_sleep_state) = 0: the result is
+    exactly `{"running": True}`, the inversion of the sleep flag and
+    nothing else.
+    """
+    result = parse_wave3_message(_payload(12))
+    assert result == {"running": True}
+
+
+def test_a_masked_frame_without_its_seq_yields_nothing() -> None:
+    """Regression pin on measured frames, not a proof: every captured
+    `standby_full`/`runtime_full` frame, rebuilt with its sequence number
+    removed, must decode to nothing. `_pdata_candidates` falls back to the
+    still-masked bytes when it cannot compute the XOR key, and those bytes
+    do not happen to parse into anything this map recognizes.
+    """
+    frames = _frames()
+    checked = 0
+    for frame in frames:
+        if frame["tag"] not in _MASKED_TAGS:
+            continue
+        header = _first_header(bytes.fromhex(frame["hex"]))
+        rebuilt = _rebuild_frame(header, drop_seq=True)
+        assert parse_wave3_message(rebuilt) is None
+        checked += 1
+    assert checked == 10
+
+
+def test_a_get_reply_bundle_decodes_plain_and_agrees_with_the_push() -> None:
+    """Frame 11, an unmasked `get_reply_bundle` bundling three headers
+    (`23`/`22`/`21`) in one message with no `enc_type` at all: the merged
+    result comes from the `22` and `21` headers only (`23` DevRequest is
+    unmapped), and its ambient temperature agrees with the same sensor
+    pushed 62 minutes earlier as a masked `standby_full` upload (frame 0) -
+    two different message shapes, plain and masked, reporting one reading.
+    """
+    result = parse_wave3_message(_payload(11))
+    assert result is not None
+
+    assert result["temp_ambient_c"] == pytest.approx(21.64, abs=0.01)
+    assert result["operating_mode"] == "fan"
+    assert result["running"] is False
+    assert result["firmware_version"] == "v1.1.0.104"
+
+    push = parse_wave3_message(_payload(0))
+    assert push is not None
+    assert abs(result["temp_ambient_c"] - push["temp_ambient_c"]) < 0.05
+
+
+def test_a_masked_frame_without_its_flag_yields_nothing() -> None:
+    """Regression pin on measured frames, not a proof: every captured
+    standby_full/runtime_full/running_full frame, rebuilt with its
+    `enc_type` header field removed, must decode to nothing. Without the
+    flag, `_pdata_candidates` treats the still-masked bytes as already
+    plain and hands them straight to the decoder, which does not happen to
+    recognize anything in them - this is the wider counterpart of
+    `test_a_masked_frame_without_its_seq_yields_nothing` above, which only
+    walks `_MASKED_TAGS` and so never reaches `running_full`.
+    """
+    checked = 0
+    for frame in _frames():
+        if frame["tag"] not in _ALL_MASKED_FULL_TAGS:
+            continue
+        header = _first_header(bytes.fromhex(frame["hex"]))
+        header_no_flag = dict(header)
+        header_no_flag["enc_type"] = None
+        rebuilt = _rebuild_frame(header_no_flag)
+        assert parse_wave3_message(rebuilt) is None
+        checked += 1
+    assert checked == 11
+
+
+def test_a_dev_request_is_not_a_reading() -> None:
+    """Frame 2, `254/23` DevRequest: no field in this message is mapped, so
+    the frame carries no reading at all - not an empty dict, `None`.
+    """
+    assert parse_wave3_message(_payload(2)) is None
+
+
+def test_a_meter_frame_is_not_a_wave3_frame() -> None:
+    """A Smart Meter `254/21` frame carries none of the WAVE 3 field
+    numbers (515, 962, 963, 772 belong to that device's own map, not this
+    one): the WAVE 3 parser must not mistake another device's reading for
+    its own.
+    """
+    meter_frames = json.loads(_METER_FIXTURE.read_text())["frames"]
+    payload = bytes.fromhex(meter_frames[0]["hex"])
+    assert parse_wave3_message(payload) is None
+
+
+def test_a_fault_code_sets_the_fault_flag() -> None:
+    """`dev_errcode_list` (field 627) collapses to a single `fault` flag:
+    true when any code in its packed repeated list is non-zero, false when
+    every code is zero. Built as a synthetic unmasked `254/21` frame, since
+    no captured frame ever carried a non-zero code to exercise this with.
+    """
+
+    def _frame_with_codes(codes: list[int]) -> bytes:
+        packed = b"".join(encode_varint(code) for code in codes)
+        record = encode_field_bytes(1, packed)
+        pdata = encode_field_bytes(_ERRCODE_LIST_FIELD, record)
+        return _rebuild_frame({"cmd_func": 254, "cmd_id": 21}, pdata_override=pdata)
+
+    faulted = parse_wave3_message(_frame_with_codes([0, 0, 7, 0, 0, 0]))
+    assert faulted is not None
+    assert faulted["fault"] is True
+
+    clean = parse_wave3_message(_frame_with_codes([0, 0, 0, 0, 0, 0]))
+    assert clean is not None
+    assert clean["fault"] is False
+
+
+def test_an_unpacked_error_list_is_read_too() -> None:
+    """`_decode_errcode_list` never switches on wire type, so the unpacked
+    repeated encoding - one varint field 1 per element, wire type 0 -
+    works today by accident (PLAN-047 review, finding A7). Pin it: a
+    non-zero code among unpacked entries still sets `fault`.
+    """
+    codes = [0, 0, 7, 0]
+    record = b"".join(encode_field_varint(1, code) for code in codes)
+    pdata = encode_field_bytes(_ERRCODE_LIST_FIELD, record)
+    frame = _rebuild_frame({"cmd_func": 254, "cmd_id": 21}, pdata_override=pdata)
+
+    result = parse_wave3_message(frame)
+    assert result is not None
+    assert result["fault"] is True
+
+
+_RANGE_TEMP_KEYS = (
+    "temp_ambient_c",
+    "temp_indoor_supply_air_c",
+    "temp_indoor_return_air_c",
+    "temp_outdoor_ambient_c",
+    "temp_condenser_c",
+    "temp_evaporator_c",
+    "temp_compressor_discharge_c",
+)
+_RANGE_OPERATING_MODES = frozenset({"cooling", "heating", "fan", "dehumidify", "constant_temp"})
+
+
+def test_every_full_frame_stays_inside_the_measured_ranges() -> None:
+    """Sanity floor over every masked full-upload frame plus the plain
+    get_reply bundle: temperatures, humidity and AC input power stay
+    inside the range this 24-hour capture actually measured, and a present
+    `operating_mode` is always one of the five named modes. The count of
+    fields actually compared is asserted with a floor - a parser that
+    quietly stops producing readings would still pass an "at least one
+    frame decoded" check, but not a floor on how much was measured.
+    """
+    frames = _frames()
+    masked_full_indices = [i for i, frame in enumerate(frames) if frame["tag"] in _ALL_MASKED_FULL_TAGS]
+    assert len(masked_full_indices) == 11
+
+    results = [parse_wave3_message(_payload(i)) for i in masked_full_indices]
+    bundle = parse_wave3_message(_payload(11))
+    assert bundle is not None
+    results.append(bundle)
+
+    checked = 0
+    for result in results:
+        assert result is not None
+        for key in _RANGE_TEMP_KEYS:
+            if key not in result:
+                continue
+            assert 15 <= result[key] <= 40
+            checked += 1
+        if "humi_ambient_pct" in result:
+            assert 0 <= result["humi_ambient_pct"] <= 100
+            checked += 1
+        if "ac_input_power_w" in result:
+            assert 0 <= result["ac_input_power_w"] <= 3000
+            checked += 1
+        if result.get("operating_mode") is not None:
+            assert result["operating_mode"] in _RANGE_OPERATING_MODES
+            checked += 1
+
+    # Measured 65 over these 12 records (PLAN-047 review, finding A1). The
+    # floor sits below that so a legitimate fixture edit does not trip it,
+    # and above the 45 that emptying the whole (254, 22) field map alone
+    # would leave - a floor low enough to survive losing a message type
+    # entirely is not a floor.
+    assert checked >= 60


### PR DESCRIPTION
## WAVE 3 (AC71) read path, PLAN-047 Phase A

Adds the EcoFlow WAVE 3 portable air conditioner as a read-only device in Enhanced Mode: 24 sensors, 6 binary sensors, one energy counter integrated from the input power.

**Why Enhanced Mode only.** The Developer API lists the unit but refuses every reading with error 1006, so the device picker keeps it off the developer-key path (`ENHANCED_ONLY_DEVICE_TYPES`).

**How the data arrives.** The unit pushes its full status every 120 s and a runtime block every 300 s, plus 2 s power increments while running; nothing is polled. Frames are routed by device type before the registry lookup because the message ids are shared with the Smart Meter and the Stream AC Pro. The four active-mode values are derived over accumulated state so a mode switch in an incremental frame moves them immediately. The firmware revision from the runtime upload reaches the device registry.

**Verification.**
- Parser tests replay the maintainer's own captures through a serial-masked fixture built by script (19 tests, every one put against a mutation).
- HA-layer tests go through the coordinator's apply path: entity set, full upload, incremental mode switch, energy integration to the computed value, firmware to the registry, config-flow guard.
- Full suite green; Docker Desktop window on the live unit (see the checks).

Ref #161
