### PR TITLE
ci: run the gates on Python 3.14 against the Home Assistant people actually have

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,10 @@ updates:
         patterns: ["*"]
         update-types: ["minor", "patch"]
     ignore:
-      # pytest-homeassistant-custom-component >=0.13.317 requires Python 3.14.
-      # Our CI runs Python 3.13. Re-evaluate when CI is upgraded to 3.14.
+      # The test framework decides which Home Assistant the type gate reads its
+      # annotations from, so it is raised deliberately, in a commit that fixes
+      # whatever the newer release reports, rather than by a dependency bump.
       - dependency-name: "pytest-homeassistant-custom-component"
-        versions: [">=0.13.317"]
 
   # GitHub Actions versions
   - package-ecosystem: "github-actions"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set up Python 3.13
+      - name: Set up Python 3.14
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: 'pip'
           cache-dependency-path: requirements_test.txt
       - name: Install dependencies
@@ -38,10 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set up Python 3.13
+      - name: Set up Python 3.14
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: 'pip'
           cache-dependency-path: requirements-dev.txt
       - name: Install dependencies
@@ -62,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set up Python 3.13
+      - name: Set up Python 3.14
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: 'pip'
           cache-dependency-path: |
             requirements-dev.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [tool.ruff]
-target-version = "py313"
+# The oldest runtime the integration ships to, NOT the CI interpreter. This
+# tells the formatter which syntax it may emit, and 3.14 lets it write PEP 758
+# unparenthesized except clauses, which do not parse on any older Python. HACS
+# declares a minimum of Home Assistant 2025.1.0, which runs on 3.12 and 3.13.
+target-version = "py312"
 line-length = 88
 extend-exclude = ["custom_components/ecoflow_energy/ecoflow/proto/ecocharge_pb2.py"]
 
@@ -8,7 +12,7 @@ select = ["E", "F", "W", "I", "UP", "B", "SIM", "RET", "C4"]
 ignore = []
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.14"
 # A function without annotations is not checked leniently, it is not checked at
 # all: the checker walks past it and says nothing. With this on, writing one is
 # itself the finding. The integration reached it with six functions to fix, so

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,14 +4,11 @@
 # Assistant the type gate reads its annotations from. A floor lets the resolver
 # pick, and the type gate can then turn red on a branch that changed nothing.
 #
-# The two lines are not a preference. Releases from 0.13.317 need Python 3.14,
-# and CI runs 3.13, so the resolver was already capped there by the interpreter
-# rather than by intent. Measured 2026-09-08: CI installed 0.13.316 and read
-# Home Assistant 2026.2.3, a workstation on Python 3.14 installed 0.13.321 and
-# read 2026.4.0. Both green, two months apart, and nothing said so.
+# 0.13.364 brings Home Assistant 2026.9.1, which is what a current installation
+# runs. Before this, CI ran Python 3.13, which capped the resolver at 0.13.316
+# and Home Assistant 2026.2.3, so the gate had been reading annotations seven
+# months behind the release people actually have.
 #
-# Raising either line is its own commit, with whatever the newer Home Assistant
-# reports fixed in it. Moving CI to Python 3.14 removes the split and is its own
-# piece of work; see the dependabot ignore rule.
-pytest-homeassistant-custom-component==0.13.316; python_version < "3.14"
-pytest-homeassistant-custom-component==0.13.321; python_version >= "3.14"
+# Raising this is its own commit, with whatever the newer Home Assistant reports
+# fixed in it.
+pytest-homeassistant-custom-component==0.13.364

--- a/tests/ha/test_delta3_idle_shutdown_entity.py
+++ b/tests/ha/test_delta3_idle_shutdown_entity.py
@@ -117,7 +117,7 @@ def _coordinator(
 def _select(coordinator: EcoFlowDeviceCoordinator, key: str) -> EcoFlowSelect:
     defn = next(d for d in DELTA3_SELECTS if d.key == key)
     entity = EcoFlowSelect(coordinator, defn)
-    entity.async_write_ha_state = MagicMock()
+    entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
     entity.entity_id = f"select.{key}"
     return entity
 

--- a/tests/ha/test_delta3_port_priority_entities.py
+++ b/tests/ha/test_delta3_port_priority_entities.py
@@ -131,7 +131,7 @@ def _coordinator(
 def _switch(coordinator: EcoFlowDeviceCoordinator, key: str) -> EcoFlowSwitch:
     defn = next(d for d in DELTA3_SWITCHES if d.key == key)
     entity = EcoFlowSwitch(coordinator, defn)
-    entity.async_write_ha_state = MagicMock()
+    entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
     entity.entity_id = f"switch.{key}"
     return entity
 
@@ -139,7 +139,7 @@ def _switch(coordinator: EcoFlowDeviceCoordinator, key: str) -> EcoFlowSwitch:
 def _number(coordinator: EcoFlowDeviceCoordinator, key: str) -> EcoFlowNumber:
     defn = next(d for d in DELTA3_NUMBERS if d.key == key)
     entity = EcoFlowNumber(coordinator, defn)
-    entity.async_write_ha_state = MagicMock()
+    entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
     entity.entity_id = f"number.{key}"
     return entity
 

--- a/tests/ha/test_delta3_screen_timeout_entity.py
+++ b/tests/ha/test_delta3_screen_timeout_entity.py
@@ -112,7 +112,7 @@ def _coordinator(
 def _select(coordinator: EcoFlowDeviceCoordinator) -> EcoFlowSelect:
     defn = next(d for d in DELTA3_SELECTS if d.key == DELTA3_SCREEN_TIMEOUT_KEY)
     entity = EcoFlowSelect(coordinator, defn)
-    entity.async_write_ha_state = MagicMock()
+    entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
     entity.entity_id = f"select.{DELTA3_SCREEN_TIMEOUT_KEY}"
     return entity
 

--- a/tests/ha/test_powerocean_number.py
+++ b/tests/ha/test_powerocean_number.py
@@ -1037,7 +1037,7 @@ class TestPowerOceanAppSurplusAutoSync:
         coordinator.async_set_powerocean_soc_debounced = AsyncMock(return_value=True)
         defn = next(d for d in POWEROCEAN_NUMBERS if d.key == "solar_surplus_threshold")
         entity = EcoFlowNumber(coordinator, defn)
-        entity.async_write_ha_state = MagicMock()
+        entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
         with patch(
             "custom_components.ecoflow_energy.number.time.monotonic",
             return_value=2000.0,

--- a/tests/ha/test_powerocean_schedule_entities.py
+++ b/tests/ha/test_powerocean_schedule_entities.py
@@ -262,6 +262,11 @@ class TestStandardMode:
         assert _schedule_keys(sensors) == set()
         assert _schedule_keys(binary_sensors) == set()
 
+        # Standard Mode polls, so the base class arms a refresh timer this
+        # test would otherwise leave running. The Enhanced Mode tests above
+        # set no interval and have nothing to cancel.
+        await coordinator.async_shutdown()
+
 
 class TestScheduleAppearsAndDisappears:
     async def test_a_schedule_created_later_adds_its_entities(

--- a/tests/ha/test_stream_ac5000_controls.py
+++ b/tests/ha/test_stream_ac5000_controls.py
@@ -78,14 +78,14 @@ def _coordinator(
 def _number(coordinator: EcoFlowDeviceCoordinator, key: str) -> EcoFlowNumber:
     defn = next(d for d in STREAMAC5000_NUMBERS if d.key == key)
     entity = EcoFlowNumber(coordinator, defn)
-    entity.async_write_ha_state = MagicMock()
+    entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
     return entity
 
 
 def _select(coordinator: EcoFlowDeviceCoordinator, key: str) -> EcoFlowSelect:
     defn = next(d for d in STREAMAC5000_SELECTS if d.key == key)
     entity = EcoFlowSelect(coordinator, defn)
-    entity.async_write_ha_state = MagicMock()
+    entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
     return entity
 
 
@@ -163,7 +163,7 @@ def _config_field(pdata: bytes) -> int:
 def _switch(coordinator: EcoFlowDeviceCoordinator, key: str) -> EcoFlowSwitch:
     defn = next(d for d in STREAMAC5000_SWITCHES if d.key == key)
     entity = EcoFlowSwitch(coordinator, defn)
-    entity.async_write_ha_state = MagicMock()
+    entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
     return entity
 
 
@@ -354,7 +354,7 @@ class TestSocLimitNumbers:
             d for d in STREAMAC5000_SWITCHES if d.key == "backup_reserve_switch"
         )
         entity = EcoFlowSwitch(coordinator, defn)
-        entity.async_write_ha_state = MagicMock()
+        entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
 
         await entity.async_turn_off()
 
@@ -373,7 +373,7 @@ class TestSocLimitNumbers:
             d for d in STREAMAC5000_SWITCHES if d.key == "backup_reserve_switch"
         )
         entity = EcoFlowSwitch(coordinator, defn)
-        entity.async_write_ha_state = MagicMock()
+        entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
 
         with pytest.raises(HomeAssistantError) as err:
             await entity.async_turn_off()

--- a/tests/ha/test_stream_number.py
+++ b/tests/ha/test_stream_number.py
@@ -207,7 +207,7 @@ class TestStreamBackupReserveSet:
         coordinator.async_set_updated_data(dict(coordinator._device_data))
         defn = next(d for d in STREAM_NUMBERS if d.key == "backup_reserve")
         entity = EcoFlowNumber(coordinator, defn)
-        entity.async_write_ha_state = MagicMock()
+        entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
         return entity, coordinator
 
     async def test_set_builds_cmd_id_17_payload(
@@ -286,7 +286,7 @@ class TestStreamLedBrightnessSet:
             item for item in STREAM_NUMBERS if item.key == "led_brightness"
         )
         entity = EcoFlowNumber(coordinator, definition)
-        entity.async_write_ha_state = MagicMock()
+        entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
         return entity, coordinator
 
     async def test_set_builds_captured_field_384_frame(
@@ -396,7 +396,7 @@ class TestStreamSocLimitSet:
         coordinator.async_set_updated_data(dict(values))
         definition = next(item for item in STREAM_NUMBERS if item.key == key)
         entity = EcoFlowNumber(coordinator, definition)
-        entity.async_write_ha_state = MagicMock()
+        entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
         coordinator.async_send_proto_set_command = AsyncMock(return_value=True)
         return entity, coordinator
 
@@ -514,7 +514,7 @@ class TestStreamSocLimitSet:
             item for item in STREAM_NUMBERS if item.key == "stream_discharge_limit"
         )
         discharge_entity = EcoFlowNumber(coordinator, discharge_definition)
-        discharge_entity.async_write_ha_state = MagicMock()
+        discharge_entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
 
         first_started = asyncio.Event()
         release_first = asyncio.Event()
@@ -582,7 +582,7 @@ class TestBackupReserveFloorFollowsTheDischargeLimit:
             item for item in (definitions or STREAM_NUMBERS) if item.key == key
         )
         entity = EcoFlowNumber(coordinator, definition)
-        entity.async_write_ha_state = MagicMock()
+        entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
         return entity, coordinator
 
     async def test_a_reported_limit_lifts_the_floor(
@@ -758,7 +758,7 @@ class TestBackupReserveFloorFollowsTheDischargeLimit:
                 item for item in STREAM_NUMBERS if item.key == "stream_discharge_limit"
             ),
         )
-        limit.async_write_ha_state = MagicMock()
+        limit.async_write_ha_state = MagicMock()  # type: ignore[misc]
         assert entity.native_min_value == 23
 
         await limit.async_set_native_value(40.0)

--- a/tests/ha/test_wave3_entities.py
+++ b/tests/ha/test_wave3_entities.py
@@ -57,6 +57,7 @@ from custom_components.ecoflow_energy.const import (
     WAVE3_SWITCHES,
 )
 from custom_components.ecoflow_energy.coordinator import EcoFlowDeviceCoordinator
+from custom_components.ecoflow_energy.coordinator.state_apply import _registry_device
 from custom_components.ecoflow_energy.diagnostics import (
     async_get_config_entry_diagnostics,
 )
@@ -173,7 +174,7 @@ def _coordinator(
 def _switch(coordinator: EcoFlowDeviceCoordinator, key: str) -> EcoFlowSwitch:
     defn = next(d for d in WAVE3_SWITCHES if d.key == key)
     entity = EcoFlowSwitch(coordinator, defn)
-    entity.async_write_ha_state = MagicMock()
+    entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
     entity.entity_id = f"switch.{key}"
     return entity
 
@@ -181,7 +182,7 @@ def _switch(coordinator: EcoFlowDeviceCoordinator, key: str) -> EcoFlowSwitch:
 def _number(coordinator: EcoFlowDeviceCoordinator, key: str) -> EcoFlowNumber:
     defn = next(d for d in WAVE3_NUMBERS if d.key == key)
     entity = EcoFlowNumber(coordinator, defn)
-    entity.async_write_ha_state = MagicMock()
+    entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
     entity.entity_id = f"number.{key}"
     return entity
 
@@ -189,7 +190,7 @@ def _number(coordinator: EcoFlowDeviceCoordinator, key: str) -> EcoFlowNumber:
 def _select(coordinator: EcoFlowDeviceCoordinator, key: str) -> EcoFlowSelect:
     defn = next(d for d in WAVE3_SELECTS if d.key == key)
     entity = EcoFlowSelect(coordinator, defn)
-    entity.async_write_ha_state = MagicMock()
+    entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
     entity.entity_id = f"select.{key}"
     return entity
 
@@ -471,7 +472,7 @@ class TestTheCaptureReachesTheEntities:
         with patch(_CLOCK, return_value=1000.0):
             coordinator._apply_data(parsed)
 
-        device = registry.async_get_device(identifiers={(DOMAIN, WAVE3_DEVICE["sn"])})
+        device = _registry_device(registry, WAVE3_DEVICE["sn"], entry.entry_id)
         assert device is not None
         assert device.sw_version == "v1.1.0.104"
         assert "firmware_version" not in coordinator.data
@@ -523,10 +524,7 @@ class TestTheCaptureReachesTheEntities:
             coordinator._apply_data(dict(parsed))
 
         registry = dr.async_get(hass)
-        assert (
-            registry.async_get_device(identifiers={(DOMAIN, WAVE3_DEVICE["sn"])})
-            is None
-        )
+        assert _registry_device(registry, WAVE3_DEVICE["sn"], entry.entry_id) is None
 
         # Platform setup registers the device afterwards, as it does in
         # real use.
@@ -539,7 +537,7 @@ class TestTheCaptureReachesTheEntities:
         with patch(_CLOCK, return_value=1300.0):
             coordinator._apply_data(dict(parsed))
 
-        device = registry.async_get_device(identifiers={(DOMAIN, WAVE3_DEVICE["sn"])})
+        device = _registry_device(registry, WAVE3_DEVICE["sn"], entry.entry_id)
         assert device is not None
         assert device.sw_version == "v1.1.0.104"
 
@@ -666,6 +664,13 @@ class TestTheEntitiesReachTheWire:
         assert _sent_pdata(mqtt) == "c80901"
 
 
+def _cancel_stale_check(coordinator: EcoFlowDeviceCoordinator) -> None:
+    """Cancel the watch `_check_stale` arms for itself before it fires."""
+    if coordinator._stale_check_unsub is not None:
+        coordinator._stale_check_unsub.cancel()
+        coordinator._stale_check_unsub = None
+
+
 class TestStandbyCadence:
     """In standby the WAVE 3 pushes its full status every 120 s and nothing
     in between. Under the 35 s default the coordinator re-sent its initial
@@ -717,13 +722,14 @@ class TestStandbyCadence:
         coordinator._mqtt_client = mqtt
         coordinator._last_mqtt_ts = 1000.0
         coordinator._log_event = MagicMock()
-        # The check reschedules itself on the real clock; keep it out of the
-        # test's teardown, where the mocked client would meet a real age.
-        coordinator._schedule_stale_check = MagicMock()
         mqtt.reconnect_attempts = 0
 
+        # `_check_stale` re-arms itself at the end of its own body rather than
+        # through `_schedule_stale_check`, so each call leaves a handle behind
+        # and the next call overwrites the reference to it. Cancel per call.
         with patch(self._AVAIL_CLOCK, return_value=1100.0):
             coordinator._check_stale()
+        _cancel_stale_check(coordinator)
         assert not any(
             call.args and call.args[0] == "stale_reactivate"
             for call in coordinator._log_event.call_args_list
@@ -736,6 +742,7 @@ class TestStandbyCadence:
         # Positive control: past the threshold the cheap remedy still runs.
         with patch(self._AVAIL_CLOCK, return_value=1000.0 + 300.0):
             coordinator._check_stale()
+        _cancel_stale_check(coordinator)
         assert any(
             call.args and call.args[0] == "stale_reactivate"
             for call in coordinator._log_event.call_args_list
@@ -793,7 +800,7 @@ class TestRegistryLookup:
 def _climate(coordinator: EcoFlowDeviceCoordinator) -> EcoFlowWave3Climate:
     """Build one WAVE 3 climate entity directly, same shape as `_switch`."""
     entity = EcoFlowWave3Climate(coordinator)
-    entity.async_write_ha_state = MagicMock()
+    entity.async_write_ha_state = MagicMock()  # type: ignore[misc]
     entity.entity_id = "climate.wave_3"
     return entity
 


### PR DESCRIPTION
CI checked this integration against Home Assistant **2026.2.3**. A current installation runs **2026.9.1**. Seven months of annotations and test-harness rules were never seen by any gate.

The reason was Python, and nobody had chosen it. Releases of the test framework past `0.13.316` need 3.14, CI ran 3.13, so the resolver was capped there as a side effect. All three jobs move to 3.14 and the framework is pinned to the release that brings 2026.9.1, the version a maintainer's own production reports.

## What that surfaced

None of it was visible before, and none of it reached an owner.

**Three tests looked a device up through the registry call 2026.9 deprecates.** The integration itself was already correct: it asks the registry which API it has and takes the newer one, which is what PR #361 built. The tests simply kept their own copy of the old call. They use the same helper now, so the test exercises the path production takes.

**Two tests left a timer running** that the newer harness refuses. One carried a comment describing the wrong mechanism: the stale check re-arms itself at the end of its own body rather than through the method the test had replaced, so replacing that method never prevented anything, and each of the two calls left a handle behind while the second overwrote the reference to the first. The other builds a polling coordinator, whose base class arms a refresh, and never shut it down.

**Twenty assignments replace a method Home Assistant has since marked `@final`.** That is the same thing the suite already does deliberately elsewhere, but the checker reports it under `misc`, too broad to switch off without going blind to real findings. Each line says so for itself.

## One thing is deliberately not moved, and it is the important one

`target-version` stays at the oldest runtime this integration ships to, **not** the interpreter CI runs on.

Set to 3.14 it rewrote nineteen files into PEP 758 unparenthesized except clauses:

```python
except TypeError, ValueError:      # valid from 3.14, parses nowhere earlier
```

HACS declares support back to Home Assistant 2025.1.0, which runs on 3.12 and 3.13. A **formatting setting** would have made the integration fail to import for every owner on an older installation. It is reverted, the target reads `py312`, and the comment beside it says which question that setting answers, because it is not the same question as the checker's `python_version`.

Worth noting how it was caught: an interpreter-based syntax check missed it entirely, because the interpreter doing the checking was 3.14 and accepts the syntax. The linter with the correct target found it. A control run on the new thing cannot tell you about the old one.

## Numbers, all against Home Assistant 2026.9.1 on Python 3.14

- `ruff check` clean, `ruff format --check` reports all 146 files formatted
- The type checker: no issues in 62 source files, none in 84 test files
- 3332 tests pass, from 2 failures and 2 collection errors when first measured

Ref PLAN-128
