### PR TITLE
test: check the bodies the type checker was skipping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,15 @@ disable_error_code = ["empty-body"]
 [[tool.mypy.overrides]]
 module = ["tests.*", "conftest"]
 disable_error_code = ["method-assign"]
-# The suite still has about a thousand test methods with no return annotation.
-# Requiring them is its own piece of work and its own decision; until then the
-# rule holds for the integration, where it costs nothing, and not here, where
-# it would mean a thousand edits nobody has asked for.
+# The suite still has about a thousand test methods with no return annotation,
+# and requiring them buys almost nothing: what a signature on a test method
+# would say is `-> None`, and nobody reads it.
+#
+# What does matter is the line below. Without it the checker skips the *body*
+# of every unannotated function, so a third of this suite was never looked at
+# and "no issues found" meant "none in the two thirds I read". Measured
+# 2026-09-08: turning it on surfaced ten findings in that invisible third, all
+# of shapes already fixed elsewhere. Coverage comes from here, not from the
+# annotations.
 disallow_untyped_defs = false
+check_untyped_defs = true

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -20,9 +20,11 @@ class TestDecodeVersion:
         assert decode_version(0) == ""
         assert decode_version(-1) == ""
         assert decode_version(0x1_0000_0000) == ""
-        assert decode_version("1.2.3") == ""
-        assert decode_version(None) == ""
-        assert decode_version(1.5) == ""
+        # The wrong types are the subject: the helper has to refuse a string,
+        # nothing at all and a float rather than decode them.
+        assert decode_version("1.2.3") == ""  # type: ignore[arg-type]
+        assert decode_version(None) == ""  # type: ignore[arg-type]
+        assert decode_version(1.5) == ""  # type: ignore[arg-type]
 
     def test_rejects_bool(self):
         # bool is an int subclass; True would otherwise decode to v0.0.0.1.

--- a/tests/test_powerocean_parser.py
+++ b/tests/test_powerocean_parser.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 from ecoflow_energy.ecoflow.parsers.powerocean import (
@@ -1034,19 +1035,19 @@ class TestMultiBatteryPack:
 
     def test_aggregate_bp_skips_phantom(self):
         """_extract_battery_pack picks first real pack, not phantom."""
-        data = {
+        data: dict[str, Any] = {
             "bp_addr.PHANTOM": {},
             "bp_addr.REAL": {"bpSoh": 98, "bpCycles": 42},
         }
-        result = {}
+        result: dict[str, Any] = {}
         _extract_battery_pack(data, result)
         assert result["bp_soh_pct"] == 98.0
         assert result["bp_cycles"] == 42.0
 
     def test_aggregate_bp_phantom_only(self):
         """Only phantom packs - no aggregate sensors produced."""
-        data = {"bp_addr.PHANTOM": {}}
-        result = {}
+        data: dict[str, Any] = {"bp_addr.PHANTOM": {}}
+        result: dict[str, Any] = {}
         _extract_battery_pack(data, result)
         assert "bp_soh_pct" not in result
 

--- a/tests/test_powerocean_timer_task_write.py
+++ b/tests/test_powerocean_timer_task_write.py
@@ -207,7 +207,8 @@ def test_power_change_refuses_to_invent_an_echoed_field(dropped):
         "time_table": CAPTURE_TIME_TABLE,
         "armed": True,
     }
-    kwargs[dropped] = None
+    # Dropping one argument is the subject: the builder must refuse it.
+    kwargs[dropped] = None  # type: ignore[assignment]
     with pytest.raises(TypeError, match=dropped):
         build("power", **kwargs)
 

--- a/tests/test_proto_decoder.py
+++ b/tests/test_proto_decoder.py
@@ -234,6 +234,7 @@ class TestProtobufImportFailure:
         # Remove the attribute from the parent package so Python cannot
         # short-circuit the import via the package namespace.
         proto_pkg = sys.modules.get(proto_pkg_key)
+        assert proto_pkg is not None
         had_attr = hasattr(proto_pkg, "ecocharge_pb2")
         if had_attr:
             saved_attr = proto_pkg.ecocharge_pb2
@@ -266,7 +267,9 @@ class TestProtobufImportFailure:
             if saved_module is not None:
                 sys.modules[pb2_key] = saved_module
             if had_attr:
-                proto_pkg.ecocharge_pb2 = saved_attr
+                # Put back what the test removed above; the module has no
+                # such attribute declared, which is why it is set by name.
+                proto_pkg.ecocharge_pb2 = saved_attr  # type: ignore[attr-defined]
 
 
 class TestDecoderMalformedInput:


### PR DESCRIPTION
A third of this suite was never looked at, and the claim that it was clean has been on the record since yesterday.

The type checker skips the **body** of any function that carries no annotations. It does not check it leniently; it does not check it at all. 1,068 of the 3,315 test functions carry none, so "no issues found in 84 source files" meant "none in the two thirds I read".

## The distinction that decides the question

Two settings are easy to confuse and they buy very different things:

| Setting | What it does | Cost here | What it buys |
|---|---|---:|---|
| `check_untyped_defs` | Checks the bodies of unannotated functions | **10 findings** | The gate covers the whole suite instead of two thirds |
| `disallow_untyped_defs` | Also requires the annotations themselves | ~1,068 edits | The signatures, which on a test method read `-> None` |

The coverage comes from the first. This change turns it on and leaves the second off, with the reasoning written next to the switch.

## The ten findings in the invisible third

Small, and of shapes already fixed elsewhere in this line of work:

- Three collections needing an annotation the checker could not infer from an empty literal.
- Three accesses to a module the test itself removes and restores, where `sys.modules.get` returns a module or nothing.
- Four calls whose wrong type is the entire point of the test. `test_rejects_non_versions` passes a string, nothing, and a float to a helper declared to take an integer, because refusing all three is what it checks. Those keep a suppression with the reason on the line; correcting them would leave the test green and checking nothing.

That the invisible third held only ten is itself the useful result: it is evidence the suite is in good shape, not evidence the check was unnecessary. The check is what turns that from a belief into a measurement.

## Numbers

- The type checker: no issues in 62 source files, none in 84 test files, now including every body
- `ruff check` clean, `ruff format --check` reports all 146 files formatted
- 3331 tests pass, 1 skipped

Ref PLAN-128
