### PR TITLE
test: type-check the suite, and gate it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,5 +77,11 @@ jobs:
           # the same source the test job uses, so both gates read the same
           # Home Assistant rather than two that drift apart.
           pip install -r requirements_test.txt
-      - name: Run mypy
+      # Two steps, not one invocation over both paths. The suite imports the
+      # integration under two module names (with and without the
+      # custom_components prefix), and mypy refuses a single run in which one
+      # file is reachable under two names. Each entry point is its own check.
+      - name: Run mypy over the integration
         run: mypy custom_components/ecoflow_energy
+      - name: Run mypy over the tests
+        run: mypy tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,16 @@ python_version = "3.13"
 ignore_missing_imports = true
 exclude = "ecocharge_pb2\\.py$"
 
+# Both module names are real. mypy computes `ecoflow_energy.*` when it is
+# pointed at custom_components/, and `custom_components.ecoflow_energy.*` when
+# it reaches the same file through a test that imports it by that path. An
+# override naming only one of them is silently inactive for the other, and the
+# gate then answers differently depending on what it was pointed at.
 [[tool.mypy.overrides]]
-module = "ecoflow_energy.ecoflow.proto.ecocharge_pb2"
+module = [
+    "ecoflow_energy.ecoflow.proto.ecocharge_pb2",
+    "custom_components.ecoflow_energy.ecoflow.proto.ecocharge_pb2",
+]
 follow_imports = "skip"
 ignore_errors = true
 
@@ -23,5 +31,16 @@ ignore_errors = true
 # four methods whose return type is not `None`; nothing else in the module
 # is exempted.
 [[tool.mypy.overrides]]
-module = "ecoflow_energy.coordinator._typing"
+module = [
+    "ecoflow_energy.coordinator._typing",
+    "custom_components.ecoflow_energy.coordinator._typing",
+]
 disable_error_code = ["empty-body"]
+
+# A test replaces a method on an instance to observe what the code under test
+# does with it. That is the point of the test, not a mistake, and it is the
+# only check switched off here: everything else the type checker reports about
+# the suite is fixed rather than silenced.
+[[tool.mypy.overrides]]
+module = ["tests.*", "conftest"]
+disable_error_code = ["method-assign"]

--- a/tests/ha/conftest.py
+++ b/tests/ha/conftest.py
@@ -7,14 +7,30 @@ a real (in-memory) Home Assistant instance via the ``hass`` fixture.
 from __future__ import annotations
 
 import threading
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Iterable
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+
+def add_entities_collector(target: list[Any]) -> AddEntitiesCallback:
+    """Collect the entities a platform creates into `target`.
+
+    A platform's setup takes a callback with an optional second argument, so a
+    bare `list.extend` does not fit the signature Home Assistant declares even
+    though it works at runtime. This is that callback, in one place rather than
+    redefined in every file that sets a platform up.
+    """
+
+    def _add(new_entities: Iterable[Any], update_before_add: bool = False) -> None:
+        target.extend(new_entities)
+
+    return _add
 
 
 @pytest.fixture(autouse=True)

--- a/tests/ha/test_config_flow.py
+++ b/tests/ha/test_config_flow.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import aiohttp
 import pytest
 from homeassistant import config_entries
-from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_RECONFIGURE
+from homeassistant.config_entries import (
+    SOURCE_REAUTH,
+    SOURCE_RECONFIGURE,
+    ConfigFlowContext,
+    ConfigFlowResult,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -124,7 +130,9 @@ class TestPowerStreamModeBoundary:
         )
 
         assert result["type"] is FlowResultType.FORM
-        assert result["errors"]["base"] == "powerstream_requires_standard"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "powerstream_requires_standard"
 
     async def test_app_auth_options_reject_before_entry_mutation(
         self, hass: HomeAssistant
@@ -168,7 +176,9 @@ class TestPowerStreamModeBoundary:
             )
 
         assert result["type"] is FlowResultType.FORM
-        assert result["errors"]["base"] == "powerstream_requires_standard"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "powerstream_requires_standard"
         assert entry.data == before
 
     async def test_options_stored_fallback_keeps_standard_mode_hint(
@@ -197,7 +207,9 @@ class TestPowerStreamModeBoundary:
         ):
             result = await hass.config_entries.options.async_init(entry.entry_id)
 
-        options = result["data_schema"].schema[CONF_DEVICES].config["options"]
+        schema = result["data_schema"]
+        assert schema is not None
+        options = schema.schema[CONF_DEVICES].config["options"]
         assert options == [
             {
                 "value": POWERSTREAM_DEVICE["sn"],
@@ -349,7 +361,9 @@ class TestEnhancedOnlyModeBoundary:
         )
 
         assert result["type"] is FlowResultType.FORM
-        assert result["errors"]["base"] == "device_requires_enhanced"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "device_requires_enhanced"
 
     @pytest.mark.parametrize("device,expected_label", ENHANCED_ONLY_DEVICE_CASES)
     async def test_app_flow_preselects_the_device_and_accepts_it(
@@ -411,7 +425,9 @@ class TestEnhancedOnlyModeBoundary:
             )
 
         assert result["type"] is FlowResultType.FORM
-        assert result["errors"]["base"] == "device_requires_enhanced"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "device_requires_enhanced"
         assert entry.data == before
 
     @pytest.mark.parametrize("device,expected_label", ENHANCED_ONLY_DEVICE_CASES)
@@ -441,7 +457,9 @@ class TestEnhancedOnlyModeBoundary:
         ):
             result = await hass.config_entries.options.async_init(entry.entry_id)
 
-        options = result["data_schema"].schema[CONF_DEVICES].config["options"]
+        schema = result["data_schema"]
+        assert schema is not None
+        options = schema.schema[CONF_DEVICES].config["options"]
         assert options == [
             {
                 "value": device["sn"],
@@ -500,7 +518,9 @@ class TestDeveloperStep:
                 {CONF_ACCESS_KEY: "bad_key", CONF_SECRET_KEY: "bad_secret"},
             )
             assert result["type"] is FlowResultType.FORM
-            assert result["errors"]["base"] == "invalid_auth"
+            errors = result["errors"]
+            assert errors is not None
+            assert errors["base"] == "invalid_auth"
 
     async def test_no_devices_error(self, hass: HomeAssistant) -> None:
         """Valid auth but no devices shows error."""
@@ -519,7 +539,9 @@ class TestDeveloperStep:
                 {CONF_ACCESS_KEY: "ak", CONF_SECRET_KEY: "sk"},
             )
             assert result["type"] is FlowResultType.FORM
-            assert result["errors"]["base"] == "no_devices"
+            errors = result["errors"]
+            assert errors is not None
+            assert errors["base"] == "no_devices"
 
     async def test_success_advances_to_devices(self, hass: HomeAssistant) -> None:
         """Valid credentials + devices advances to device selection."""
@@ -568,7 +590,9 @@ class TestDeveloperStep:
             )
             assert result["type"] is FlowResultType.FORM
             assert result["step_id"] == "developer"
-            assert result["errors"]["base"] == expected_error
+            errors = result["errors"]
+            assert errors is not None
+            assert errors["base"] == expected_error
 
 
 # ===========================================================================
@@ -590,7 +614,9 @@ class TestAppCredentialsStep:
                 {CONF_EMAIL: "test@example.com", CONF_PASSWORD: "wrong"},
             )
             assert result["type"] is FlowResultType.FORM
-            assert result["errors"]["base"] == "enhanced_login_failed"
+            errors = result["errors"]
+            assert errors is not None
+            assert errors["base"] == "enhanced_login_failed"
 
     async def test_connection_error(self, hass: HomeAssistant) -> None:
         """Connection error during app login shows cannot_connect."""
@@ -605,7 +631,9 @@ class TestAppCredentialsStep:
                 {CONF_EMAIL: "test@example.com", CONF_PASSWORD: "secret"},
             )
             assert result["type"] is FlowResultType.FORM
-            assert result["errors"]["base"] == "cannot_connect"
+            errors = result["errors"]
+            assert errors is not None
+            assert errors["base"] == "cannot_connect"
 
     async def test_unknown_error(self, hass: HomeAssistant) -> None:
         """A parsing error during app login shows unknown."""
@@ -620,7 +648,9 @@ class TestAppCredentialsStep:
                 {CONF_EMAIL: "test@example.com", CONF_PASSWORD: "test_password"},
             )
             assert result["type"] is FlowResultType.FORM
-            assert result["errors"]["base"] == "unknown"
+            errors = result["errors"]
+            assert errors is not None
+            assert errors["base"] == "unknown"
 
     async def test_empty_credentials_error(self, hass: HomeAssistant) -> None:
         """Empty email/password shows enhanced_login_failed without calling login."""
@@ -634,7 +664,9 @@ class TestAppCredentialsStep:
                 {CONF_EMAIL: "", CONF_PASSWORD: ""},
             )
             assert result["type"] is FlowResultType.FORM
-            assert result["errors"]["base"] == "enhanced_login_failed"
+            errors = result["errors"]
+            assert errors is not None
+            assert errors["base"] == "enhanced_login_failed"
             mock_login.assert_not_called()
 
     async def test_devices_without_sn_shows_no_devices(
@@ -662,7 +694,9 @@ class TestAppCredentialsStep:
                 {CONF_EMAIL: "test@example.com", CONF_PASSWORD: "test_password"},
             )
             assert result["type"] is FlowResultType.FORM
-            assert result["errors"]["base"] == "no_devices"
+            errors = result["errors"]
+            assert errors is not None
+            assert errors["base"] == "no_devices"
 
     async def test_no_devices_shows_error(self, hass: HomeAssistant) -> None:
         """Successful login but no devices shows error."""
@@ -684,7 +718,9 @@ class TestAppCredentialsStep:
                 {CONF_EMAIL: "test@example.com", CONF_PASSWORD: "secret"},
             )
             assert result["type"] is FlowResultType.FORM
-            assert result["errors"]["base"] == "no_devices"
+            errors = result["errors"]
+            assert errors is not None
+            assert errors["base"] == "no_devices"
 
     async def test_success_advances_to_devices(self, hass: HomeAssistant) -> None:
         """Successful login + devices advances to device selection."""
@@ -839,9 +875,11 @@ class TestDevicesStep:
                 {CONF_ACCESS_KEY: "ak", CONF_SECRET_KEY: "sk"},
             )
 
+        schema = result["data_schema"]
+        assert schema is not None
         labels = {
             opt["value"]: opt["label"]
-            for opt in result["data_schema"].schema[CONF_DEVICES].config["options"]
+            for opt in schema.schema[CONF_DEVICES].config["options"]
         }
         assert labels["ZZ99FAKE00000001"].endswith(
             " - not supported yet (no data exposed)"
@@ -857,7 +895,9 @@ class TestDevicesStep:
         )
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "devices"
-        assert result["errors"]["base"] == "no_devices"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "no_devices"
 
 
 # ===========================================================================
@@ -1178,7 +1218,9 @@ class TestOptionsFlow:
                 {CONF_MODE: MODE_STANDARD, CONF_DEVICES: []},
             )
         assert result["type"] is FlowResultType.FORM
-        assert result["errors"]["base"] == "no_devices"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "no_devices"
 
     async def test_options_enhanced_to_standard_removes_credentials(
         self, hass: HomeAssistant
@@ -1293,7 +1335,9 @@ class TestOptionsFlow:
             result["step_id"] == "init_app"
         )  # account sign-in renders its own help text
 
-        options = result["data_schema"].schema[CONF_DEVICES].config["options"]
+        schema = result["data_schema"]
+        assert schema is not None
+        options = schema.schema[CONF_DEVICES].config["options"]
         values = [opt["value"] for opt in options]
         assert values == ["SN001", "SN002"]
 
@@ -1334,9 +1378,11 @@ class TestOptionsFlow:
         ):
             result = await hass.config_entries.options.async_init(entry.entry_id)
 
+        schema = result["data_schema"]
+        assert schema is not None
         labels = {
             opt["value"]: opt["label"]
-            for opt in result["data_schema"].schema[CONF_DEVICES].config["options"]
+            for opt in schema.schema[CONF_DEVICES].config["options"]
         }
         assert labels["ZZ99FAKE00000001"].endswith(
             " - not supported yet (no data exposed)"
@@ -1381,9 +1427,11 @@ class TestOptionsFlow:
         ):
             result = await hass.config_entries.options.async_init(entry.entry_id)
 
+        schema = result["data_schema"]
+        assert schema is not None
         labels = {
             opt["value"]: opt["label"]
-            for opt in result["data_schema"].schema[CONF_DEVICES].config["options"]
+            for opt in schema.schema[CONF_DEVICES].config["options"]
         }
         assert "not supported" not in labels["R351FAKE00000001"]
 
@@ -1403,7 +1451,9 @@ class TestOptionsFlow:
             result["step_id"] == "init_app"
         )  # account sign-in renders its own help text
 
-        options = result["data_schema"].schema[CONF_DEVICES].config["options"]
+        schema = result["data_schema"]
+        assert schema is not None
+        options = schema.schema[CONF_DEVICES].config["options"]
         assert [opt["value"] for opt in options] == ["SN001"]
 
     async def test_options_stored_fallback_marks_unsupported(
@@ -1442,9 +1492,11 @@ class TestOptionsFlow:
         ):
             result = await hass.config_entries.options.async_init(entry.entry_id)
 
+        schema = result["data_schema"]
+        assert schema is not None
         labels = {
             opt["value"]: opt["label"]
-            for opt in result["data_schema"].schema[CONF_DEVICES].config["options"]
+            for opt in schema.schema[CONF_DEVICES].config["options"]
         }
         assert labels["ZZ99FAKE00000001"].endswith(
             " - not supported yet (no data exposed)"
@@ -1478,7 +1530,9 @@ class TestOptionsFlow:
                 {CONF_EMAIL: "test@example.com", CONF_PASSWORD: "wrong"},
             )
         assert result["type"] is FlowResultType.FORM
-        assert result["errors"]["base"] == "enhanced_login_failed"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "enhanced_login_failed"
 
     async def test_options_switch_to_enhanced_saves_credentials(
         self, hass: HomeAssistant
@@ -1555,7 +1609,9 @@ class TestOptionsFlow:
 
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "init"
-        options = result["data_schema"].schema[CONF_DEVICES].config["options"]
+        schema = result["data_schema"]
+        assert schema is not None
+        options = schema.schema[CONF_DEVICES].config["options"]
         assert [opt["value"] for opt in options] == ["SN001"]
 
 
@@ -1631,7 +1687,9 @@ class TestOptionsDeveloperStep:
             mock_cls.assert_not_called()
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "developer"
-        assert result["errors"]["base"] == "invalid_auth"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "invalid_auth"
 
     async def test_valid_keys_save_options(self, hass: HomeAssistant) -> None:
         """Valid keys save the options and persist Standard mode credentials."""
@@ -1676,7 +1734,9 @@ class TestOptionsDeveloperStep:
             )
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "developer"
-        assert result["errors"]["base"] == "invalid_auth"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "invalid_auth"
 
     async def test_network_error_shows_cannot_connect(
         self, hass: HomeAssistant
@@ -1695,7 +1755,9 @@ class TestOptionsDeveloperStep:
             )
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "developer"
-        assert result["errors"]["base"] == "cannot_connect"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "cannot_connect"
 
 
 # ===========================================================================
@@ -1766,7 +1828,9 @@ class TestOptionsEnhancedStepErrors:
             )
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "enhanced"
-        assert result["errors"]["base"] == "enhanced_login_failed"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "enhanced_login_failed"
 
 
 # ===========================================================================
@@ -1858,7 +1922,9 @@ class TestReauthFlow:
                 {CONF_ACCESS_KEY: "bad_key", CONF_SECRET_KEY: "bad_secret"},
             )
         assert result["type"] is FlowResultType.FORM
-        assert result["errors"]["base"] == "invalid_auth"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "invalid_auth"
 
     async def test_reauth_success_standard(self, hass: HomeAssistant) -> None:
         """Successful reauth for Standard Mode updates entry and aborts."""
@@ -1970,7 +2036,9 @@ class TestReauthFlow:
                 {CONF_EMAIL: "test@example.com", CONF_PASSWORD: "wrong"},
             )
         assert result["type"] is FlowResultType.FORM
-        assert result["errors"]["base"] == "enhanced_login_failed"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "enhanced_login_failed"
 
     async def test_reauth_connection_error(self, hass: HomeAssistant) -> None:
         """Connection error during reauth shows cannot_connect."""
@@ -1991,7 +2059,9 @@ class TestReauthFlow:
                 {CONF_ACCESS_KEY: "ak", CONF_SECRET_KEY: "sk"},
             )
         assert result["type"] is FlowResultType.FORM
-        assert result["errors"]["base"] == "cannot_connect"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "cannot_connect"
 
 
 # ===========================================================================
@@ -2081,7 +2151,9 @@ class TestReconfigureFlow:
                 {CONF_ACCESS_KEY: "bad_key", CONF_SECRET_KEY: "bad_secret"},
             )
         assert result["type"] is FlowResultType.FORM
-        assert result["errors"]["base"] == "invalid_auth"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "invalid_auth"
 
     async def test_reconfigure_success_standard(self, hass: HomeAssistant) -> None:
         """Successful reconfigure for Standard Mode updates entry."""
@@ -2169,7 +2241,9 @@ class TestReconfigureFlow:
             )
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "reconfigure_enhanced"
-        assert result["errors"]["base"] == "enhanced_login_failed"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "enhanced_login_failed"
 
     async def test_reconfigure_connection_error(self, hass: HomeAssistant) -> None:
         """Connection error shows cannot_connect."""
@@ -2189,7 +2263,9 @@ class TestReconfigureFlow:
                 {CONF_ACCESS_KEY: "ak", CONF_SECRET_KEY: "sk"},
             )
         assert result["type"] is FlowResultType.FORM
-        assert result["errors"]["base"] == "cannot_connect"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "cannot_connect"
 
 
 # ===========================================================================
@@ -2279,7 +2355,9 @@ class TestAppAuthReauthFlow:
                 {CONF_EMAIL: "test@example.com", CONF_PASSWORD: "wrong"},
             )
         assert result["type"] is FlowResultType.FORM
-        assert result["errors"]["base"] == "enhanced_login_failed"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "enhanced_login_failed"
 
 
 # ===========================================================================
@@ -2365,7 +2443,9 @@ class TestAppAuthReconfigureFlow:
                 {CONF_EMAIL: "test@example.com", CONF_PASSWORD: "wrong"},
             )
         assert result["type"] is FlowResultType.FORM
-        assert result["errors"]["base"] == "enhanced_login_failed"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "enhanced_login_failed"
 
 
 # ===========================================================================
@@ -2471,7 +2551,7 @@ class TestReauthReconfigureExceptions:
         return entry
 
     async def _init_flow(self, hass: HomeAssistant, entry, source: str):
-        context = {"source": source, "entry_id": entry.entry_id}
+        context: ConfigFlowContext = {"source": source, "entry_id": entry.entry_id}
         data = entry.data if source == SOURCE_REAUTH else None
         return await hass.config_entries.flow.async_init(
             DOMAIN, context=context, data=data
@@ -2521,7 +2601,9 @@ class TestReauthReconfigureExceptions:
             )
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == step_id
-        assert result["errors"]["base"] == expected_error
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == expected_error
 
     @pytest.mark.parametrize(("side_effect", "expected_error"), EXCEPTION_ERROR_CASES)
     @pytest.mark.parametrize(
@@ -2556,7 +2638,9 @@ class TestReauthReconfigureExceptions:
             )
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == step_id
-        assert result["errors"]["base"] == expected_error
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == expected_error
 
     @pytest.mark.parametrize(("side_effect", "expected_error"), EXCEPTION_ERROR_CASES)
     @pytest.mark.parametrize(
@@ -2590,7 +2674,9 @@ class TestReauthReconfigureExceptions:
             )
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == step_id
-        assert result["errors"]["base"] == expected_error
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == expected_error
 
     @pytest.mark.parametrize(
         ("source", "step_id"),
@@ -2619,7 +2705,9 @@ class TestReauthReconfigureExceptions:
             mock_login.assert_not_called()
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == step_id
-        assert result["errors"]["base"] == "enhanced_login_failed"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "enhanced_login_failed"
 
     @pytest.mark.parametrize(
         ("source", "step_id"),
@@ -2647,7 +2735,9 @@ class TestReauthReconfigureExceptions:
             mock_login.assert_not_called()
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == step_id
-        assert result["errors"]["base"] == "enhanced_login_failed"
+        errors = result["errors"]
+        assert errors is not None
+        assert errors["base"] == "enhanced_login_failed"
 
 
 # ===========================================================================
@@ -2937,7 +3027,7 @@ class TestPickerHelpMatchesTheModeItRenders:
     RECORDING_PHRASES = ("recording below", "Aufzeichnung der Diagnosedaten")
 
     @staticmethod
-    def _render(template: str, placeholders: dict[str, str]) -> str:
+    def _render(template: str, placeholders: Mapping[str, str]) -> str:
         """Resolve a translation string the way the frontend would.
 
         Only the two forms this repo uses are handled: plain `{token}` and
@@ -2951,7 +3041,7 @@ class TestPickerHelpMatchesTheModeItRenders:
             token, body = match.group(1), match.group(2)
             if token not in placeholders:
                 raise AssertionError(f"flow supplied no placeholder {token!r}")
-            arms = dict(re.findall(r"(\w+)\s*\{([^{}]*)\}", body))
+            arms: dict[str, str] = dict(re.findall(r"(\w+)\s*\{([^{}]*)\}", body))
             return arms.get(placeholders[token], arms.get("other", ""))
 
         rendered = re.sub(
@@ -2964,7 +3054,7 @@ class TestPickerHelpMatchesTheModeItRenders:
         return rendered
 
     @staticmethod
-    async def _open(hass: HomeAssistant, entry) -> dict:
+    async def _open(hass: HomeAssistant, entry) -> ConfigFlowResult:
         """Open the options form without letting it reach the network.
 
         Both branches of the device-list fetch are stubbed, so which mode is
@@ -2987,7 +3077,7 @@ class TestPickerHelpMatchesTheModeItRenders:
             return await hass.config_entries.options.async_init(entry.entry_id)
 
     @classmethod
-    def _devices_help(cls, result: dict) -> str:
+    def _devices_help(cls, result: ConfigFlowResult) -> str:
         """The help text the user is shown, for the step actually rendered.
 
         Reading the step id off the result rather than assuming `init` is
@@ -3017,7 +3107,9 @@ class TestPickerHelpMatchesTheModeItRenders:
         entry = TestOptionsFlow()._create_standard_entry(hass)
         result = await self._open(hass, entry)
 
-        schema_keys = {key.schema for key in result["data_schema"].schema}
+        schema = result["data_schema"]
+        assert schema is not None
+        schema_keys = {key.schema for key in schema.schema}
         assert CONF_RAW_CAPTURE not in schema_keys
 
         text = self._devices_help(result)
@@ -3037,7 +3129,9 @@ class TestPickerHelpMatchesTheModeItRenders:
         )
         result = await self._open(hass, entry)
 
-        schema_keys = {key.schema for key in result["data_schema"].schema}
+        schema = result["data_schema"]
+        assert schema is not None
+        schema_keys = {key.schema for key in schema.schema}
         assert CONF_RAW_CAPTURE in schema_keys
 
         assert "recording below" in self._devices_help(result)

--- a/tests/ha/test_coordinator.py
+++ b/tests/ha/test_coordinator.py
@@ -6547,8 +6547,12 @@ class TestAppAuthMode:
         coordinator._credential_obtained_ts = 1.0  # fixed positive value
 
         # Replace the coroutine method with a sync no-op to avoid async scheduling
-        # issues
-        coordinator._proactive_credential_refresh = lambda: None  # type: ignore[assignment]
+        # issues. Deliberate: the replacement is sync on purpose (so calling it
+        # here does not leave an unawaited coroutine behind), which is exactly
+        # what these two codes complain about.
+        coordinator._proactive_credential_refresh = (  # type: ignore[assignment, return-value]
+            lambda: None
+        )
         with (
             patch.object(hass, "async_create_task") as mock_task,
             patch(

--- a/tests/ha/test_coordinator.py
+++ b/tests/ha/test_coordinator.py
@@ -4162,7 +4162,7 @@ class TestBpRemapping:
         coordinator = EcoFlowDeviceCoordinator(
             hass, enhanced_config_entry, MOCK_POWEROCEAN_DEVICE
         )
-        raw = {
+        raw: dict[str, Any] = {
             "all_packs": [
                 {},  # phantom
                 {},  # phantom
@@ -6550,8 +6550,8 @@ class TestAppAuthMode:
         # issues. Deliberate: the replacement is sync on purpose (so calling it
         # here does not leave an unawaited coroutine behind), which is exactly
         # what these two codes complain about.
-        coordinator._proactive_credential_refresh = (  # type: ignore[assignment, return-value]
-            lambda: None
+        coordinator._proactive_credential_refresh = (
+            lambda: None  # type: ignore[assignment, return-value]
         )
         with (
             patch.object(hass, "async_create_task") as mock_task,
@@ -6662,6 +6662,7 @@ class TestAppAuthMode:
         with patch.object(entry, "async_start_reauth") as mock_reauth:
             await coordinator._refresh_mqtt_credentials()
         mock_reauth.assert_called_once()
+        assert isinstance(coordinator._mqtt_client, MagicMock)
         coordinator._mqtt_client.update_credentials.assert_not_called()
 
     async def test_reactive_refresh_login_failure_triggers_reauth(
@@ -6731,6 +6732,7 @@ class TestAppAuthMode:
         with patch.object(entry, "async_start_reauth") as mock_reauth:
             await coordinator._proactive_credential_refresh()
         mock_reauth.assert_not_called()
+        assert isinstance(coordinator._mqtt_client, MagicMock)
         coordinator._mqtt_client.update_credentials.assert_not_called()
         assert coordinator.event_log == []
 
@@ -6851,6 +6853,7 @@ class TestSnapshotContinuity:
             return_value=1000.0 + STALE_THRESHOLD_S + 10,
         ):
             coordinator._check_stale()
+            assert coordinator._stale_check_unsub is not None
             coordinator._stale_check_unsub.cancel()
 
         # Snapshot data must still be available (stale, not hard unavailable)
@@ -6882,6 +6885,7 @@ class TestSnapshotContinuity:
             return_value=1000.0 + SOFT_UNAVAILABLE_S + 10,
         ):
             coordinator._check_stale()
+            assert coordinator._stale_check_unsub is not None
             coordinator._stale_check_unsub.cancel()
 
         # Data should persist in degraded stage (not yet hard unavailable)
@@ -6916,6 +6920,7 @@ class TestSnapshotContinuity:
             return_value=1000.0 + HARD_UNAVAILABLE_S + 10,
         ):
             coordinator._check_stale()
+            assert coordinator._stale_check_unsub is not None
             coordinator._stale_check_unsub.cancel()
 
         # Data should be expired
@@ -6951,6 +6956,7 @@ class TestSnapshotContinuity:
             return_value=1000.0 + HARD_UNAVAILABLE_S + 10,
         ):
             coordinator._check_stale()
+            assert coordinator._stale_check_unsub is not None
             coordinator._stale_check_unsub.cancel()
 
         assert coordinator.snapshot.data == {}
@@ -7231,6 +7237,7 @@ class TestDeveloperCredentialRefresh:
 
         await coordinator._refresh_mqtt_credentials()
 
+        assert isinstance(coordinator._mqtt_client, MagicMock)
         coordinator._mqtt_client.update_credentials.assert_not_called()
         assert coordinator.event_log == []
 
@@ -7258,6 +7265,7 @@ class TestDeveloperCredentialRefresh:
         ):
             await coordinator._refresh_mqtt_credentials()
 
+        assert isinstance(coordinator._mqtt_client, MagicMock)
         coordinator._mqtt_client.update_credentials.assert_called_once_with(
             "new-account",
             "new-password",
@@ -7280,6 +7288,7 @@ class TestDeveloperCredentialRefresh:
         with patch.object(standard_config_entry, "async_start_reauth") as mock_reauth:
             await coordinator._refresh_mqtt_credentials()
 
+        assert isinstance(coordinator._mqtt_client, MagicMock)
         coordinator._mqtt_client.update_credentials.assert_not_called()
         assert coordinator.event_log[-1]["type"] == "credential_refresh_fail"
         assert coordinator.event_log[-1]["detail"] == "developer-auth"
@@ -7296,6 +7305,7 @@ class TestDeveloperCredentialRefresh:
 
         await coordinator._proactive_credential_refresh()
 
+        assert isinstance(coordinator._mqtt_client, MagicMock)
         coordinator._mqtt_client.update_credentials.assert_not_called()
         assert coordinator.event_log == []
 
@@ -7311,6 +7321,7 @@ class TestDeveloperCredentialRefresh:
         reconnect exactly like a changed account does.
         """
         coordinator = self._coordinator(hass, standard_config_entry)
+        assert isinstance(coordinator._mqtt_client, MagicMock)
         coordinator._mqtt_client.update_broker.return_value = True
         coordinator._iot_api = MagicMock()
         coordinator._iot_api.refresh_credentials = AsyncMock(
@@ -7357,6 +7368,7 @@ class TestDeveloperCredentialRefresh:
 
         await coordinator._refresh_mqtt_credentials()
 
+        assert isinstance(coordinator._mqtt_client, MagicMock)
         coordinator._mqtt_client.update_broker.assert_called_once_with(
             ("mqtt-a.ecoflow.com", 8085, "/mqtt")
         )
@@ -7389,6 +7401,7 @@ class TestDeveloperCredentialRefresh:
         ):
             await coordinator._proactive_credential_refresh()
 
+        assert isinstance(coordinator._mqtt_client, MagicMock)
         coordinator._mqtt_client.update_credentials.assert_called_once_with(
             "old-account",
             "rotated-password",
@@ -7416,6 +7429,7 @@ class TestDeveloperCredentialRefresh:
         with patch.object(hass, "async_add_executor_job") as mock_exec:
             await coordinator._proactive_credential_refresh()
 
+        assert isinstance(coordinator._mqtt_client, MagicMock)
         coordinator._mqtt_client.update_credentials.assert_called_once_with(
             "new-account",
             "new-password",
@@ -7438,6 +7452,7 @@ class TestDeveloperCredentialRefresh:
         with patch.object(standard_config_entry, "async_start_reauth") as mock_reauth:
             await coordinator._proactive_credential_refresh()
 
+        assert isinstance(coordinator._mqtt_client, MagicMock)
         coordinator._mqtt_client.update_credentials.assert_not_called()
         assert coordinator.event_log[-1]["type"] == "credential_proactive_fail"
         assert coordinator.event_log[-1]["detail"] == "api failed"

--- a/tests/ha/test_delta3_idle_shutdown_entity.py
+++ b/tests/ha/test_delta3_idle_shutdown_entity.py
@@ -46,6 +46,8 @@ from custom_components.ecoflow_energy.select import (
     async_setup_entry as select_setup,
 )
 
+from .conftest import add_entities_collector
+
 DELTA3_MAX_PLUS: dict[str, Any] = {
     "sn": "D3M1TEST00000001",
     "name": "Delta 3 Max Plus",
@@ -197,6 +199,7 @@ class TestWrite:
 
         await _select(coordinator, key).async_select_option("4_hours")
 
+        assert isinstance(coordinator.async_send_delta3_set, AsyncMock)
         command = coordinator.async_send_delta3_set.call_args[0][0]
         assert command["params"] == {params_key: 240}
 
@@ -207,6 +210,7 @@ class TestWrite:
 
         await _select(coordinator, key).async_select_option("never")
 
+        assert isinstance(coordinator.async_send_delta3_set, AsyncMock)
         command = coordinator.async_send_delta3_set.call_args[0][0]
         assert command["params"] == {params_key: 0}
 
@@ -235,6 +239,7 @@ class TestWrite:
 
         await _select(coordinator, key).async_select_option("5_minutes")
 
+        assert isinstance(coordinator.async_send_delta3_set, AsyncMock)
         coordinator.async_send_delta3_set.assert_not_called()
 
     async def test_writing_one_does_not_disturb_the_others(
@@ -258,7 +263,7 @@ class TestPlatformGating:
             DELTA3_MAX_PLUS["sn"]: coordinator
         }
         created: list[Any] = []
-        await select_setup(hass, entry, created.extend)
+        await select_setup(hass, entry, add_entities_collector(created))
         return {e._definition.key for e in created}
 
     async def test_enhanced_mode_gets_all_four(self, hass: HomeAssistant) -> None:

--- a/tests/ha/test_delta3_port_priority_entities.py
+++ b/tests/ha/test_delta3_port_priority_entities.py
@@ -15,6 +15,7 @@ switch platform gained together with this feature.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -145,6 +146,7 @@ def _number(coordinator: EcoFlowDeviceCoordinator, key: str) -> EcoFlowNumber:
 
 def _sent_item(coordinator: EcoFlowDeviceCoordinator) -> dict[str, Any]:
     """Return the port priority payload handed to the coordinator."""
+    assert isinstance(coordinator.async_send_delta3_set, AsyncMock)
     coordinator.async_send_delta3_set.assert_called_once()
     command = coordinator.async_send_delta3_set.call_args[0][0]
     return command["params"]["cfgPowerOutagesList"]
@@ -198,6 +200,7 @@ class TestSwitchCarriesTheReportedCutoff:
             await entity.async_turn_on()
 
         assert err.value.translation_key == "set_command_not_ready"
+        assert isinstance(coordinator.async_send_delta3_set, AsyncMock)
         coordinator.async_send_delta3_set.assert_not_called()
 
     async def test_a_refused_write_does_not_move_the_switch(
@@ -220,6 +223,7 @@ class TestSwitchCarriesTheReportedCutoff:
 
         await entity.async_turn_on()
 
+        assert isinstance(coordinator.async_send_delta3_set, AsyncMock)
         command = coordinator.async_send_delta3_set.call_args[0][0]
         assert "cfgPowerOutagesList" not in command["params"]
 
@@ -260,6 +264,7 @@ class TestNumberCarriesTheReportedFlag:
             await entity.async_set_native_value(20.0)
 
         assert err.value.translation_key == "set_command_not_ready"
+        assert isinstance(coordinator.async_send_delta3_set, AsyncMock)
         coordinator.async_send_delta3_set.assert_not_called()
 
     async def test_the_regular_numbers_are_untouched(self, hass: HomeAssistant) -> None:
@@ -268,6 +273,7 @@ class TestNumberCarriesTheReportedFlag:
 
         await entity.async_set_native_value(80.0)
 
+        assert isinstance(coordinator.async_send_delta3_set, AsyncMock)
         command = coordinator.async_send_delta3_set.call_args[0][0]
         assert "cfgPowerOutagesList" not in command["params"]
 
@@ -337,7 +343,13 @@ class TestSwitchPlatformGating:
         coordinator, entry = _coordinator(hass, device, REPORTED, enhanced)
         hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {device["sn"]: coordinator}
         created: list[Any] = []
-        await switch_setup(hass, entry, created.extend)
+
+        def _collect(
+            new_entities: Iterable[Any], update_before_add: bool = False
+        ) -> None:
+            created.extend(new_entities)
+
+        await switch_setup(hass, entry, _collect)
         return {e._definition.key for e in created}
 
     async def test_max_plus_in_enhanced_mode_gets_them(
@@ -400,6 +412,7 @@ class TestWritesInSuccession:
         await switch.async_turn_on()  # AC 1 -> non-essential
         await number.async_set_native_value(25)  # ... before the device echoes
 
+        assert isinstance(coordinator.async_send_delta3_set, AsyncMock)
         sent = coordinator.async_send_delta3_set.call_args[0][0]
         item = sent["params"]["cfgPowerOutagesList"]
 
@@ -418,6 +431,7 @@ class TestWritesInSuccession:
         await number.async_set_native_value(20)
         await switch.async_turn_off()
 
+        assert isinstance(coordinator.async_send_delta3_set, AsyncMock)
         item = coordinator.async_send_delta3_set.call_args[0][0]["params"][
             "cfgPowerOutagesList"
         ]
@@ -453,6 +467,7 @@ class TestDerivedBoundsArePublished:
         coordinator, _ = _coordinator(hass, DELTA3_MAX_PLUS, REPORTED)
         number = _number(coordinator, "port_priority_ac1_soc")
         number._handle_coordinator_update()
+        assert isinstance(number.async_write_ha_state, MagicMock)
         number.async_write_ha_state.reset_mock()
 
         assert (number.native_min_value, number.native_max_value) == (5, 95)
@@ -464,6 +479,7 @@ class TestDerivedBoundsArePublished:
         number._handle_coordinator_update()
 
         assert (number.native_min_value, number.native_max_value) == (25, 75)
+        assert isinstance(number.async_write_ha_state, MagicMock)
         assert number.async_write_ha_state.called
 
     async def test_unchanged_limits_do_not_force_a_write(
@@ -473,6 +489,7 @@ class TestDerivedBoundsArePublished:
         coordinator, _ = _coordinator(hass, DELTA3_MAX_PLUS, REPORTED)
         number = _number(coordinator, "port_priority_ac1_soc")
         number._handle_coordinator_update()
+        assert isinstance(number.async_write_ha_state, MagicMock)
         number.async_write_ha_state.reset_mock()
 
         coordinator.async_set_updated_data(dict(coordinator._device_data))

--- a/tests/ha/test_delta3_screen_timeout_entity.py
+++ b/tests/ha/test_delta3_screen_timeout_entity.py
@@ -58,6 +58,8 @@ from custom_components.ecoflow_energy.select import (
     async_setup_entry as select_setup,
 )
 
+from .conftest import add_entities_collector
+
 DELTA3_MAX_PLUS: dict[str, Any] = {
     "sn": "D3M1TEST00000001",
     "name": "Delta 3 Max Plus",
@@ -170,6 +172,7 @@ class TestWrite:
 
         await entity.async_select_option("30_seconds")
 
+        assert isinstance(coordinator.async_send_delta3_set, AsyncMock)
         command = coordinator.async_send_delta3_set.call_args[0][0]
         assert command["params"] == {SCREEN_TIMEOUT_PARAMS_KEY: 30}
 
@@ -179,6 +182,7 @@ class TestWrite:
 
         await entity.async_select_option("never")
 
+        assert isinstance(coordinator.async_send_delta3_set, AsyncMock)
         command = coordinator.async_send_delta3_set.call_args[0][0]
         assert command["params"] == {SCREEN_TIMEOUT_PARAMS_KEY: 0}
 
@@ -227,6 +231,7 @@ class TestWrite:
 
         await entity.async_select_option("2_hours")
 
+        assert isinstance(coordinator.async_send_delta3_set, AsyncMock)
         coordinator.async_send_delta3_set.assert_not_called()
 
 
@@ -283,7 +288,7 @@ class TestPlatformGating:
             DELTA3_MAX_PLUS["sn"]: coordinator
         }
         created: list[Any] = []
-        await select_setup(hass, entry, created.extend)
+        await select_setup(hass, entry, add_entities_collector(created))
         return {e._definition.key for e in created}
 
     async def test_enhanced_mode_gets_the_select(self, hass: HomeAssistant) -> None:

--- a/tests/ha/test_diagnostics.py
+++ b/tests/ha/test_diagnostics.py
@@ -807,8 +807,10 @@ class TestEnergyIntegratorDiagnostics:
             hass, standard_config_entry, MOCK_DELTA_DEVICE
         )
         coordinator._energy_integrator._state = {
-            "broken_energy_kwh": ("not", "a", "number"),
-            "short_energy_kwh": (1.0,),
+            # Both entries are malformed on purpose: the test is that a state
+            # file carrying them is survived rather than trusted.
+            "broken_energy_kwh": ("not", "a", "number"),  # type: ignore[dict-item]
+            "short_energy_kwh": (1.0,),  # type: ignore[dict-item]
             "solar_energy_kwh": (18.7, 1000.0, 150.0),
         }
 

--- a/tests/ha/test_init.py
+++ b/tests/ha/test_init.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
@@ -1281,7 +1282,7 @@ class TestUnroutedDeviceProbeWiring:
         raw_capture: bool | None = True,
         capture_until: float | None = None,
     ) -> MockConfigEntry:
-        data = {
+        data: dict[str, Any] = {
             CONF_AUTH_METHOD: auth_method,
             CONF_MODE: MODE_ENHANCED,
             CONF_EMAIL: "test@example.com",
@@ -1654,6 +1655,7 @@ class TestRawCaptureWithoutASkippedDevice:
             await hass.async_block_till_done()
 
         mock_start.assert_awaited_once()
+        assert mock_start.await_args is not None
         probed = [item["sn"] for item in mock_start.await_args.args[1]]
         assert probed == [unsupported["sn"]]
 

--- a/tests/ha/test_powerglow_gating.py
+++ b/tests/ha/test_powerglow_gating.py
@@ -35,6 +35,8 @@ from custom_components.ecoflow_energy.ecoflow.parsers.powerocean_proto import (
 )
 from custom_components.ecoflow_energy.sensor import async_setup_entry as sensor_setup
 
+from .conftest import add_entities_collector
+
 POWEROCEAN_DEVICE: dict[str, Any] = {
     "sn": "HJ31TEST00000001",
     "name": "PowerOcean",
@@ -104,7 +106,7 @@ async def _setup(
     }
 
     created: list[Any] = []
-    await sensor_setup(hass, entry, created.extend)
+    await sensor_setup(hass, entry, add_entities_collector(created))
     return coordinator, created
 
 
@@ -231,7 +233,7 @@ class TestLateAccessory:
             second["sn"]: without_rod,
         }
         created: list[Any] = []
-        await sensor_setup(hass, entry, created.extend)
+        await sensor_setup(hass, entry, add_entities_collector(created))
 
         with_rod.set_device_value("heating_rod_power_w", 1750.0)
         with_rod.async_set_updated_data(dict(with_rod.device_data))
@@ -265,7 +267,7 @@ class TestUnload:
         }
 
         calls: list[Any] = []
-        await sensor_setup(hass, entry, calls.append)
+        await sensor_setup(hass, entry, add_entities_collector(calls))
         assert coordinator._listeners
         calls.clear()
 

--- a/tests/ha/test_powerocean_number.py
+++ b/tests/ha/test_powerocean_number.py
@@ -238,7 +238,8 @@ class TestPowerOceanNumberBasic:
             hass,
             enhanced_config_entry,
         )
-        coordinator.async_set_updated_data(None)
+        # Passing nothing is the subject: the entity must report nothing back.
+        coordinator.async_set_updated_data(None)  # type: ignore[arg-type]
         assert entity.native_value is None
 
 

--- a/tests/ha/test_powerocean_schedule_controls.py
+++ b/tests/ha/test_powerocean_schedule_controls.py
@@ -21,6 +21,7 @@ rather than compared as opaque bytes.
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -72,14 +73,19 @@ POWEROCEAN_DEVICE: dict[str, Any] = {
 GET_REPLY = f"/app/user123/{POWEROCEAN_DEVICE['sn']}/thing/property/get_reply"
 
 
-class FakeMqtt:
+class FakeMqtt(MagicMock):
     """Records what the coordinator hands the broker.
 
     Only the two methods the SET path calls. The payload is kept so the test
     can decode what actually went out rather than trust the return value.
+
+    Subclasses `MagicMock` so the assignment to the coordinator's
+    `EcoFlowMQTTClient | None`-typed attribute type-checks; the methods below
+    are real overrides and shadow Mock's auto-attribute behaviour.
     """
 
     def __init__(self, connected: bool = True, delivers: bool = True) -> None:
+        super().__init__()
         self._connected = connected
         self.delivers = delivers
         self.sent: list[bytes] = []
@@ -128,6 +134,15 @@ def _entry(
     )
 
 
+def _collector(target: list[Any]) -> Callable[[Iterable[Any], bool], None]:
+    """Adapt a plain list to the `AddEntitiesCallback` signature."""
+
+    def _add(new_entities: Iterable[Any], update_before_add: bool = False) -> None:
+        target.extend(new_entities)
+
+    return _add
+
+
 def _report(
     coordinator: EcoFlowDeviceCoordinator, payload: bytes, sn: str | None = None
 ) -> None:
@@ -158,8 +173,8 @@ async def _setup(
 
     switches: list[Any] = []
     numbers: list[Any] = []
-    await switch_setup(hass, entry, switches.extend)
-    await number_setup(hass, entry, numbers.extend)
+    await switch_setup(hass, entry, _collector(switches))
+    await number_setup(hass, entry, _collector(numbers))
     return coordinator, switches, numbers, mqtt
 
 
@@ -209,6 +224,7 @@ def _fields(payload: bytes) -> dict[int, Any]:
     while pos < len(body):
         key, pos = _varint(body, pos)
         field, wire = key >> 3, key & 0x07
+        value: int | bytes
         if wire == 0:
             value, pos = _varint(body, pos)
         elif wire == 2:
@@ -551,8 +567,8 @@ class TestNoSchedule:
         hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
             POWEROCEAN_DEVICE["sn"]: coordinator
         }
-        await switch_setup(hass, entry, added.extend)
-        await number_setup(hass, entry, added.extend)
+        await switch_setup(hass, entry, _collector(added))
+        await number_setup(hass, entry, _collector(added))
         assert _schedule_keys(added) == set()
 
         _report(coordinator, LIST_ARMED_1500W)
@@ -582,8 +598,8 @@ class TestStandardMode:
 
         switches: list[Any] = []
         numbers: list[Any] = []
-        await switch_setup(hass, entry, switches.extend)
-        await number_setup(hass, entry, numbers.extend)
+        await switch_setup(hass, entry, _collector(switches))
+        await number_setup(hass, entry, _collector(numbers))
 
         assert _schedule_keys(switches) == set()
         assert _schedule_keys(numbers) == set()

--- a/tests/ha/test_powerocean_schedule_controls.py
+++ b/tests/ha/test_powerocean_schedule_controls.py
@@ -21,7 +21,6 @@ rather than compared as opaque bytes.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -61,6 +60,8 @@ from tests.test_powerocean_timer_task import (
     _header,
 )
 from tests.test_powerocean_timer_task_write import pdata_of
+
+from .conftest import add_entities_collector
 
 POWEROCEAN_DEVICE: dict[str, Any] = {
     "sn": "HJ31TEST00000001",
@@ -134,15 +135,6 @@ def _entry(
     )
 
 
-def _collector(target: list[Any]) -> Callable[[Iterable[Any], bool], None]:
-    """Adapt a plain list to the `AddEntitiesCallback` signature."""
-
-    def _add(new_entities: Iterable[Any], update_before_add: bool = False) -> None:
-        target.extend(new_entities)
-
-    return _add
-
-
 def _report(
     coordinator: EcoFlowDeviceCoordinator, payload: bytes, sn: str | None = None
 ) -> None:
@@ -173,8 +165,8 @@ async def _setup(
 
     switches: list[Any] = []
     numbers: list[Any] = []
-    await switch_setup(hass, entry, _collector(switches))
-    await number_setup(hass, entry, _collector(numbers))
+    await switch_setup(hass, entry, add_entities_collector(switches))
+    await number_setup(hass, entry, add_entities_collector(numbers))
     return coordinator, switches, numbers, mqtt
 
 
@@ -567,8 +559,8 @@ class TestNoSchedule:
         hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
             POWEROCEAN_DEVICE["sn"]: coordinator
         }
-        await switch_setup(hass, entry, _collector(added))
-        await number_setup(hass, entry, _collector(added))
+        await switch_setup(hass, entry, add_entities_collector(added))
+        await number_setup(hass, entry, add_entities_collector(added))
         assert _schedule_keys(added) == set()
 
         _report(coordinator, LIST_ARMED_1500W)
@@ -598,8 +590,8 @@ class TestStandardMode:
 
         switches: list[Any] = []
         numbers: list[Any] = []
-        await switch_setup(hass, entry, _collector(switches))
-        await number_setup(hass, entry, _collector(numbers))
+        await switch_setup(hass, entry, add_entities_collector(switches))
+        await number_setup(hass, entry, add_entities_collector(numbers))
 
         assert _schedule_keys(switches) == set()
         assert _schedule_keys(numbers) == set()

--- a/tests/ha/test_powerocean_schedule_entities.py
+++ b/tests/ha/test_powerocean_schedule_entities.py
@@ -47,6 +47,8 @@ from tests.test_powerocean_timer_task import (
     _header,
 )
 
+from .conftest import add_entities_collector
+
 POWEROCEAN_DEVICE: dict[str, Any] = {
     "sn": "HJ31TEST00000001",
     "name": "PowerOcean",
@@ -108,8 +110,8 @@ async def _setup(
 
     sensors: list[Any] = []
     binary_sensors: list[Any] = []
-    await sensor_setup(hass, entry, sensors.extend)
-    await binary_sensor_setup(hass, entry, binary_sensors.extend)
+    await sensor_setup(hass, entry, add_entities_collector(sensors))
+    await binary_sensor_setup(hass, entry, add_entities_collector(binary_sensors))
     return coordinator, sensors, binary_sensors
 
 
@@ -253,8 +255,8 @@ class TestStandardMode:
 
         sensors: list[Any] = []
         binary_sensors: list[Any] = []
-        await sensor_setup(hass, entry, sensors.extend)
-        await binary_sensor_setup(hass, entry, binary_sensors.extend)
+        await sensor_setup(hass, entry, add_entities_collector(sensors))
+        await binary_sensor_setup(hass, entry, add_entities_collector(binary_sensors))
 
         assert coordinator.enhanced_mode is False
         assert _schedule_keys(sensors) == set()

--- a/tests/ha/test_powerstream_entities.py
+++ b/tests/ha/test_powerstream_entities.py
@@ -33,6 +33,8 @@ from custom_components.ecoflow_energy.const import (
 from custom_components.ecoflow_energy.coordinator import EcoFlowDeviceCoordinator
 from custom_components.ecoflow_energy.sensor import async_setup_entry as sensor_setup
 
+from .conftest import add_entities_collector
+
 CAPTURE = (
     Path(__file__).parent.parent / "fixtures" / "powerstream" / "hw51_quota_masked.json"
 )
@@ -136,7 +138,7 @@ class TestThePlatform:
         }
 
         created: list[Any] = []
-        await sensor_setup(hass, powerstream_entry, created.extend)
+        await sensor_setup(hass, powerstream_entry, add_entities_collector(created))
         keys = {
             entity._definition.key
             for entity in created
@@ -155,7 +157,7 @@ class TestThePlatform:
         await coordinator.async_refresh()
 
         created: list[Any] = []
-        await sensor_setup(hass, coordinator._entry, created.extend)
+        await sensor_setup(hass, coordinator._entry, add_entities_collector(created))
         states = {
             entity._definition.key: entity.native_value
             for entity in created

--- a/tests/ha/test_powerstream_registry_cleanup.py
+++ b/tests/ha/test_powerstream_registry_cleanup.py
@@ -151,7 +151,9 @@ def test_every_current_powerstream_id_and_customization_survives(
     _async_remove_retired_platform_entities(hass, entry)
 
     assert set(current.values()) <= _ids(hass)
-    assert registry.async_get(current["solar_w"]).name == "Roof solar"
+    solar = registry.async_get(current["solar_w"])
+    assert solar is not None
+    assert solar.name == "Roof solar"
 
 
 def test_cleanup_is_platform_and_key_exact(hass: HomeAssistant) -> None:

--- a/tests/ha/test_smart_meter_entities.py
+++ b/tests/ha/test_smart_meter_entities.py
@@ -49,6 +49,8 @@ from custom_components.ecoflow_energy.ecoflow.const import (
 )
 from custom_components.ecoflow_energy.sensor import async_setup_entry as sensor_setup
 
+from .conftest import add_entities_collector
+
 CAPTURE = (
     Path(__file__).parent.parent
     / "fixtures"
@@ -307,7 +309,7 @@ class TestTheCaptureReachesTheEntities:
         }
 
         created: list[Any] = []
-        await sensor_setup(hass, entry, created.extend)
+        await sensor_setup(hass, entry, add_entities_collector(created))
         values = {
             entity._definition.key: entity.native_value
             for entity in created
@@ -346,7 +348,7 @@ class TestTheCaptureReachesTheEntities:
         }
 
         created: list[Any] = []
-        await binary_sensor_setup(hass, entry, created.extend)
+        await binary_sensor_setup(hass, entry, add_entities_collector(created))
         values = {
             entity._definition.key: entity.is_on
             for entity in created
@@ -390,7 +392,7 @@ class TestTheNetCounterCanFall:
         coordinator._apply_data({"grid_net_energy_wh": 300.0})
 
         created: list[Any] = []
-        await sensor_setup(hass, entry, created.extend)
+        await sensor_setup(hass, entry, add_entities_collector(created))
         values = {
             entity._definition.key: entity.native_value
             for entity in created
@@ -448,7 +450,7 @@ class TestThePowerFactorClearSurvivesAMerge:
         coordinator._apply_data(under_load)
 
         created: list[Any] = []
-        await sensor_setup(hass, entry, created.extend)
+        await sensor_setup(hass, entry, add_entities_collector(created))
         values = {
             entity._definition.key: entity.native_value
             for entity in created

--- a/tests/ha/test_solar_tracker_entities.py
+++ b/tests/ha/test_solar_tracker_entities.py
@@ -39,6 +39,8 @@ from custom_components.ecoflow_energy.ecoflow.const import (
 )
 from custom_components.ecoflow_energy.sensor import async_setup_entry as sensor_setup
 
+from .conftest import add_entities_collector
+
 CAPTURE = (
     Path(__file__).parent.parent
     / "fixtures"
@@ -101,7 +103,7 @@ async def _setup_entities(
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {device["sn"]: coordinator}
 
     created: list[Any] = []
-    await sensor_setup(hass, entry, created.extend)
+    await sensor_setup(hass, entry, add_entities_collector(created))
     return [entity for entity in created if hasattr(entity, "_definition")]
 
 
@@ -162,7 +164,7 @@ class TestTheCaptureReachesTheEntities:
         }
 
         created: list[Any] = []
-        await sensor_setup(hass, entry, created.extend)
+        await sensor_setup(hass, entry, add_entities_collector(created))
         values = {
             entity._definition.key: entity.native_value
             for entity in created
@@ -193,7 +195,7 @@ class TestTheCaptureReachesTheEntities:
         }
 
         created: list[Any] = []
-        await sensor_setup(hass, entry, created.extend)
+        await sensor_setup(hass, entry, add_entities_collector(created))
         values = {
             entity._definition.key: entity.native_value
             for entity in created

--- a/tests/ha/test_stream_ac5000_controls.py
+++ b/tests/ha/test_stream_ac5000_controls.py
@@ -89,10 +89,17 @@ def _select(coordinator: EcoFlowDeviceCoordinator, key: str) -> EcoFlowSelect:
     return entity
 
 
+def _sender(coordinator: EcoFlowDeviceCoordinator) -> AsyncMock:
+    """Narrow the coordinator's mocked proto SET sender for assertions."""
+    sender = coordinator.async_send_proto_set_command
+    assert isinstance(sender, AsyncMock)
+    return sender
+
+
 def _sent(coordinator: EcoFlowDeviceCoordinator) -> tuple[dict, bytes]:
     """Return the header and pdata of the single frame that was sent."""
-    coordinator.async_send_proto_set_command.assert_called_once()
-    payload = coordinator.async_send_proto_set_command.call_args[0][0]
+    _sender(coordinator).assert_called_once()
+    payload = _sender(coordinator).call_args[0][0]
     assert isinstance(payload, bytes)
     headers, _ = decode_header_message(payload)
     assert headers
@@ -113,6 +120,7 @@ def _walk(buf: bytes):
     while offset < len(buf):
         key, offset = _varint(buf, offset)
         number, wire = key >> 3, key & 7
+        value: int | bytes
         if wire == 0:
             value, offset = _varint(buf, offset)
         elif wire == 2:
@@ -143,7 +151,7 @@ def _pdata_of(call) -> bytes:
 
 def _last_pdata(coordinator: EcoFlowDeviceCoordinator) -> bytes:
     """The task itself, when a removal of the other kind went out first."""
-    return _pdata_of(coordinator.async_send_proto_set_command.call_args_list[-1])
+    return _pdata_of(_sender(coordinator).call_args_list[-1])
 
 
 def _config_field(pdata: bytes) -> int:
@@ -259,7 +267,7 @@ class TestSocLimitNumbers:
             await entity.async_set_native_value(85)
 
         assert err.value.translation_key == "set_command_not_ready"
-        coordinator.async_send_proto_set_command.assert_not_called()
+        _sender(coordinator).assert_not_called()
 
     async def test_a_limit_the_device_would_reject_is_not_sent(
         self, hass: HomeAssistant, enhanced_config_entry: MockConfigEntry
@@ -276,7 +284,7 @@ class TestSocLimitNumbers:
             await entity.async_set_native_value(10)
 
         assert err.value.translation_key == "set_value_rejected"
-        coordinator.async_send_proto_set_command.assert_not_called()
+        _sender(coordinator).assert_not_called()
 
     @pytest.mark.parametrize(
         ("key", "value", "counterpart", "expected"),
@@ -331,7 +339,7 @@ class TestSocLimitNumbers:
             await entity.async_set_native_value(40)
 
         assert err.value.translation_key == "set_command_not_ready"
-        coordinator.async_send_proto_set_command.assert_not_called()
+        _sender(coordinator).assert_not_called()
 
     async def test_a_float_reserve_still_toggles_the_switch(
         self, hass: HomeAssistant, enhanced_config_entry: MockConfigEntry
@@ -371,7 +379,7 @@ class TestSocLimitNumbers:
             await entity.async_turn_off()
 
         assert err.value.translation_key == "set_command_not_ready"
-        coordinator.async_send_proto_set_command.assert_not_called()
+        _sender(coordinator).assert_not_called()
 
 
 class TestPowerSetpoints:
@@ -534,7 +542,7 @@ class TestPowerSetpoints:
 
         await entity.async_set_native_value(300)
 
-        sent = coordinator.async_send_proto_set_command.call_args_list
+        sent = _sender(coordinator).call_args_list
         assert len(sent) == 2
         remove = _pdata_of(sent[0])
         # operation 3 (remove), type 1 (charge), and it goes out first
@@ -567,7 +575,7 @@ class TestPowerSetpoints:
 
         await entity.async_set_native_value(300)
 
-        sent = coordinator.async_send_proto_set_command.call_args_list
+        sent = _sender(coordinator).call_args_list
         assert len(sent) == 2, "the parked charge task was not removed"
         # operation 3 (remove) naming task 1, the parked charge task
         assert bytes([0x08, 3, 0x10, 1]) in _pdata_of(sent[0])
@@ -588,7 +596,7 @@ class TestPowerSetpoints:
 
         await entity.async_set_native_value(300)
 
-        sent = coordinator.async_send_proto_set_command.call_args_list
+        sent = _sender(coordinator).call_args_list
         # operation 3 (remove) naming 2, the number reported, not the kind's 1
         assert bytes([0x08, 3, 0x10, 2]) in _pdata_of(sent[0])
 
@@ -631,7 +639,7 @@ class TestPowerSetpoints:
 
         await entity.async_set_native_value(300)
 
-        assert len(coordinator.async_send_proto_set_command.call_args_list) == 1
+        assert len(_sender(coordinator).call_args_list) == 1
 
     async def test_the_removed_task_stops_being_reported(
         self, hass: HomeAssistant, enhanced_config_entry: MockConfigEntry
@@ -677,10 +685,10 @@ class TestPowerSetpoints:
         entity = _number(coordinator, "scheduled_discharge_power_w")
 
         await entity.async_set_native_value(300)
-        coordinator.async_send_proto_set_command.reset_mock()
+        _sender(coordinator).reset_mock()
         await entity.async_set_native_value(400)
 
-        assert len(coordinator.async_send_proto_set_command.call_args_list) == 1
+        assert len(_sender(coordinator).call_args_list) == 1
 
     async def test_a_failed_removal_does_not_write_the_new_task(
         self, hass: HomeAssistant, enhanced_config_entry: MockConfigEntry
@@ -688,13 +696,13 @@ class TestPowerSetpoints:
         """Writing anyway would leave exactly the overlapping pair."""
         data = dict(REPORTED, scheduled_charge_power_w=600)
         coordinator = _coordinator(hass, enhanced_config_entry, data=data)
-        coordinator.async_send_proto_set_command.return_value = False
+        _sender(coordinator).return_value = False
         entity = _number(coordinator, "scheduled_discharge_power_w")
 
         with pytest.raises(HomeAssistantError):
             await entity.async_set_native_value(300)
 
-        assert len(coordinator.async_send_proto_set_command.call_args_list) == 1
+        assert len(_sender(coordinator).call_args_list) == 1
         # The task may well still be there, so it stays reported.
         assert coordinator.data["scheduled_charge_power_w"] == 600
 
@@ -711,7 +719,7 @@ class TestPowerSetpoints:
 
         await entity.async_set_native_value(300)
 
-        coordinator.async_send_proto_set_command.assert_called_once()
+        _sender(coordinator).assert_called_once()
         assert "custom mode" in caplog.text
 
     async def test_no_warning_in_custom_mode(
@@ -947,7 +955,7 @@ class TestGridOutputPower:
         with pytest.raises(HomeAssistantError):
             await entity.async_set_native_value(1000)
 
-        coordinator.async_send_proto_set_command.assert_not_called()
+        _sender(coordinator).assert_not_called()
 
     async def test_the_reported_ceiling_narrows_the_slider(
         self, hass: HomeAssistant, enhanced_config_entry: MockConfigEntry
@@ -1116,6 +1124,7 @@ class TestGridInputPower:
         assert entity.native_max_value >= max(recorded)
         # A range that admits them and a step that does not would still leave
         # the recorded values unreachable from the slider.
+        assert entity.native_step is not None
         assert all(value % entity.native_step == 0 for value in recorded)
 
     async def test_the_write_goes_out_under_the_device_config_lock(

--- a/tests/ha/test_stream_ac5000_entities.py
+++ b/tests/ha/test_stream_ac5000_entities.py
@@ -11,8 +11,10 @@ fill it is permanent for that owner.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock
 
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -103,6 +105,15 @@ def _entry(device: dict[str, Any]) -> MockConfigEntry:
     )
 
 
+def _collector(target: list[Any]) -> Callable[[Iterable[Any], bool], None]:
+    """Adapt a plain list to the `AddEntitiesCallback` signature."""
+
+    def _add(new_entities: Iterable[Any], update_before_add: bool = False) -> None:
+        target.extend(new_entities)
+
+    return _add
+
+
 async def _setup_keys(
     hass: HomeAssistant,
     platform_setup,
@@ -117,7 +128,7 @@ async def _setup_keys(
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {ES22_DEVICE["sn"]: coordinator}
 
     created: list[Any] = []
-    await platform_setup(hass, entry, created.extend)
+    await platform_setup(hass, entry, _collector(created))
     return {
         entity._definition.key for entity in created if hasattr(entity, "_definition")
     }
@@ -183,7 +194,7 @@ class TestStreamAC5000EntitySet:
         }
 
         created: list[Any] = []
-        await sensor_setup(hass, entry, created.extend)
+        await sensor_setup(hass, entry, _collector(created))
         solar = next(
             entity
             for entity in created
@@ -254,7 +265,7 @@ class TestStreamAC5000TaskReadback:
             ES22_DEVICE["sn"]: coordinator
         }
         created: list[Any] = []
-        await number_setup(hass, entry, created.extend)
+        await number_setup(hass, entry, _collector(created))
         number = next(
             entity
             for entity in created
@@ -319,7 +330,7 @@ class TestStreamAC5000Definitions:
     def test_a_zero_does_not_announce_an_accessory(self) -> None:
         """The gate itself, not just the flag that switches it on."""
 
-        class _Stub:
+        class _Stub(MagicMock):
             device_data = {"solar_w": 0.0, "grid_phase_a_active_power_w": 0.0}
             data: dict[str, Any] = {}
 
@@ -377,11 +388,11 @@ class TestStreamAC5000Definitions:
     def test_every_control_is_enhanced_only(self) -> None:
         """This device has no Developer API at all, so with developer keys a
         control would be created that can neither write nor read back."""
-        for definition in (
-            *STREAMAC5000_NUMBERS,
-            *STREAMAC5000_SWITCHES,
-            *STREAMAC5000_SELECTS,
-        ):
+        for definition in STREAMAC5000_NUMBERS:
+            assert definition.enhanced_only is True, definition.key
+        for definition in STREAMAC5000_SWITCHES:
+            assert definition.enhanced_only is True, definition.key
+        for definition in STREAMAC5000_SELECTS:
             assert definition.enhanced_only is True, definition.key
 
     def test_a_control_is_named_after_the_reading_it_writes(self) -> None:

--- a/tests/ha/test_stream_ac5000_entities.py
+++ b/tests/ha/test_stream_ac5000_entities.py
@@ -11,7 +11,6 @@ fill it is permanent for that owner.
 from __future__ import annotations
 
 import json
-from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -57,6 +56,8 @@ from custom_components.ecoflow_energy.sensor import (
     async_setup_entry as sensor_setup,
 )
 from custom_components.ecoflow_energy.switch import async_setup_entry as switch_setup
+
+from .conftest import add_entities_collector
 
 ES22_DEVICE: dict[str, Any] = {
     "sn": "ES22TEST00000001",
@@ -105,15 +106,6 @@ def _entry(device: dict[str, Any]) -> MockConfigEntry:
     )
 
 
-def _collector(target: list[Any]) -> Callable[[Iterable[Any], bool], None]:
-    """Adapt a plain list to the `AddEntitiesCallback` signature."""
-
-    def _add(new_entities: Iterable[Any], update_before_add: bool = False) -> None:
-        target.extend(new_entities)
-
-    return _add
-
-
 async def _setup_keys(
     hass: HomeAssistant,
     platform_setup,
@@ -128,7 +120,7 @@ async def _setup_keys(
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {ES22_DEVICE["sn"]: coordinator}
 
     created: list[Any] = []
-    await platform_setup(hass, entry, _collector(created))
+    await platform_setup(hass, entry, add_entities_collector(created))
     return {
         entity._definition.key for entity in created if hasattr(entity, "_definition")
     }
@@ -194,7 +186,7 @@ class TestStreamAC5000EntitySet:
         }
 
         created: list[Any] = []
-        await sensor_setup(hass, entry, _collector(created))
+        await sensor_setup(hass, entry, add_entities_collector(created))
         solar = next(
             entity
             for entity in created
@@ -265,7 +257,7 @@ class TestStreamAC5000TaskReadback:
             ES22_DEVICE["sn"]: coordinator
         }
         created: list[Any] = []
-        await number_setup(hass, entry, _collector(created))
+        await number_setup(hass, entry, add_entities_collector(created))
         number = next(
             entity
             for entity in created
@@ -388,12 +380,12 @@ class TestStreamAC5000Definitions:
     def test_every_control_is_enhanced_only(self) -> None:
         """This device has no Developer API at all, so with developer keys a
         control would be created that can neither write nor read back."""
-        for definition in STREAMAC5000_NUMBERS:
-            assert definition.enhanced_only is True, definition.key
-        for definition in STREAMAC5000_SWITCHES:
-            assert definition.enhanced_only is True, definition.key
-        for definition in STREAMAC5000_SELECTS:
-            assert definition.enhanced_only is True, definition.key
+        for number_def in STREAMAC5000_NUMBERS:
+            assert number_def.enhanced_only is True, number_def.key
+        for switch_def in STREAMAC5000_SWITCHES:
+            assert switch_def.enhanced_only is True, switch_def.key
+        for select_def in STREAMAC5000_SELECTS:
+            assert select_def.enhanced_only is True, select_def.key
 
     def test_a_control_is_named_after_the_reading_it_writes(self) -> None:
         """One value, one wording.

--- a/tests/ha/test_stream_number.py
+++ b/tests/ha/test_stream_number.py
@@ -54,7 +54,7 @@ from custom_components.ecoflow_energy.number import (
     async_setup_entry as number_setup,
 )
 
-from .conftest import MOCK_STREAM_DEVICE
+from .conftest import MOCK_STREAM_DEVICE, add_entities_collector
 from .test_stream_ac5000_entities import ES22_DEVICE
 
 BK31_DEVICE: dict[str, Any] = {
@@ -167,7 +167,7 @@ class TestStreamNumberPlatformSetup:
             BK31_DEVICE["sn"]: coordinator
         }
         created: list[Any] = []
-        await number_setup(hass, entry, created.extend)
+        await number_setup(hass, entry, add_entities_collector(created))
         return {
             entity._definition.key
             for entity in created
@@ -406,6 +406,7 @@ class TestStreamSocLimitSet:
             decode_header_message,
         )
 
+        assert isinstance(coordinator.async_send_proto_set_command, AsyncMock)
         payload = coordinator.async_send_proto_set_command.call_args.args[0]
         headers, _ = decode_header_message(payload)
         return headers[0], bytes.fromhex(headers[0]["pdata"])
@@ -484,6 +485,7 @@ class TestStreamSocLimitSet:
             await entity.async_set_native_value(90)
 
         assert err.value.translation_key == "set_command_not_ready"
+        assert isinstance(coordinator.async_send_proto_set_command, AsyncMock)
         coordinator.async_send_proto_set_command.assert_not_called()
 
     async def test_rejects_limits_that_cross(
@@ -499,6 +501,7 @@ class TestStreamSocLimitSet:
             await entity.async_set_native_value(19)
 
         assert err.value.translation_key == "set_value_rejected"
+        assert isinstance(coordinator.async_send_proto_set_command, AsyncMock)
         coordinator.async_send_proto_set_command.assert_not_called()
 
     async def test_concurrent_limits_preserve_both_changes(
@@ -607,6 +610,7 @@ class TestBackupReserveFloorFollowsTheDischargeLimit:
             {"min_discharge_soc_pct": 20, "backup_reserve_pct": 23},
         )
         entity._handle_coordinator_update()
+        assert isinstance(entity.async_write_ha_state, MagicMock)
         entity.async_write_ha_state.reset_mock()
 
         coordinator.async_set_updated_data(
@@ -628,6 +632,7 @@ class TestBackupReserveFloorFollowsTheDischargeLimit:
             {"min_discharge_soc_pct": 20, "backup_reserve_pct": 23},
         )
         entity._handle_coordinator_update()
+        assert isinstance(entity.async_write_ha_state, MagicMock)
         entity.async_write_ha_state.reset_mock()
 
         coordinator.async_set_updated_data(dict(coordinator._device_data))

--- a/tests/ha/test_stream_pv_string_gating.py
+++ b/tests/ha/test_stream_pv_string_gating.py
@@ -35,6 +35,8 @@ from custom_components.ecoflow_energy.const import (
 from custom_components.ecoflow_energy.coordinator import EcoFlowDeviceCoordinator
 from custom_components.ecoflow_energy.sensor import async_setup_entry as sensor_setup
 
+from .conftest import add_entities_collector
+
 # Stream Ultra X, the four-string unit the report comes from.
 STREAM_DEVICE: dict[str, Any] = {
     "sn": "BK61TEST00000001",
@@ -94,7 +96,7 @@ async def _setup(
     }
 
     created: list[Any] = []
-    await sensor_setup(hass, entry, created.extend)
+    await sensor_setup(hass, entry, add_entities_collector(created))
     return coordinator, created
 
 

--- a/tests/ha/test_wave3_controls.py
+++ b/tests/ha/test_wave3_controls.py
@@ -159,6 +159,7 @@ class TestWave3SendSet:
         coordinator = _coordinator(hass)
         full = coordinator._parse_message(TOPIC, _frame(FULL_DISPLAY_INDEX))
         with patch(_CLOCK, return_value=1000.0):
+            assert full is not None
             coordinator._apply_data(full)
 
         mode_switch = coordinator._parse_message(TOPIC, _mode_change_frame(486, 1))
@@ -185,6 +186,7 @@ class TestWave3SendSet:
     ) -> None:
         coordinator = _coordinator(hass)
         full = coordinator._parse_message(TOPIC, _frame(FULL_DISPLAY_INDEX))
+        assert full is not None
         with patch(_CLOCK, return_value=1000.0):
             coordinator._apply_data(full)
         assert coordinator.data["operating_mode"] == "fan"

--- a/tests/ha/test_wave3_entities.py
+++ b/tests/ha/test_wave3_entities.py
@@ -306,6 +306,7 @@ class TestWave3Controls:
             await entity.async_set_native_value(22.0)
 
         assert excinfo.value.translation_key == "set_value_rejected"
+        assert excinfo.value.translation_placeholders is not None
         assert (
             excinfo.value.translation_placeholders["reason"]
             == "no setpoint in fan mode"

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -400,11 +400,13 @@ def _extract_sensor_keys(var_name: str) -> list[str]:
             value = node.value
 
         if target_name == var_name and isinstance(value, ast.List):
-            keys = []
+            keys: list[str] = []
             for elt in value.elts:
                 if isinstance(elt, ast.Call) and elt.args:
                     first_arg = elt.args[0]
-                    if isinstance(first_arg, ast.Constant):
+                    if isinstance(first_arg, ast.Constant) and isinstance(
+                        first_arg.value, str
+                    ):
                         keys.append(first_arg.value)
             return keys
     return []

--- a/tests/test_delta3_commands.py
+++ b/tests/test_delta3_commands.py
@@ -88,6 +88,7 @@ class TestEnvelope:
         all use `dirSrc`. Pinned so nobody "fixes" it back.
         """
         cmd = build_switch_command("ac_out_switch", True)
+        assert cmd is not None
         assert "dirSrc" in cmd
         assert "dirSoc" not in cmd
 
@@ -107,18 +108,28 @@ class TestSwitchCommands:
     def test_flat_switches_map_to_the_documented_param(
         self, key: str, params_key: str
     ) -> None:
-        assert build_switch_command(key, True)["params"] == {params_key: True}
-        assert build_switch_command(key, False)["params"] == {params_key: False}
+        cmd_on = build_switch_command(key, True)
+        cmd_off = build_switch_command(key, False)
+        assert cmd_on is not None
+        assert cmd_off is not None
+        assert cmd_on["params"] == {params_key: True}
+        assert cmd_off["params"] == {params_key: False}
 
     def test_energy_backup_is_nested(self) -> None:
         """cfgEnergyBackup is the only control with a nested payload."""
         cmd = build_switch_command("energy_backup_switch", True)
+        assert cmd is not None
         assert cmd["params"] == {"cfgEnergyBackup": {"energyBackupEn": True}}
 
     def test_values_are_real_booleans(self) -> None:
         """The contract types these as bool, not 0/1."""
-        params = build_switch_command("ac_out_switch", 1)["params"]
-        assert params["cfgAcOutOpen"] is True
+        # Deliberate: the contract types this argument bool. Passing 1 is the
+        # point of the test - it proves a truthy int still coerces to True
+        # instead of being rejected or stored verbatim. Do not "fix" this to
+        # True, that would delete the coercion check while leaving it green.
+        cmd = build_switch_command("ac_out_switch", 1)  # type: ignore[arg-type]
+        assert cmd is not None
+        assert cmd["params"]["cfgAcOutOpen"] is True
 
     def test_unknown_key_returns_none(self) -> None:
         assert build_switch_command("no_such_switch", True) is None
@@ -136,7 +147,9 @@ class TestNumberCommands:
     def test_in_range_values_pass_through(
         self, key: str, params_key: str, value: int
     ) -> None:
-        assert build_number_command(key, value)["params"] == {params_key: value}
+        cmd = build_number_command(key, value)
+        assert cmd is not None
+        assert cmd["params"] == {params_key: value}
 
     @pytest.mark.parametrize(
         ("key", "params_key", "low", "high"),
@@ -149,22 +162,29 @@ class TestNumberCommands:
     def test_values_are_clamped_to_the_vendor_range(
         self, key: str, params_key: str, low: int, high: int
     ) -> None:
-        assert build_number_command(key, low - 10)["params"][params_key] == low
-        assert build_number_command(key, high + 10)["params"][params_key] == high
-        assert build_number_command(key, low)["params"][params_key] == low
-        assert build_number_command(key, high)["params"][params_key] == high
+        below_range = build_number_command(key, low - 10)
+        above_range = build_number_command(key, high + 10)
+        at_low = build_number_command(key, low)
+        at_high = build_number_command(key, high)
+        assert below_range is not None
+        assert above_range is not None
+        assert at_low is not None
+        assert at_high is not None
+        assert below_range["params"][params_key] == low
+        assert above_range["params"][params_key] == high
+        assert at_low["params"][params_key] == low
+        assert at_high["params"][params_key] == high
 
     def test_backup_reserve_tops_out_at_fifty_not_hundred(self) -> None:
         """Easy to get wrong: this is a ratio, not a SoC target."""
-        assert (
-            build_number_command("backup_reserve_soc", 100)["params"][
-                "cfgBackupReverseSoc"
-            ]
-            == 50
-        )
+        cmd = build_number_command("backup_reserve_soc", 100)
+        assert cmd is not None
+        assert cmd["params"]["cfgBackupReverseSoc"] == 50
 
     def test_float_input_is_rounded_to_int(self) -> None:
-        params = build_number_command("max_charge_soc", 79.6)["params"]
+        cmd = build_number_command("max_charge_soc", 79.6)
+        assert cmd is not None
+        params = cmd["params"]
         assert params["cfgMaxChgSoc"] == 80
         assert isinstance(params["cfgMaxChgSoc"], int)
 
@@ -201,14 +221,17 @@ class TestProtoCommands:
         ],
     )
     def test_switch_payload_bytes(self, key: str, expected_pdata: str) -> None:
-        frame = build_proto_command(build_switch_command(key, True), self.SN)
+        cmd = build_switch_command(key, True)
+        assert cmd is not None
+        frame = build_proto_command(cmd, self.SN)
         assert frame is not None
         assert self._pdata(frame) == expected_pdata
 
     def test_switch_off_writes_zero(self) -> None:
-        frame = build_proto_command(
-            build_switch_command("beeper_switch", False), self.SN
-        )
+        cmd = build_switch_command("beeper_switch", False)
+        assert cmd is not None
+        frame = build_proto_command(cmd, self.SN)
+        assert frame is not None
         assert self._pdata(frame) == "4800"
 
     @pytest.mark.parametrize(
@@ -222,25 +245,30 @@ class TestProtoCommands:
     def test_number_payload_bytes(
         self, key: str, value: int, expected_pdata: str
     ) -> None:
-        frame = build_proto_command(build_number_command(key, value), self.SN)
+        cmd = build_number_command(key, value)
+        assert cmd is not None
+        frame = build_proto_command(cmd, self.SN)
         assert frame is not None
         assert self._pdata(frame) == expected_pdata
 
     def test_number_values_stay_inside_the_vendor_range(self) -> None:
         """The clamp is shared with the HTTP path, so it applies here too."""
-        frame = build_proto_command(
-            build_number_command("max_charge_soc", 200), self.SN
-        )
+        cmd = build_number_command("max_charge_soc", 200)
+        assert cmd is not None
+        frame = build_proto_command(cmd, self.SN)
+        assert frame is not None
         assert self._pdata(frame) == "880264"  # clamped to 100
-        frame = build_proto_command(
-            build_number_command("backup_reserve_soc", 99), self.SN
-        )
+        cmd = build_number_command("backup_reserve_soc", 99)
+        assert cmd is not None
+        frame = build_proto_command(cmd, self.SN)
+        assert frame is not None
         assert self._pdata(frame) == "b00632"  # clamped to 50
 
     def test_frame_carries_the_hardware_verified_header(self) -> None:
-        frame = build_proto_command(
-            build_switch_command("beeper_switch", True), self.SN
-        )
+        cmd = build_switch_command("beeper_switch", True)
+        assert cmd is not None
+        frame = build_proto_command(cmd, self.SN)
+        assert frame is not None
         headers, _ = decode_header_message(frame)
         header = headers[0]
         assert header["src"] == 32
@@ -263,9 +291,13 @@ class TestProtoCommands:
     def test_every_control_has_a_binary_counterpart(self) -> None:
         """One table drives both wires, so neither can lose a control."""
         for key in DELTA3_SWITCH_PARAMS:
-            assert build_proto_command(build_switch_command(key, True), self.SN)
+            switch_cmd = build_switch_command(key, True)
+            assert switch_cmd is not None
+            assert build_proto_command(switch_cmd, self.SN)
         for key in DELTA3_NUMBER_PARAMS:
-            assert build_proto_command(build_number_command(key, 10), self.SN)
+            number_cmd = build_number_command(key, 10)
+            assert number_cmd is not None
+            assert build_proto_command(number_cmd, self.SN)
 
     def test_unknown_parameter_returns_none(self) -> None:
         command = {"cmdId": 17, "params": {"cfgSomethingElse": 1}}
@@ -291,6 +323,7 @@ class TestAcCharging:
 
     def test_power_always_carries_the_mode(self) -> None:
         command = build_number_command("ac_charge_power_limit", 1200)
+        assert command is not None
         assert command["params"] == {
             "cfgPlugInInfoAcInChgPowMax": 1200,
             "cfgAcInChgMode": 0,
@@ -305,6 +338,7 @@ class TestAcCharging:
         self, requested: int, expected: int
     ) -> None:
         command = build_number_command("ac_charge_power_limit", requested)
+        assert command is not None
         assert command["params"]["cfgPlugInInfoAcInChgPowMax"] == expected
 
     def test_mode_field_number(self) -> None:
@@ -312,9 +346,9 @@ class TestAcCharging:
 
     def test_both_fields_reach_one_binary_frame(self) -> None:
         """The pair must survive into the frame, not just into the params."""
-        frame = build_proto_command(
-            build_number_command("ac_charge_power_limit", 800), self.SN
-        )
+        cmd = build_number_command("ac_charge_power_limit", 800)
+        assert cmd is not None
+        frame = build_proto_command(cmd, self.SN)
         assert frame is not None
         headers, _ = decode_header_message(frame)
         pdata = bytes.fromhex(headers[0]["pdata"])
@@ -323,9 +357,10 @@ class TestAcCharging:
 
     def test_fields_are_in_ascending_order(self) -> None:
         """Matching the app's own serialisation removes one variable."""
-        frame = build_proto_command(
-            build_number_command("ac_charge_power_limit", 1200), self.SN
-        )
+        cmd = build_number_command("ac_charge_power_limit", 1200)
+        assert cmd is not None
+        frame = build_proto_command(cmd, self.SN)
+        assert frame is not None
         headers, _ = decode_header_message(frame)
         pdata = bytes.fromhex(headers[0]["pdata"])
         assert pdata.index(b"\xb0\x03") < pdata.index(b"\xe8\x07")

--- a/tests/test_delta3_port_priority.py
+++ b/tests/test_delta3_port_priority.py
@@ -17,6 +17,8 @@ from custom_components.ecoflow_energy.const import (
     DELTA3_NUMBERS,
     DELTA3_SWITCHES,
     DEVICE_TYPE_DELTA3,
+    EcoFlowNumberDef,
+    EcoFlowSwitchDef,
     excluded_keys_for_serial,
     filter_defs_for_serial,
 )
@@ -190,7 +192,9 @@ class TestWriter:
 
     def test_frame_carries_field_376_as_a_submessage(self) -> None:
         command = build_port_priority_command("ac2", True, 40)
+        assert command is not None
         frame = build_proto_command(command, "D3M1TESTSERIAL01", seq=1234)
+        assert frame is not None
         headers, _ = decode_header_message(frame)
         header = headers[0]
         pdata = bytes.fromhex(header["pdata"])
@@ -204,7 +208,9 @@ class TestWriter:
     def test_frame_round_trips_through_the_read_back_message(self) -> None:
         """What we write must decode as what the device sends us."""
         command = build_port_priority_command("dc", False, 35)
+        assert command is not None
         frame = build_proto_command(command, "D3M1TESTSERIAL01", seq=7)
+        assert frame is not None
         pdata = bytes.fromhex(decode_header_message(frame)[0][0]["pdata"])
 
         # Strip the field 376 header (tag + length) and parse the payload.
@@ -222,6 +228,7 @@ class TestWriter:
     def test_port_enum_follows_the_app(self, stem: str, port_type: int) -> None:
         command = build_port_priority_command(stem, True, 40)
 
+        assert command is not None
         assert command["params"]["cfgPowerOutagesList"]["portType"] == port_type
 
     def test_unknown_port_returns_none(self) -> None:
@@ -311,11 +318,11 @@ class TestEntityReach:
     """These values travel on the push path only."""
 
     def test_every_port_priority_control_is_enhanced_only(self) -> None:
-        controls = [
-            d
-            for d in (*DELTA3_SWITCHES, *DELTA3_NUMBERS)
-            if d.key.startswith("port_priority_")
+        every: list[EcoFlowNumberDef | EcoFlowSwitchDef] = [
+            *DELTA3_SWITCHES,
+            *DELTA3_NUMBERS,
         ]
+        controls = [d for d in every if d.key.startswith("port_priority_")]
 
         assert len(controls) == 6
         assert all(d.enhanced_only for d in controls)

--- a/tests/test_entity_translations.py
+++ b/tests/test_entity_translations.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
+from typing import Any
 
 import pytest
 from ecoflow_energy import const as C
@@ -31,9 +32,9 @@ LANGS = ("en", "de")
 DIAGNOSTIC_SENSOR_KEYS = {"mqtt_status", "connection_mode"}
 
 
-def _collect(pattern: str) -> dict[str, object]:
+def _collect(pattern: str) -> dict[str, Any]:
     """Collect entity definitions from all const.py lists matching a pattern."""
-    defs: dict[str, object] = {}
+    defs: dict[str, Any] = {}
     for name in dir(C):
         if re.fullmatch(pattern, name) and isinstance(getattr(C, name), list):
             for item in getattr(C, name):

--- a/tests/test_smart_meter_parser.py
+++ b/tests/test_smart_meter_parser.py
@@ -226,7 +226,11 @@ _FULL = {
     },
 }
 
-_EXPECTED = {**_INCREMENTAL, **_WITH_ENERGY_RECORD, **_FULL}
+_EXPECTED: dict[int, dict[str, Any]] = {
+    **_INCREMENTAL,
+    **_WITH_ENERGY_RECORD,
+    **_FULL,
+}
 
 # Upload periods only, nothing readable.
 _RUNTIME_ONLY = (3, 7, 12)

--- a/tests/test_stream_5000.py
+++ b/tests/test_stream_5000.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 from ecoflow_energy.const import (
@@ -48,9 +49,9 @@ def _frames() -> list[dict]:
     return json.loads(ES21_FRAMES.read_text(encoding="utf-8"))["frames"]
 
 
-def _parse_all() -> dict[str, object]:
+def _parse_all() -> dict[str, Any]:
     """Replay every captured frame the way the coordinator would."""
-    state: dict[str, object] = {}
+    state: dict[str, Any] = {}
     for frame in _frames():
         parsed = parse_stream_ac5000_message(bytes.fromhex(frame["hex"]))
         if parsed:

--- a/tests/test_stream_ac5000_commands.py
+++ b/tests/test_stream_ac5000_commands.py
@@ -111,6 +111,7 @@ def _walk(buf: bytes):
     while offset < len(buf):
         key, offset = _varint(buf, offset)
         number, wire = key >> 3, key & 7
+        value: int | bytes
         if wire == 0:
             value, offset = _varint(buf, offset)
         elif wire == 2:

--- a/tests/test_stream_ac5000_parser.py
+++ b/tests/test_stream_ac5000_parser.py
@@ -873,8 +873,10 @@ class TestCaptureReplay:
             home = parsed.get("home_w")
             from_batt = parsed.get("home_from_batt_w")
             from_grid = parsed.get("home_from_grid_w")
-            if not all(
-                isinstance(v, (int, float)) for v in (home, from_batt, from_grid)
+            if not (
+                isinstance(home, (int, float))
+                and isinstance(from_batt, (int, float))
+                and isinstance(from_grid, (int, float))
             ):
                 continue
             total = from_batt + from_grid + (parsed.get("home_from_solar_w") or 0.0)


### PR DESCRIPTION
53,620 lines of tests that had never been type-checked now are, and the Types job covers them.

## What the checker found

Pointed at the suite it reported **308** findings. Nineteen of those were in the integration rather than in the tests: the same files, already clean when the checker is pointed at the integration directly.

That was the first thing fixed, because a gate whose verdict depends on where it was aimed is not a gate. The module path differs by entry point (the checker computes one name walking down from the integration and another when a test reaches the same file through its own import), and a per-module rule naming only one of them is silently inactive for the other. Both names are listed now, and each rule was proved to be doing something by removing it and watching the count come back: 49 for one, 37 for the other.

## What was fixed, and why it is worth it

**The one shape that dominated (21):** a platform's setup handed a bare list-extend where Home Assistant declares a callback taking an optional second argument. It works at runtime and does not match the signature, and five separate files had each written their own adapter for it. There is one now, in the shared fixtures, and the five copies are gone.

**The next shape (roughly 130):** a helper or a registry lookup returns a value or nothing, and the test used it as though it always returned a value. Each now carries the assertion it should have had. This is the part that pays for itself: a regression that empties one of those lookups used to surface as a complaint about `NoneType`, and now the test says which expectation broke.

**A wrinkle worth knowing** for anyone doing this elsewhere: where the object is a stand-in installed by a shared helper, narrowing away nothing is not enough. What is left is the real bound method, which has none of the recording the test then asks it about. Those assert the stand-in's own type instead, a stronger statement than the one it replaces, and the one the test actually set up.

**Three annotations said `object`** where the code produces real numbers and dictionaries, so arithmetic and attribute access on them could not be checked at all. Correcting those closed nine findings on their own.

## What is deliberately suppressed

Five lines, each with the reason on it, and nothing else anywhere:

- `method-assign` for the suite, in `pyproject.toml`. A test that swaps a method for a stand-in is doing the thing it exists to do.
- Four `type: ignore` in tests whose subject *is* the wrong type: a helper that must coerce a truthy number to a real boolean, a diagnostics test feeding a malformed state file, an entity test passing nothing to a coordinator. Correcting any of those would leave the test green and checking nothing.

## One bug the checker could not have caught

A helper added during the work was written as a coroutine and called without awaiting, so the platform under test received a coroutine where it expected a function and eight tests failed from inside the integration. The checker was satisfied either way; only running the suite found it. Fixed, and worth naming because it is the exact failure this kind of pass invites.

## The Types job runs the checker twice

Not once over both paths. The suite imports the integration under two module names, with and without the directory prefix, and the checker refuses a single run in which one file is reachable under two names. Each entry point is its own step.

## Numbers

- `mypy tests/`: 308 findings, then no issues in 84 source files
- `mypy custom_components/ecoflow_energy`: no issues in 62 source files, unchanged throughout
- `ruff check` and `ruff format --check` clean over both trees
- 3306 tests pass, 1 skipped, unchanged throughout

Ref PLAN-128
