### PR TITLE
refactor: annotate the last six functions, and require it from here on

### DIFF
--- a/custom_components/ecoflow_energy/__init__.py
+++ b/custom_components/ecoflow_energy/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import re
 import time
+from datetime import datetime
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
@@ -99,7 +100,7 @@ def _async_schedule_raw_capture_expiry(hass: HomeAssistant, entry: ConfigEntry) 
     # is reported as unsafe and the window never actually closes. It went
     # unnoticed because no test had ever let the timer fire.
     @callback
-    def _expire(_now) -> None:
+    def _expire(_now: datetime) -> None:
         _LOGGER.info("The raw data capture window has ended - switching it off.")
         _async_disable_raw_capture(hass, entry)
 

--- a/custom_components/ecoflow_energy/ecoflow/cloud_mqtt.py
+++ b/custom_components/ecoflow_energy/ecoflow/cloud_mqtt.py
@@ -336,7 +336,14 @@ class EcoFlowMQTTClient:
             self._log_issue("error", "MQTT: client creation failed: %s", exc)
             return False
 
-    def _on_connect(self, client, userdata, flags, rc, properties=None):
+    def _on_connect(
+        self,
+        client: mqtt.Client,
+        userdata: Any,
+        flags: Any,
+        rc: Any,
+        properties: Any = None,
+    ) -> None:
         """Callback on MQTT connection.
 
         Under paho-mqtt 2.x VERSION2 callbacks ``rc`` is a ReasonCode object
@@ -489,8 +496,13 @@ class EcoFlowMQTTClient:
                 self.status_handler("connect_failed", rc_val, reason)
 
     def _on_disconnect(
-        self, client, userdata, disconnect_flags, reason_code, properties
-    ):
+        self,
+        client: mqtt.Client,
+        userdata: Any,
+        disconnect_flags: Any,
+        reason_code: Any,
+        properties: Any,
+    ) -> None:
         """Callback on MQTT disconnect.
 
         ``reason_code`` is a ReasonCode object under paho-mqtt 2.x VERSION2
@@ -565,7 +577,7 @@ class EcoFlowMQTTClient:
             self.max_reconnect_delay,
         )
 
-    def _schedule_reconnect(self):
+    def _schedule_reconnect(self) -> None:
         """Signal that a reconnect is needed."""
         _LOGGER.debug(
             "MQTT: reconnect scheduled - attempts: %d/%d",
@@ -613,7 +625,9 @@ class EcoFlowMQTTClient:
                     return True
         return False
 
-    def _on_message(self, client, userdata, msg):
+    def _on_message(
+        self, client: mqtt.Client, userdata: Any, msg: mqtt.MQTTMessage
+    ) -> None:
         """Callback for incoming MQTT messages."""
         if (
             msg.topic == f"/app/device/property/{self._device_sn}"

--- a/custom_components/ecoflow_energy/ecoflow/proto/decoder.py
+++ b/custom_components/ecoflow_energy/ecoflow/proto/decoder.py
@@ -37,7 +37,7 @@ _HEADER_FIELDS = {
 }
 
 
-def _read_varint(mv, i):
+def _read_varint(mv: memoryview | bytes, i: int) -> tuple[int | None, int]:
     """Read a variable-length integer from protobuf wire format at position i.
 
     Returns ``(None, len(mv))`` on truncated or oversized (>64-bit) input so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,12 @@ ignore = []
 
 [tool.mypy]
 python_version = "3.13"
+# A function without annotations is not checked leniently, it is not checked at
+# all: the checker walks past it and says nothing. With this on, writing one is
+# itself the finding. The integration reached it with six functions to fix, so
+# it is on here and deliberately not on for the suite, where a thousand test
+# methods still carry no return annotation.
+disallow_untyped_defs = true
 ignore_missing_imports = true
 exclude = "ecocharge_pb2\\.py$"
 
@@ -44,3 +50,8 @@ disable_error_code = ["empty-body"]
 [[tool.mypy.overrides]]
 module = ["tests.*", "conftest"]
 disable_error_code = ["method-assign"]
+# The suite still has about a thousand test methods with no return annotation.
+# Requiring them is its own piece of work and its own decision; until then the
+# rule holds for the integration, where it costs nothing, and not here, where
+# it would mean a thousand edits nobody has asked for.
+disallow_untyped_defs = false


### PR DESCRIPTION
The answer to "what is left after the type checker is clean", measured rather than guessed.

A function with no annotations is not checked leniently. It is not checked at all: the checker walks past it and reports nothing, so the gate has been silently blind to whatever those functions do. `disallow_untyped_defs` makes writing one a finding in its own right.

Counted across the tree:

| | Functions | Without a full annotation |
|---|---:|---:|
| Integration | 623 | **6** |
| Tests | 3315 | 1068 |

So the integration was already there, six functions short, and this closes them:

- Four are the callbacks the MQTT library calls. Their parameters are that library's shape, not ours, so they are annotated as what the library passes rather than invented.
- One is a timer callback Home Assistant hands a timestamp.
- One is the varint reader, which returns nothing on a truncated or oversized frame. That was said in the docstring and is now in the signature, where a caller can see it.

## Both directions were run before the setting was trusted

- With it **off**, removing one of the six annotations again is reported nowhere. That is exactly the state this change ends, and the reason the six were invisible until they were counted by hand.
- With it **on**, the same removal is named at its line: `Function is missing a type annotation [no-untyped-def]`.

A rule that silences or requires something has to be shown doing it; this repo has been bitten by ones that did neither.

## Deliberately not on for the suite

About a thousand test methods still carry no return annotation. Requiring them is its own piece of work and its own decision, and switching it on here would mean a thousand edits nobody has asked for. The override says so in place.

## Numbers

- The type checker reports no issues in 62 source files and none in 84 test files
- `ruff check` clean, `ruff format --check` reports all 146 files formatted
- 3331 tests pass, 1 skipped

Ref PLAN-128
