### PR TITLE
style: enforce the line length and rewrap what the formatter leaves alone

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,12 @@
+# Commits that only reformatted code, never changed what it does.
+#
+# GitHub reads this file on its own. To make the blame command here skip them
+# too, once per checkout:
+#
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# A line below must be a full 40 character hash of a commit that is on main,
+# so an entry is added after the pull request has been squashed, never before.
+
+# style: run the formatter over the integration and the tests (#366)
+d5261c3e9d5372a484cd977ecf80a303ee10d68c

--- a/custom_components/ecoflow_energy/__init__.py
+++ b/custom_components/ecoflow_energy/__init__.py
@@ -558,7 +558,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: EcoFlowConfigEntry) -> b
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Reload integration when config entry data changes (e.g. mode switch via Options Flow)
+    # Reload integration when config entry data changes (e.g. mode switch via
+    # Options Flow)
     entry.async_on_unload(entry.add_update_listener(_async_reload_entry))
 
     return True

--- a/custom_components/ecoflow_energy/config_flow_options.py
+++ b/custom_components/ecoflow_energy/config_flow_options.py
@@ -243,11 +243,24 @@ class OptionsFlowMixin(_Base):
             }
             device_options = {
                 sn: (
-                    f"{get_device_name('', sn) or DEVICE_TYPE_DISPLAY_NAMES.get(stored_types[sn], short_serial(sn))}"
+                    f"{
+                        get_device_name('', sn)
+                        or DEVICE_TYPE_DISPLAY_NAMES.get(
+                            stored_types[sn], short_serial(sn)
+                        )
+                    }"
                     f" ({short_serial(sn)})"
                     f"{unsupported_suffix(stored_types[sn])}"
-                    f"{' - requires Standard Mode' if stored_types[sn] == DEVICE_TYPE_POWERSTREAM else ''}"
-                    f"{' - requires Enhanced Mode' if stored_types[sn] in ENHANCED_ONLY_DEVICE_TYPES else ''}"
+                    f"{
+                        ' - requires Standard Mode'
+                        if stored_types[sn] == DEVICE_TYPE_POWERSTREAM
+                        else ''
+                    }"
+                    f"{
+                        ' - requires Enhanced Mode'
+                        if stored_types[sn] in ENHANCED_ONLY_DEVICE_TYPES
+                        else ''
+                    }"
                 )
                 for sn in current_device_sns
             }

--- a/custom_components/ecoflow_energy/const.py
+++ b/custom_components/ecoflow_energy/const.py
@@ -278,7 +278,9 @@ HTTP_SUPPLEMENT_INTERVAL_S = (
 )
 ENERGY_STREAM_KEEPALIVE_S = 20  # Re-send EnergyStreamSwitch every 20s
 QUOTAS_KEEPALIVE_S = 30  # latestQuotas poll interval (app-level keepalive)
-APP_SURPLUS_SYNC_MIN_INTERVAL_S = 30.0  # min interval between auto-sync SETs that mirror EmsParamChangeReport.dev_soc into the EMS sysBatBackupRatio
+# min interval between auto-sync SETs that mirror EmsParamChangeReport.dev_soc into the
+# EMS sysBatBackupRatio
+APP_SURPLUS_SYNC_MIN_INTERVAL_S = 30.0
 APP_SURPLUS_SYNC_USER_GRACE_S = (
     5.0  # ignore discrepancy briefly after a user SET to wait for the device echo
 )
@@ -290,7 +292,9 @@ APP_SURPLUS_SYNC_USER_GRACE_S = (
 # nothing more; it matches the entity-side optimistic lock so both expire
 # together. A frame that agrees with the write clears it immediately.
 POWEROCEAN_SCHEDULE_ARMED_LATCH_S = 5.0
-POWEROCEAN_SOC_DEBOUNCE_S = 0.3  # coalesce slider-drag SETs into one frame; the device cannot keep up with 5%-step sets at 100ms cadence and the EMS/App-layer fields desync
+# coalesce slider-drag SETs into one frame; the device cannot keep up with 5%-step sets
+# at 100ms cadence and the EMS/App-layer fields desync
+POWEROCEAN_SOC_DEBOUNCE_S = 0.3
 # The two state keys the PowerOcean SoC sliders write. They are sent as one
 # frame, so a failed write has to undo both. Kept next to the debounce window
 # because the snapshot and the rollback have to agree on exactly this pair -

--- a/custom_components/ecoflow_energy/coordinator/availability.py
+++ b/custom_components/ecoflow_energy/coordinator/availability.py
@@ -39,7 +39,8 @@ class AvailabilityMixin(_Base):
 
         Stages (app-auth MQTT-only path):
         - "healthy": data flowing within stale threshold
-        - "stale": data age > stale threshold, reconnect active, entities still available
+        - "stale": data age > stale threshold, reconnect active, entities still
+          available
         - "degraded": data age > soft_unavailable, entities available with old values
         - "unavailable": data age > hard_unavailable, entities go unavailable in HA
 
@@ -230,7 +231,8 @@ class AvailabilityMixin(_Base):
                         )
                     else:
                         _LOGGER.info(
-                            "MQTT stale for %s [%s] (%.0fs) while connected - forcing reconnect",
+                            "MQTT stale for %s [%s] (%.0fs) while connected - "
+                            "forcing reconnect",
                             self.device_name,
                             self.device_tag,
                             age,

--- a/custom_components/ecoflow_energy/coordinator/credentials.py
+++ b/custom_components/ecoflow_energy/coordinator/credentials.py
@@ -110,7 +110,8 @@ class CredentialsMixin(_Base):
             else:
                 self._log_event("credential_refresh_fail", "app-auth, no credentials")
                 _LOGGER.warning(
-                    "App-auth credential refresh failed for %s - triggering re-authentication",
+                    "App-auth credential refresh failed for %s - triggering "
+                    "re-authentication",
                     self.device_tag,
                 )
                 self._entry.async_start_reauth(self.hass)
@@ -131,7 +132,8 @@ class CredentialsMixin(_Base):
             else:
                 self._log_event("credential_refresh_fail", "developer-auth")
                 _LOGGER.warning(
-                    "MQTT credential refresh failed for %s - triggering re-authentication",
+                    "MQTT credential refresh failed for %s - triggering "
+                    "re-authentication",
                     self.device_tag,
                 )
                 self._entry.async_start_reauth(self.hass)
@@ -219,7 +221,8 @@ class CredentialsMixin(_Base):
                 self._log_event("credential_proactive_ok", "app-auth")
                 if cert_account != old_account or broker_changed:
                     _LOGGER.debug(
-                        "Proactive refresh: credentials changed for %s - force reconnect",
+                        "Proactive refresh: credentials changed for %s - "
+                        "force reconnect",
                         self.device_tag,
                     )
                     self.hass.async_add_executor_job(self._mqtt_client.force_reconnect)
@@ -238,7 +241,8 @@ class CredentialsMixin(_Base):
                 self._log_event("credential_proactive_ok", "developer-auth")
                 if cert_account != old_account or broker_changed:
                     _LOGGER.debug(
-                        "Proactive refresh: credentials changed for %s - force reconnect",
+                        "Proactive refresh: credentials changed for %s - "
+                        "force reconnect",
                         self.device_tag,
                     )
                     self.hass.async_add_executor_job(self._mqtt_client.force_reconnect)

--- a/custom_components/ecoflow_energy/coordinator/http_poll.py
+++ b/custom_components/ecoflow_energy/coordinator/http_poll.py
@@ -98,7 +98,8 @@ class HttpPollMixin(_Base):
                 and not transport_failure
             ):
                 _LOGGER.warning(
-                    "HTTP quota failed %d consecutive times for %s - triggering re-authentication",
+                    "HTTP quota failed %d consecutive times for %s - triggering "
+                    "re-authentication",
                     self._consecutive_http_failures,
                     self.device_tag,
                 )

--- a/custom_components/ecoflow_energy/coordinator/state_apply.py
+++ b/custom_components/ecoflow_energy/coordinator/state_apply.py
@@ -275,7 +275,8 @@ class StateApplyMixin(_Base):
 
         # Integrate power → energy via Riemann sum
         self._integrate_energy(parsed)
-        # Throttle flush scheduling: at most once per 60s (matches integrator's SAVE_INTERVAL_S)
+        # Throttle flush scheduling: at most once per 60s (matches integrator's
+        # SAVE_INTERVAL_S)
         if now - self._last_flush_ts > 60:
             self._last_flush_ts = now
             self.hass.async_create_task(self._async_flush_energy_state())
@@ -486,7 +487,8 @@ class StateApplyMixin(_Base):
     BATT_CONFIRM_S = 600  # a diverging candidate must persist this long to commit
 
     def _derive_battery_state(self) -> None:
-        """Derive battery charge/discharge state from a rolling-average power (#63, #50).
+        """Derive battery charge/discharge state from a rolling-average power
+        (#63, #50).
 
         The raw EMS field bp_chg_dsg_sta reports the controller MODE, not the
         physical state, so we override it from signed batt_w. Using the

--- a/custom_components/ecoflow_energy/diagnostics.py
+++ b/custom_components/ecoflow_energy/diagnostics.py
@@ -83,7 +83,8 @@ _SERIAL_RE = re.compile(r"[A-Z0-9]{15,}")
 # dropping such bytes instead of replacing them turns a serial with one
 # stray byte in front of it into a clean match, so the ASCII step is what
 # keeps this pass to whole encoded serials rather than to serials found
-# inside other bytes. It is also the cheaper of the two. What the full match is NOT redundant for is a
+# inside other bytes. It is also the cheaper of the two. What the full match is NOT
+# redundant for is a
 # decoded value that is ASCII and contains a serial among other text: it
 # must be rejected rather than replaced whole, and only an anchored match
 # does that. No such value is on file; a test pins it.

--- a/custom_components/ecoflow_energy/ecoflow/app_api.py
+++ b/custom_components/ecoflow_energy/ecoflow/app_api.py
@@ -79,7 +79,10 @@ class AppApiClient:
 
         Returns a normalized list of device dicts compatible with
         IoTApiClient format:
-            [{"sn": "...", "product_name": "...", "online": 1, "device_type": "..."}, ...]
+            [
+                {"sn": "...", "product_name": "...", "online": 1, "device_type": "..."},
+                ...,
+            ]
 
         Returns an empty list on failure.
         """

--- a/custom_components/ecoflow_energy/ecoflow/clientid.py
+++ b/custom_components/ecoflow_energy/ecoflow/clientid.py
@@ -1,7 +1,8 @@
 """EcoFlow Portal WSS MQTT ClientID Generator.
 
 Generates MQTT client IDs for the WSS connection to the EcoFlow broker (port 8084).
-Must be called on every connect/reconnect - old client IDs are rejected after disconnect.
+Must be called on every connect/reconnect - old client IDs are rejected after
+disconnect.
 
 Reverse-engineered from: main.9d3dab6f.js (ef-device-user-jt_v2.7.9)
 """

--- a/custom_components/ecoflow_energy/ecoflow/cloud_mqtt.py
+++ b/custom_components/ecoflow_energy/ecoflow/cloud_mqtt.py
@@ -346,7 +346,8 @@ class EcoFlowMQTTClient:
         """
         rc_val = rc.value if hasattr(rc, "value") else rc
         if rc_val == 0:
-            # Subscribe to SET reply topics (all modes) for command acknowledgement tracking.
+            # Subscribe to SET reply topics (all modes) for command acknowledgement
+            # tracking.
             # A listen-only connection sends no commands, so there is nothing to
             # acknowledge - and skipping these keeps the account identifiers out
             # of the captured topic list.
@@ -356,7 +357,10 @@ class EcoFlowMQTTClient:
                 )
                 client.subscribe(set_reply_topic, qos=1)
                 if self._user_id:
-                    app_set_reply = f"/app/{self._user_id}/{self._device_sn}/thing/property/set_reply"
+                    app_set_reply = (
+                        f"/app/{self._user_id}/{self._device_sn}"
+                        "/thing/property/set_reply"
+                    )
                     client.subscribe(app_set_reply, qos=1)
 
             if self._subscribe_data:
@@ -367,7 +371,10 @@ class EcoFlowMQTTClient:
                 client.subscribe(topic_pb, qos=0)
 
                 if self._user_id:
-                    topic_reply = f"/app/{self._user_id}/{self._device_sn}/thing/property/get_reply"
+                    topic_reply = (
+                        f"/app/{self._user_id}/{self._device_sn}"
+                        "/thing/property/get_reply"
+                    )
                     client.subscribe(topic_reply, qos=1)
 
                     if self._capture_writes:
@@ -440,7 +447,8 @@ class EcoFlowMQTTClient:
                     except Exception as exc:
                         _LOGGER.warning("Post-connect latestQuotas error: %s", exc)
                 else:
-                    # Non-enhanced (SmartPlug, Delta): protobuf get-all + JSON latestQuotas
+                    # Non-enhanced (SmartPlug, Delta): protobuf get-all + JSON
+                    # latestQuotas
                     try:
                         self.send_get_all()
                         _LOGGER.debug(

--- a/custom_components/ecoflow_energy/ecoflow/delta3_commands.py
+++ b/custom_components/ecoflow_energy/ecoflow/delta3_commands.py
@@ -74,7 +74,8 @@ DELTA3_SWITCH_PARAMS: dict[str, Delta3Switch] = {
     "bypass_out_disable_switch": Delta3Switch("cfgBypassOutDisable", 26),
 }
 
-# Energy backup is the only nested payload: {"cfgEnergyBackup": {"energyBackupEn": bool}}
+# Energy backup is the only nested payload:
+# {"cfgEnergyBackup": {"energyBackupEn": bool}}
 # On the binary channel it is equally nested: field 43 wraps an inner field 1.
 DELTA3_ENERGY_BACKUP_KEY = "energy_backup_switch"
 DELTA3_ENERGY_BACKUP_PARAMS_KEY = "cfgEnergyBackup"

--- a/custom_components/ecoflow_energy/ecoflow/frame_capture.py
+++ b/custom_components/ecoflow_energy/ecoflow/frame_capture.py
@@ -183,7 +183,8 @@ def sanitize_frame(payload: bytes, secrets: list[str]) -> bytes:
     serial, then anything written as a UUID, then a lower-case hex run a
     hyphen joins to a serial-shaped run, then the city half of any time zone
     the device reports, then anything a device presents as a whole
-    length-delimited field of identifier-shaped characters. The second pass matters because a frame
+    length-delimited field of identifier-shaped characters. The second pass matters
+    because a frame
     also carries the serial of every battery pack and of any attached
     accessory, and the caller cannot name what it has not discovered yet. The
     third and fourth catch identifiers too short, or too oddly shaped, for

--- a/custom_components/ecoflow_energy/ecoflow/wave3_commands.py
+++ b/custom_components/ecoflow_energy/ecoflow/wave3_commands.py
@@ -147,7 +147,8 @@ WAVE3_CONTROLS: dict[str, Wave3Control] = {
         maximum=None,
         step=None,
         allowed_values=(20, 40, 60, 80, 100),
-        modes=None,  # gated by exclusion (constant_temp), not inclusion - see write_refusal
+        # gated by exclusion (constant_temp), not inclusion - see write_refusal
+        modes=None,
         read_key="airflow_speed_pct",
     ),
     "target_temp_c": Wave3Control(
@@ -451,7 +452,10 @@ def write_refusal(
         return f"unknown WAVE 3 control: {key!r}"
 
     if key == "operating_submode" and value in _SUBMODE_WRITE_REFUSED_LABELS:
-        return f"{value!r} is never written by the app; observed writes are max, sleep, or eco"
+        return (
+            f"{value!r} is never written by the app; observed writes are max, "
+            "sleep, or eco"
+        )
 
     effective_mode = mode if mode is not None else state.get("operating_mode")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ extend-exclude = ["custom_components/ecoflow_energy/ecoflow/proto/ecocharge_pb2.
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "SIM", "RET", "C4"]
-ignore = ["E501"]
+ignore = []
 
 [tool.mypy]
 python_version = "3.13"

--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -53,7 +53,8 @@ from custom_components.ecoflow_energy.const import (  # noqa: E402
 )
 
 # ---------------------------------------------------------------------------
-# Enable custom integration discovery (required by pytest-homeassistant-custom-component)
+# Enable custom integration discovery (required by
+# pytest-homeassistant-custom-component)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/ha/test_config_flow.py
+++ b/tests/ha/test_config_flow.py
@@ -1542,7 +1542,8 @@ class TestOptionsFlow:
     async def test_options_developer_fetch_error_falls_back_to_stored(
         self, hass: HomeAssistant
     ) -> None:
-        """A failed device-list fetch keeps the options form usable with stored devices."""
+        """A failed device-list fetch keeps the options form usable with stored
+        devices."""
         entry = self._create_standard_entry(hass)
         with patch(
             "custom_components.ecoflow_energy.config_flow_options.IoTApiClient",
@@ -1883,7 +1884,8 @@ class TestReauthFlow:
         assert entry.data[CONF_SECRET_KEY] == "new_sk"
 
     async def test_reauth_enhanced_shows_second_step(self, hass: HomeAssistant) -> None:
-        """Reauth for Enhanced Mode shows enhanced credentials form after API validation."""
+        """Reauth for Enhanced Mode shows enhanced credentials form after API
+        validation."""
         entry = self._create_enhanced_entry(hass)
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -2771,8 +2773,8 @@ class TestDeviceLabel:
             }
         )
         assert (
-            label
-            == "Mystery Box (ZZ99...0001) (offline) - not supported yet (no data exposed)"
+            label == "Mystery Box (ZZ99...0001) (offline) - not supported yet (no data "
+            "exposed)"
         )
 
 

--- a/tests/ha/test_coordinator.py
+++ b/tests/ha/test_coordinator.py
@@ -2568,7 +2568,8 @@ class TestStaleDetection:
         hass: HomeAssistant,
         enhanced_config_entry: MockConfigEntry,
     ) -> None:
-        """Availability stage progresses through healthy -> stale -> degraded -> unavailable."""
+        """Availability stage progresses through healthy -> stale -> degraded ->
+        unavailable."""
         enhanced_config_entry.add_to_hass(hass)
         coordinator = EcoFlowDeviceCoordinator(
             hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
@@ -2602,7 +2603,8 @@ class TestStaleDetection:
         hass: HomeAssistant,
         enhanced_config_entry: MockConfigEntry,
     ) -> None:
-        """PowerOcean stays available during a 600s stream gap (observed real behavior)."""
+        """PowerOcean stays available during a 600s stream gap (observed real
+        behavior)."""
         enhanced_config_entry.add_to_hass(hass)
         coordinator = EcoFlowDeviceCoordinator(
             hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
@@ -3963,7 +3965,8 @@ class TestBpRemapping:
         hass: HomeAssistant,
         enhanced_config_entry: MockConfigEntry,
     ) -> None:
-        """ems_work_state=0 maps to 'none' (not lost by zero-omission thanks to oneof)."""
+        """ems_work_state=0 maps to 'none' (not lost by zero-omission thanks to
+        oneof)."""
         enhanced_config_entry.add_to_hass(hass)
         coordinator = EcoFlowDeviceCoordinator(
             hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
@@ -3982,7 +3985,8 @@ class TestBpRemapping:
         coordinator = EcoFlowDeviceCoordinator(
             hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
         )
-        # sys_grid_sta=0 would normally be "not_detected", but grid_is_energized=True overrides
+        # sys_grid_sta=0 would normally be "not_detected", but grid_is_energized=True
+        # overrides
         raw = {"sys_grid_sta": 0, "grid_is_energized": True}
         result = remap_bp_keys(raw, coordinator._bp_sn_to_index, coordinator.device_sn)
         assert result["grid_status"] == "ok"
@@ -4152,7 +4156,8 @@ class TestBpRemapping:
         hass: HomeAssistant,
         enhanced_config_entry: MockConfigEntry,
     ) -> None:
-        """All packs are empty dicts (EMS module placeholders) - no pack sensors produced."""
+        """All packs are empty dicts (EMS module placeholders) - no pack sensors
+        produced."""
         enhanced_config_entry.add_to_hass(hass)
         coordinator = EcoFlowDeviceCoordinator(
             hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
@@ -4407,7 +4412,8 @@ class TestBpRemapping:
         hass: HomeAssistant,
         enhanced_config_entry: MockConfigEntry,
     ) -> None:
-        """_apply_data does not re-aggregate when no pack remain_watth keys in parsed."""
+        """_apply_data does not re-aggregate when no pack remain_watth keys in
+        parsed."""
         enhanced_config_entry.add_to_hass(hass)
         coordinator = EcoFlowDeviceCoordinator(
             hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
@@ -5426,7 +5432,8 @@ class TestParseMessageGetReply:
         self,
         hass: HomeAssistant,
     ) -> None:
-        """SmartPlug get_reply with quotaMap is parsed via smartplug_http_quota parser."""
+        """SmartPlug get_reply with quotaMap is parsed via smartplug_http_quota
+        parser."""
         import json as json_mod
 
         from .conftest import MOCK_SMARTPLUG_DEVICE
@@ -5581,7 +5588,8 @@ class TestParseMessageGetReply:
         hass: HomeAssistant,
         enhanced_config_entry: MockConfigEntry,
     ) -> None:
-        """PowerOcean JSON get_reply with quotaMap is parsed via powerocean_http_quota parser."""
+        """PowerOcean JSON get_reply with quotaMap is parsed via powerocean_http_quota
+        parser."""
         import json as json_mod
 
         enhanced_config_entry.add_to_hass(hass)
@@ -5615,7 +5623,8 @@ class TestParseMessageGetReply:
         hass: HomeAssistant,
         enhanced_config_entry: MockConfigEntry,
     ) -> None:
-        """PowerOcean proto get_reply extracts EmsChangeReport (cmd_func=96, cmd_id=8)."""
+        """PowerOcean proto get_reply extracts EmsChangeReport (cmd_func=96,
+        cmd_id=8)."""
         from ecoflow_energy.ecoflow.proto.ecocharge_pb2 import JTS1EmsChangeReport
         from ecoflow_energy.ecoflow.proto_encoding import (
             encode_field_bytes,
@@ -6537,7 +6546,8 @@ class TestAppAuthMode:
         # age > CREDENTIAL_MAX_AGE_S regardless of CI system clock.
         coordinator._credential_obtained_ts = 1.0  # fixed positive value
 
-        # Replace the coroutine method with a sync no-op to avoid async scheduling issues
+        # Replace the coroutine method with a sync no-op to avoid async scheduling
+        # issues
         coordinator._proactive_credential_refresh = lambda: None  # type: ignore[assignment]
         with (
             patch.object(hass, "async_create_task") as mock_task,

--- a/tests/ha/test_entities.py
+++ b/tests/ha/test_entities.py
@@ -1394,7 +1394,8 @@ class TestEcoFlowDiagnosticSensor:
         hass: HomeAssistant,
         standard_config_entry: MockConfigEntry,
     ) -> None:
-        """mqtt_status sensor reflects 'connected_stale' when connected but no recent data."""
+        """mqtt_status sensor reflects 'connected_stale' when connected but no recent
+        data."""
         standard_config_entry.add_to_hass(hass)
         coordinator = _make_coordinator(hass, standard_config_entry)
         mock_mqtt = MagicMock()

--- a/tests/ha/test_init.py
+++ b/tests/ha/test_init.py
@@ -823,7 +823,8 @@ class TestUnsupportedDeviceSkip:
         mock_mqtt_client,
         caplog,
     ) -> None:
-        """Account sign-in: the hint points at the capture switch, which exists there."""
+        """Account sign-in: the hint points at the capture switch, which exists
+        there."""
         unsupported_device = {
             "sn": "ZZ01TEST00000001",
             "name": "Unmapped Device",

--- a/tests/ha/test_state_dedup.py
+++ b/tests/ha/test_state_dedup.py
@@ -587,7 +587,8 @@ class TestEnergyRounding:
         mock_integrator.flush.return_value = None
         coordinator._energy_integrator = mock_integrator
 
-        # Set up energy_from_api mapping (no API total in parsed → falls back to integrate)
+        # Set up energy_from_api mapping (no API total in parsed → falls back to
+        # integrate)
         coordinator._power_to_energy = {}
         coordinator._energy_from_api = [("fallback_power", "fallback_energy")]
 
@@ -608,7 +609,8 @@ class TestOptimisticDedupSync:
         hass: HomeAssistant,
         standard_config_entry: MockConfigEntry,
     ) -> None:
-        """_handle_coordinator_update must not re-write the value that _send_command already wrote."""
+        """_handle_coordinator_update must not re-write the value that _send_command
+        already wrote."""
         standard_config_entry.add_to_hass(hass)
         coordinator = _make_coordinator(hass, standard_config_entry)
         coordinator.async_set_updated_data({"ac_enabled": 1})
@@ -625,13 +627,15 @@ class TestOptimisticDedupSync:
             patch.object(coordinator, "async_send_set_command", new_callable=AsyncMock),
             patch.object(switch, "async_write_ha_state") as mock_write,
         ):
-            # User turns off: optimistic write (count = 1), syncs _last_written_value = False
+            # User turns off: optimistic write (count = 1), syncs _last_written_value =
+            # False
             with patch("time.monotonic", return_value=1000.0):
                 await switch._send_command(False)
             assert mock_write.call_count == 1
             assert switch._last_written_value is False
 
-            # Coordinator tick during lock window - is_on still returns False (lock active).
+            # Coordinator tick during lock window - is_on still returns False (lock
+            # active).
             # Because _last_written_value is already False, no second write.
             with patch("time.monotonic", return_value=1001.0):  # still within 5 s lock
                 switch._handle_coordinator_update()
@@ -642,7 +646,8 @@ class TestOptimisticDedupSync:
         hass: HomeAssistant,
         standard_config_entry: MockConfigEntry,
     ) -> None:
-        """_handle_coordinator_update must not re-write the value that async_set_native_value already wrote."""
+        """_handle_coordinator_update must not re-write the value that
+        async_set_native_value already wrote."""
         standard_config_entry.add_to_hass(hass)
         coordinator = _make_coordinator(hass, standard_config_entry)
         coordinator.async_set_updated_data({"pd.soc": 80})
@@ -662,7 +667,8 @@ class TestOptimisticDedupSync:
             patch.object(coordinator, "async_send_set_command", new_callable=AsyncMock),
             patch.object(number, "async_write_ha_state") as mock_write,
         ):
-            # User sets 95: optimistic write (count = 1), mutates data, syncs _last_written_value = 95.0
+            # User sets 95: optimistic write (count = 1), mutates data, syncs
+            # _last_written_value = 95.0
             await number.async_set_native_value(95.0)
             assert mock_write.call_count == 1
             assert number._last_written_value == 95.0

--- a/tests/ha/test_wave3_entities.py
+++ b/tests/ha/test_wave3_entities.py
@@ -1229,7 +1229,7 @@ class TestTheClimateHasNoOptimisticHold:
     checks the design that shipped instead: a write in flight does not
     change what the entity reports until the device's own push does."""
 
-    async def test_a_write_does_not_change_what_hvac_mode_reports_until_the_device_confirms(
+    async def test_hvac_mode_reports_the_old_value_until_the_device_confirms(
         self, hass: HomeAssistant
     ) -> None:
         coordinator, _mqtt = _wired(

--- a/tests/test_cloud_mqtt.py
+++ b/tests/test_cloud_mqtt.py
@@ -1,4 +1,5 @@
-"""Tests for EcoFlowMQTTClient - subscribe_data, client creation, reconnect, disconnect."""
+"""Tests for EcoFlowMQTTClient - subscribe_data, client creation, reconnect,
+disconnect."""
 
 import logging
 import time
@@ -30,7 +31,8 @@ class TestSubscribeDataFlag:
 
     @patch("ecoflow_energy.ecoflow.cloud_mqtt.mqtt.Client")
     def test_standard_mode_no_data_subscriptions(self, mock_mqtt_cls):
-        """In Standard Mode (subscribe_data=False), _on_connect subscribes only to set_reply."""
+        """In Standard Mode (subscribe_data=False), _on_connect subscribes only to
+        set_reply."""
         mock_paho = MagicMock()
         mock_mqtt_cls.return_value = mock_paho
 
@@ -48,7 +50,8 @@ class TestSubscribeDataFlag:
 
     @patch("ecoflow_energy.ecoflow.cloud_mqtt.mqtt.Client")
     def test_enhanced_mode_subscribes_data_topics(self, mock_mqtt_cls):
-        """In Enhanced Mode (subscribe_data=True), _on_connect must subscribe to data topics."""
+        """In Enhanced Mode (subscribe_data=True), _on_connect must subscribe to data
+        topics."""
         mock_paho = MagicMock()
         mock_mqtt_cls.return_value = mock_paho
 
@@ -434,7 +437,8 @@ class TestShouldAttemptReconnect:
         assert client._should_attempt_reconnect() is True
 
     def test_effective_delay_never_exceeds_cap(self):
-        """Tier multipliers must not push the effective delay past max_reconnect_delay."""
+        """Tier multipliers must not push the effective delay past
+        max_reconnect_delay."""
         client = _make_client(base_reconnect_delay=5, max_reconnect_delay=60)
         client.reconnect_attempts = 7  # tier 3: 2x multiplier
         client.last_reconnect_time = 1000.0

--- a/tests/test_coordinator_mro.py
+++ b/tests/test_coordinator_mro.py
@@ -82,7 +82,8 @@ def test_coordinator_mro_own_prefix_is_unchanged():
     mro = _mro_names(EcoFlowDeviceCoordinator)
 
     assert mro[: len(COORDINATOR_OWN_PREFIX)] == COORDINATOR_OWN_PREFIX, (
-        f"EcoFlowDeviceCoordinator.__mro__ starts with {mro[: len(COORDINATOR_OWN_PREFIX)]!r}, "
+        f"EcoFlowDeviceCoordinator.__mro__ starts with "
+        f"{mro[: len(COORDINATOR_OWN_PREFIX)]!r}, "
         f"expected {COORDINATOR_OWN_PREFIX!r} - the mixin composition order at "
         "coordinator/core.py:101 (or one mixin's own bases) has changed"
     )
@@ -132,7 +133,8 @@ def test_config_flow_mro_own_prefix_is_unchanged_and_config_flow_is_not_doubled(
         f"{mro[: len(CONFIG_FLOW_OWN_PREFIX)]!r}, expected {CONFIG_FLOW_OWN_PREFIX!r}"
     )
     assert mro.count("ConfigFlow") == 1, (
-        f"EcoFlowEnergyConfigFlow.__mro__ contains ConfigFlow {mro.count('ConfigFlow')} "
+        f"EcoFlowEnergyConfigFlow.__mro__ contains ConfigFlow "
+        f"{mro.count('ConfigFlow')} "
         f"times: {mro!r} - expected exactly once"
     )
     assert "CoordinatorState" not in mro, (

--- a/tests/test_delta_http_parser.py
+++ b/tests/test_delta_http_parser.py
@@ -219,7 +219,8 @@ class TestFieldMapIntegrity:
         assert len(DELTA2MAX_HTTP_FIELD_MAP) > 50
 
     def test_all_modules_covered(self):
-        """Field map should cover pd, inv, bms_bmsStatus, bms_emsStatus, mppt, bms_slave."""
+        """Field map should cover pd, inv, bms_bmsStatus, bms_emsStatus, mppt,
+        bms_slave."""
         prefixes = {k.split(".")[0] for k in DELTA2MAX_HTTP_FIELD_MAP}
         assert "pd" in prefixes
         assert "inv" in prefixes

--- a/tests/test_delta_parser.py
+++ b/tests/test_delta_parser.py
@@ -34,7 +34,8 @@ class TestDeltaParser:
         assert result["ac_in_w"] == 200.0
 
     def test_inv_status_ac_charge_speed(self):
-        """invStatus charge-speed keys map to the configured charge speed (issue #95)."""
+        """invStatus charge-speed keys map to the configured charge speed (issue
+        #95)."""
         report = {
             "typeCode": "invStatus",
             "params": {"SlowChgWatts": 800, "FastChgWatts": 2400},

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -38,23 +38,28 @@ class TestManifest:
         m = _load_manifest()
         for req in m["requirements"]:
             assert "pycryptodome" not in req.lower(), (
-                f"pycryptodome must not be in requirements - use cryptography instead (found: {req})"
+                f"pycryptodome must not be in requirements - use cryptography instead "
+                f"(found: {req})"
             )
 
     def test_requirements_does_not_redeclare_paho_mqtt(self):
-        """paho-mqtt ships with HA core via the `mqtt` integration - must not be redeclared here."""
+        """paho-mqtt ships with HA core via the `mqtt` integration - must not be
+        redeclared here."""
         m = _load_manifest()
         for req in m["requirements"]:
             assert "paho-mqtt" not in req.lower(), (
-                f"paho-mqtt is already part of Home Assistant core; do not list it in manifest.json (found: {req})"
+                f"paho-mqtt is already part of Home Assistant core; do not list it in "
+                f"manifest.json (found: {req})"
             )
 
     def test_requirements_does_not_redeclare_protobuf(self):
-        """protobuf ships with HA core via several core integrations - must not be redeclared here."""
+        """protobuf ships with HA core via several core integrations - must not be
+        redeclared here."""
         m = _load_manifest()
         for req in m["requirements"]:
             assert "protobuf" not in req.lower(), (
-                f"protobuf is already part of Home Assistant core; do not list it in manifest.json (found: {req})"
+                f"protobuf is already part of Home Assistant core; do not list it in "
+                f"manifest.json (found: {req})"
             )
 
     def test_version_format(self):

--- a/tests/test_powerocean_parser.py
+++ b/tests/test_powerocean_parser.py
@@ -564,7 +564,8 @@ class TestEnergyStream:
         assert result["solar_energy_kwh"] == 5.0
 
     def test_ems_change_report_energy_fallback(self):
-        """ems_change_report.* energy totals used when energy_stream.* and top-level not present."""
+        """ems_change_report.* energy totals used when energy_stream.* and top-level not
+        present."""
         data = {
             "ems_change_report.bpTotalChgEnergy": 4398306,
             "ems_change_report.bpTotalDsgEnergy": 4217302,

--- a/tests/test_solar_tracker_parser.py
+++ b/tests/test_solar_tracker_parser.py
@@ -91,7 +91,8 @@ def _value_span_of_first_field(data: bytes, target_field: int) -> tuple[int, int
 
 
 def _single_byte_varint_span(pdata: bytes, target_field: int) -> tuple[int, int]:
-    """Return the (start, end) byte range of a field whose varint value fits one byte."""
+    """Return the (start, end) byte range of a field whose varint value fits one
+    byte."""
     pos = 0
     while pos < len(pdata):
         start = pos

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -59,13 +59,15 @@ def _get_dict_keys(node: ast.expr) -> set[str]:
 
 
 def _find_async_show_form_calls(tree: ast.Module) -> list[dict]:
-    """Find all self.async_show_form() calls and extract step_id, placeholders, schema fields.
+    """Find all self.async_show_form() calls and extract step_id, placeholders, schema
+    fields.
 
     Returns a list of dicts:
         {
             "step_id": str,
             "placeholders": set[str],  # keys from description_placeholders={}
-            "schema_fields": set[str], # CONF_* keys from data_schema vol.Required/Optional
+            "schema_fields": set[str], # CONF_* keys from data_schema
+            # vol.Required/Optional
             "flow_type": "config" | "options",
             "class_name": str,
         }


### PR DESCRIPTION
The line length check goes on, and the 66 lines the formatter deliberately leaves alone are rewrapped by hand.

The formatter run in the previous release took the tree from 960 over-long lines to 66. Those 66 are strings, docstrings and comments: a formatter never rewraps those, by design, so they were the part that had to be read. 22 sat in the integration and 40 in the tests, plus four more that surfaced once the first 22 were rewrapped.

**Nothing is suppressed.** There is no line-length exception in this change, at any scope. Every one of the 66 was reachable by rewrapping a comment, splitting a literal across adjacent fragments, or in one case shortening a test name that had grown past the limit on its own.

## The literals were the part worth care

Log messages, two MQTT topics, four assertion messages and two expected values were split across adjacent string fragments, which Python joins at compile time. Every joined value was compared against what it replaced.

A passing suite is not evidence for most of these. An assertion message is only ever rendered when the assertion fails, and a topic that changes by one character is a device that stops answering rather than a test that goes red. So each split carries its own before-and-after comparison rather than resting on the suite.

## One shortcut, tried and rejected on measurement

Moving only a docstring's closing quotes to their own line fits the limit, and the very next formatter run undoes it: the formatter does not know about the limit and pulls the line back together, quietly restoring the finding. The format check caught this on nine lines. They carry real word wraps now, and `ruff format --check` confirms all 146 files are stable under both tools at once, which is the property that keeps the two rules from fighting each other.

## The blame ignore file

`.git-blame-ignore-revs` names the formatting commit. GitHub reads it by itself; locally it needs `blame.ignoreRevsFile` pointed at it once per checkout, which the file's own header says.

Worth stating plainly, because it is less than advertised: measured over twelve files and 4,965 lines, blame attributes only **two** lines to the formatting commit, with or without the file. Blame's own movement detection already sees through a reflow, and the two exceptions are lines the formatter *created* rather than changed, which have no earlier commit to fall back to. The file is there for the next formatting pass, not for this one.

## Numbers

- Over-long lines: 960 before the formatter, 66 after it, 0 now
- `ruff check custom_components/ tests/` clean with no ignore list at all
- `ruff format --check` reports all 146 files already formatted
- The type checker reports no issues in 62 source files
- 3306 tests pass, 1 skipped, unchanged throughout

Ref PLAN-127
