### PR TITLE
chore(ci): give the two gate tools their own pull request

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,12 @@ updates:
     groups:
       minor-and-patch:
         patterns: ["*"]
+        # The two gate tools are excluded from the group so each gets its own
+        # pull request. They are not libraries: a new minor changes what counts
+        # as an error, which can turn CI red on a branch that touched neither
+        # the rule nor the file, so raising one is a decision with its own
+        # findings to fix rather than a line in a batch of six.
+        exclude-patterns: ["ruff", "mypy"]
         update-types: ["minor", "patch"]
     ignore:
       # The test framework decides which Home Assistant the type gate reads its
@@ -35,4 +41,10 @@ updates:
     groups:
       minor-and-patch:
         patterns: ["*"]
+        # The two gate tools are excluded from the group so each gets its own
+        # pull request. They are not libraries: a new minor changes what counts
+        # as an error, which can turn CI red on a branch that touched neither
+        # the rule nor the file, so raising one is a decision with its own
+        # findings to fix rather than a line in a batch of six.
+        exclude-patterns: ["ruff", "mypy"]
         update-types: ["minor", "patch"]


### PR DESCRIPTION
The linter and the type checker sat in the same dependency group as the libraries the integration ships with, so this morning they were raised as two lines inside a batch rather than as a decision. This repository pins them exactly for a reason, and that reason does not survive being bundled.

They are not libraries. A new minor changes what counts as an error, so it can turn CI red on a branch that touched neither the rule nor the file, and the first instinct then is to look for the mistake in the diff, where it is not.

## Excluded from the group, not ignored

```yaml
minor-and-patch:
  patterns: ["*"]
  exclude-patterns: ["ruff", "mypy"]
  update-types: ["minor", "patch"]
```

Each still gets a pull request, so a new release is still noticed. It simply arrives on its own, where its effect can be read and its findings fixed in the same change.

The test framework stays ignored outright, because raising that one means adopting a newer Home Assistant and fixing whatever its annotations report. That is a piece of work, not a review.

## This morning's raise itself is fine and stays

`ruff` 0.15.18 to 0.16.6 and `mypy` 2.1.0 to 2.3.1 landed in #375 and are kept. Verified here rather than taken from the branch that carried them in, with the new tools against the Home Assistant the pin now names:

```
ruff 0.16.6      check     All checks passed!
ruff 0.16.6      format    146 files already formatted
mypy 2.3.1       custom_components/ecoflow_energy   no issues in 62 source files
mypy 2.3.1       tests/                             no issues in 84 source files
```

Worth noting for the record, since this repository's own rule names it: ruff 0.16 is the release that started formatting Python blocks inside Markdown, which broke a sibling project's gate on a branch that touched neither. Here the two ruff steps are pointed at `custom_components/` and `tests/` only, so no Markdown is in scope and the raise passes without a change.

Ref PLAN-128
