### PR TITLE
chore(ci): pin the Home Assistant the type gate reads its annotations from

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,17 @@
-# Test framework
-# Floor pinned to 0.13.316 because >=0.13.317 requires Python 3.14 (CI uses 3.13).
-# See .github/dependabot.yml ignore rule.
-pytest-homeassistant-custom-component>=0.13.316
+# Test framework.
+#
+# Pinned exactly rather than by floor, because this package decides which Home
+# Assistant the type gate reads its annotations from. A floor lets the resolver
+# pick, and the type gate can then turn red on a branch that changed nothing.
+#
+# The two lines are not a preference. Releases from 0.13.317 need Python 3.14,
+# and CI runs 3.13, so the resolver was already capped there by the interpreter
+# rather than by intent. Measured 2026-09-08: CI installed 0.13.316 and read
+# Home Assistant 2026.2.3, a workstation on Python 3.14 installed 0.13.321 and
+# read 2026.4.0. Both green, two months apart, and nothing said so.
+#
+# Raising either line is its own commit, with whatever the newer Home Assistant
+# reports fixed in it. Moving CI to Python 3.14 removes the split and is its own
+# piece of work; see the dependabot ignore rule.
+pytest-homeassistant-custom-component==0.13.316; python_version < "3.14"
+pytest-homeassistant-custom-component==0.13.321; python_version >= "3.14"


### PR DESCRIPTION
The last unpinned thing in the gate, and it was not one of the tools.

`ruff` and `mypy` are pinned exactly. What the type checker reads its annotations **from** was not: the test framework carried a floor, and that package brings Home Assistant with it. A floor lets the resolver choose, and a resolver that chooses differently tomorrow turns the gate red on a branch that changed nothing. That is the failure this repository already has a rule about.

## It looked stable by accident, not by intent

Releases from `0.13.317` require Python 3.14, and CI runs 3.13. So the floor was being held down by the interpreter, not by anything anyone decided. Measured today:

| | Python | Package | Home Assistant |
|---|---|---|---|
| CI | 3.13 | 0.13.316 | **2026.2.3** |
| A workstation | 3.14 | 0.13.321 | **2026.4.0** |

Both green, two months of annotations apart, and nothing anywhere said so. The moment CI moves to Python 3.14, that floor jumps forty-eight releases in a single step, and whatever the newer Home Assistant reports arrives all at once on whichever branch happens to be open.

## What changes

Nothing that is installed. Both lines are exact now, one per interpreter, so each side is stated rather than inferred. The markers were evaluated for both versions before committing:

```
Python 3.13 -> pytest-homeassistant-custom-component==0.13.316
Python 3.14 -> pytest-homeassistant-custom-component==0.13.321
```

which is precisely what each side already had. Raising either line becomes its own commit, with whatever the newer Home Assistant reports fixed in it.

Moving CI to Python 3.14 would remove the split entirely. That is a real upgrade with its own risk and its own pass, and it is deliberately not this.

## Numbers

- `ruff check` clean, `ruff format --check` reports all 146 files formatted
- The type checker: no issues in 62 source files, none in 84 test files
- 3331 tests pass, 1 skipped

Ref PLAN-128
