### PR TITLE
style: gate the formatter, and reformat the three files that drifted

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,12 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Run ruff
         run: ruff check custom_components/ tests/
+      # The formatter is a gate too. Without this step the reflow that made the
+      # tree consistent decays on the first pull request that does not run it,
+      # which happened within hours of that pass landing: three files arrived
+      # unformatted and nothing said so.
+      - name: Check formatting
+        run: ruff format --check custom_components/ tests/
 
   Types:
     name: Types

--- a/custom_components/ecoflow_energy/ecoflow/frame_capture.py
+++ b/custom_components/ecoflow_energy/ecoflow/frame_capture.py
@@ -413,14 +413,14 @@ def sanitize_frame(payload: bytes, secrets: list[str]) -> bytes:
     for region in _encrypted_regions(payload):
         if region.key is None:
             continue
-        inner = _xor(payload[region.start:region.end], region.key)
+        inner = _xor(payload[region.start : region.end], region.key)
         cleaned = _plain_passes(inner, secrets)
         if cleaned == inner:
             continue
         sanitized = (
-            sanitized[:region.start]
+            sanitized[: region.start]
             + _xor(cleaned, region.key)
-            + sanitized[region.end:]
+            + sanitized[region.end :]
         )
     return sanitized
 

--- a/tests/test_fixture_identifiers.py
+++ b/tests/test_fixture_identifiers.py
@@ -133,9 +133,7 @@ def test_no_identifier_survived_masking(path: Path) -> None:
             assert not _UUID.search(region_text), (
                 f"{where}: unmasked UUID under the mask"
             )
-            assert not _MAC.search(region_text), (
-                f"{where}: unmasked MAC under the mask"
-            )
+            assert not _MAC.search(region_text), f"{where}: unmasked MAC under the mask"
             for run in _RUN.findall(region_text):
                 if run in _PLACEHOLDERS:
                     continue

--- a/tests/test_frame_capture.py
+++ b/tests/test_frame_capture.py
@@ -709,9 +709,7 @@ class TestEncryptedRegionMasking:
 
     def test_each_header_uses_its_own_seq(self) -> None:
         """A frame-wide key would mask at most one of these two headers."""
-        header_a = _enc_header(
-            254, 39, pdata_plain=b"HJ31TESTMASK0001", seq=self._KEY
-        )
+        header_a = _enc_header(254, 39, pdata_plain=b"HJ31TESTMASK0001", seq=self._KEY)
         header_b = _enc_header(
             254, 40, pdata_plain=b"HJ31TESTMASK0002", seq=self._KEY + 1
         )


### PR DESCRIPTION
A gap in the gate that closed itself the same day it was opened.

The Lint job ran the linter and never the formatter. So the reflow that made the tree consistent was held in place by nothing at all, and it decayed within hours: the pull request that landed between that pass and this one brought three files in unformatted, the check stayed green, and the only reason anyone noticed is that the formatter was run by hand afterwards.

```
custom_components/ecoflow_energy/ecoflow/frame_capture.py
tests/test_fixture_identifiers.py
tests/test_frame_capture.py
```

The job now runs `ruff format --check` as its own step, and those three are reformatted. The formatter touched only whitespace; nothing else in this change.

Worth stating for the record, because it is the same shape as the finding that started this whole line of work: a check that runs but gates nothing is not a gate. That was true of the linter and the type checker before they were added to the branch ruleset, and it was true of the formatter until this.

## Numbers

- `ruff check` clean over both trees
- `ruff format --check`: 146 files already formatted, from 143
- The type checker reports no issues in 62 source files and none in 84 test files
- 3331 tests pass, 1 skipped

Ref PLAN-127
