### PR TITLE
Check the entity reference against the definitions it describes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@
 
 ## Highlights
 
-- **Over 200 sensors per device** - power, energy, battery packs, temperature, diagnostics
+- **In the HACS default store** - installable from HACS directly, no custom repository to add
+- **Up to 235 sensors on one device** - power, energy, battery packs, temperature, diagnostics
 - **Energy Dashboard ready** - local Riemann-sum kWh with gap detection
 - **Real-time out of the box** - Enhanced Mode: ~2-4 s updates for all devices
 - **Full PowerOcean control** - Backup Reserve, Solar Surplus Threshold, Work Mode (Self-use / AI Schedule)
@@ -177,6 +178,8 @@ Or: **HACS** > **Integrations** > **Explore & Download** > search **EcoFlow Ener
 Download the [latest release](https://github.com/shuette42/ecoflow-energy-ha/releases), copy `custom_components/ecoflow_energy/` to your HA `config/custom_components/`, restart.
 
 </details>
+
+Already running a different EcoFlow integration? It can stay installed while you try this one. [Moving from another EcoFlow integration](documentation/migration-from-another-integration.md) describes what carries over, what has to be re-pointed by hand, and an order of steps that keeps the old entities running until the new ones are confirmed.
 
 ### 2. Configure
 
@@ -414,23 +417,22 @@ automation:
 
 ---
 
-## How It Compares
+## How It Works
 
 <details>
-<summary><b>EcoFlow Energy vs other integrations</b></summary>
+<summary><b>The design decisions behind the integration</b></summary>
 
-| | EcoFlow Energy | Others |
-|:---|:---|:---|
-| Data source | MQTT push + HTTP fallback | HTTP only or basic MQTT |
-| Portal login | Not required | Required |
-| Reconnect | 4-tier, never gives up | Simple retry |
-| Fallback | Auto HTTP when MQTT stale | None |
-| Stream health | 3-state monitoring | Not tracked |
-| Energy tracking | Local Riemann-sum | API totals |
-| Device types | Heterogeneous in one integration | Single type |
-| PowerOcean control | Backup Reserve, Solar Surplus, Work Mode (verified app-replay) | Read-only or untested |
-| Control | Optimistic lock, zero-flicker | Read-only or basic |
-| Offline handling | Expected, no error spam | Error |
+| | |
+|:---|:---|
+| Data source | MQTT push, with HTTP polling as the fallback in Standard Mode |
+| Sign-in | Standard Mode uses the Developer Portal access and secret key; Enhanced Mode signs in with the EcoFlow account |
+| Reconnect | Four-tier backoff that keeps retrying instead of giving up |
+| Fallback | Switches to HTTP polling when the MQTT stream goes stale (Standard Mode) |
+| Stream health | Three states, live, stale and offline, published as a diagnostic sensor |
+| Energy tracking | Local Riemann sum with gap detection, adopting the device's own lifetime counters where it reports them |
+| Devices | Every supported model in one integration, on one config entry per account |
+| Controls | Each write is the frame the EcoFlow app sends for the same setting, and the entity shows what the device reports back |
+| Offline devices | An expected state that does not fill the log with errors |
 
 </details>
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -22,3 +22,7 @@ Complete list of all sensors, switches, numbers, and binary sensors per device:
 - [WAVE 3](entities/wave-3.md) - 18 sensors, 5 binary sensors, 4 switches, 5 numbers, 5 selects, 1 climate (`AC71`) - a portable air conditioner, Enhanced Mode only
 
 Counts are the device-specific entity definitions. Every device additionally exposes 2 universal diagnostic sensors (connection status and active mode) that are not included above.
+
+## Guides
+
+- [Moving from another EcoFlow integration](migration-from-another-integration.md) - what carries over, what has to be re-pointed by hand, and an order of steps that keeps the old entities running until the new ones are confirmed

--- a/documentation/entities/powerocean.md
+++ b/documentation/entities/powerocean.md
@@ -166,7 +166,7 @@ These sensors are pre-configured for the HA Energy Dashboard (`total_increasing`
 | MPPT 1/2 Fault Code | A raw code from the device, passed through unchanged. EcoFlow publishes no meaning for the values, so nothing here translates them, and "fault" is their field name rather than a verdict. An owner tracing one unit found the code following sunrise and sunset with no alert in the EcoFlow app, which points at a producing / not producing state rather than an error. Read it as unlabelled: for automations the power reading of the string itself is the better signal. | disabled |
 | PCS AC/DC Error Code | Inverter error codes | disabled |
 | PCS AC Warning Code | Inverter warnings | disabled |
-| WiFi / Ethernet / 4G Status | Connectivity status | disabled |
+| WiFi/Ethernet/4G Status | Connectivity status | disabled |
 | EMS LED Brightness | LED brightness setting | disabled |
 | EMS Work State | Internal work state | disabled |
 | Total Battery Capacity | System battery capacity | disabled |

--- a/documentation/entities/stream-ac-pro.md
+++ b/documentation/entities/stream-ac-pro.md
@@ -32,21 +32,21 @@ The fields were observed in live iOS MQTT captures on `/app/{userId}/{sn}/thing/
 
 House, grid, and solar flow values are meter-dependent and disabled by default unless an EcoFlow-compatible meter is paired in the app.
 
-| Entity | Confirmed / observed field |
-|:---|:---|
-| Solar Power | `254/21` field `517` |
-| Home Power | `254/21` field `516` |
-| Grid Power | `254/21` field `515` |
-| Home From Battery | `254/21` field `1003` |
-| Home From Grid | `254/21` field `1004` |
-| AC Outlet 1 Power | `254/21` field `1210` |
-| AC Outlet 2 Power | `254/21` field `1211` |
-| LED Brightness | `254/21` field `994`, set reply field `384` |
-| AC Outlet 1 State | `254/21` field `980` |
-| AC Outlet 2 State | `254/21` field `982` |
-| Backup Reserve | `254/21` field `461`, set reply field `102` |
-| Max Charge SoC | `254/21` field `270` |
-| Min Discharge SoC | `254/21` field `271` |
+| Entity | Type | Confirmed / observed field |
+|:---|:---|:---|
+| Solar Power | sensor | `254/21` field `517` |
+| Home Power | sensor | `254/21` field `516` |
+| Grid Power | sensor | `254/21` field `515` |
+| Home From Battery | sensor | `254/21` field `1003` |
+| Home From Grid | sensor | `254/21` field `1004` |
+| AC Outlet 1 Power | sensor | `254/21` field `1210` |
+| AC Outlet 2 Power | sensor | `254/21` field `1211` |
+| LED Brightness | sensor | `254/21` field `994`, set reply field `384` |
+| AC Outlet 1 | binary sensor | `254/21` field `980` |
+| AC Outlet 2 | binary sensor | `254/21` field `982` |
+| Backup Reserve | sensor | `254/21` field `461`, set reply field `102` |
+| Max Charge SoC | number | `254/21` field `270` |
+| Min Discharge SoC | number | `254/21` field `271` |
 
 ## Capture Notes
 

--- a/documentation/entities/stream.md
+++ b/documentation/entities/stream.md
@@ -151,21 +151,33 @@ The LED control reproduces the hardware-confirmed app ConfigWrite field `384` wi
 
 The Stream Micro is a grid-tie solar inverter: two solar strings, one single-phase grid connection, no battery and no AC outlets. It speaks the same protocol as the rest of the Stream family and shares this parser, but not the whole entity set.
 
-**Totals:** 21 sensors, no binary sensors, no numbers.
+**Totals:** 21 sensor definitions, no binary sensors, no numbers. 17 are listed in the table below; the other 4 are the PV 3/4 power and energy sensors, which stay in the shared Stream definition list but never populate on a two-string unit - see the note after the table.
 
 **Enhanced Mode only.** The Stream Micro is not exposed through the EcoFlow Developer API, so it needs the EcoFlow account sign-in.
 
-### What it reports
+## Sensors - Stream Micro (`BK01`)
 
-| Group | Entities |
-|:---|:---|
-| Solar | PV 1 Power, PV 2 Power (enabled) · PV Voltage, PV Current, PV 2 Voltage, PV 2 Current (disabled diagnostics) |
-| Grid | AC Voltage, AC Current, AC Frequency, AC Grid Connection Power (enabled) · Grid Connection Power (disabled diagnostic) |
-| Configuration | Grid Connection State, Feed-in Power Limit (enabled diagnostics) |
-| Device | WiFi Signal, LED Brightness (disabled diagnostics) |
-| Energy Dashboard | PV 1 Energy, PV 2 Energy (disabled by default, enable them for **Solar production**) |
+| Entity | Unit | Category | Default | Description |
+|:---|:---:|:---:|:---:|:---|
+| PV 1 Power | W | - | enabled | Solar string 1 |
+| PV 2 Power | W | - | enabled | Solar string 2 |
+| PV Voltage | V | diagnostic | disabled | Input voltage of string 1 |
+| PV Current | A | diagnostic | disabled | Input current of string 1 |
+| PV 2 Voltage | V | diagnostic | disabled | Input voltage of string 2 |
+| PV 2 Current | A | diagnostic | disabled | Input current of string 2 |
+| AC Voltage | V | - | enabled | AC line voltage |
+| AC Current | A | - | enabled | AC line current |
+| AC Frequency | Hz | - | enabled | AC line frequency |
+| AC Grid Connection Power | W | - | enabled | Signed grid connection ("Netz-Anschluss": negative = input, positive = output/feed-in) |
+| Grid Connection Power | W | diagnostic | disabled | Raw grid connection reading |
+| Grid Connection State | - | diagnostic | enabled | `feed_grid`, `grid_in`, `not_online` or `invalid` |
+| Feed-in Power Limit | W | diagnostic | enabled | The feed-in cap configured in the EcoFlow app (read-only here) |
+| WiFi Signal | dBm | diagnostic | disabled | Signal strength of the device's WiFi module (negative, closer to zero is better) |
+| LED Brightness | % | diagnostic | disabled | Current LED brightness |
+| PV 1 Energy | kWh | diagnostic | disabled | Per-string solar production, disabled by default (enable it for **Solar production**) |
+| PV 2 Energy | kWh | diagnostic | disabled | Per-string solar production, disabled by default (enable it for **Solar production**) |
 
-PV 3 and PV 4 are not created here. They are *accessory* entities across the whole Stream family, so a two-string unit never gains them.
+PV 3 and PV 4 are not created here, on either the power or the energy side. They are *accessory* entities across the whole Stream family, so a two-string unit never gains them.
 
 ### What it deliberately does not get
 

--- a/documentation/migration-from-another-integration.md
+++ b/documentation/migration-from-another-integration.md
@@ -14,7 +14,7 @@ Nothing here asks you to remove anything first. Both integrations are ordinary c
 | Detailed history | No | Same reason, and it is short-lived on every entity anyway: the recorder purges it after ten days by default. |
 | Automations and scripts | No, they need editing | They reference entity ids, so each one has to point at the new id. |
 | Dashboards | No, they need editing | Same reason. Cards reference entity ids. |
-| Helpers, template sensors, utility meters | No, they need editing | Same reason. A utility meter also restarts its own counting when you re-point it. |
+| Helpers, template sensors, utility meters | No, they need editing | Same reason. A utility meter needs its source changed, and it is worth reading what it shows afterwards before you rely on the number. |
 | Energy dashboard slots | No, they need re-selecting | Each slot points at one entity id and has to be pointed at the new one. |
 | The device itself and its cloud account | Yes | Nothing on the device or in your EcoFlow account is changed by any of this. |
 

--- a/documentation/migration-from-another-integration.md
+++ b/documentation/migration-from-another-integration.md
@@ -1,0 +1,85 @@
+# Moving from another EcoFlow integration
+
+If you already run a different EcoFlow integration in Home Assistant, this page describes what happens when you add this one, what carries over, what does not, and the order of steps that keeps your system working while you switch.
+
+Nothing here asks you to remove anything first. Both integrations are ordinary config entries and they can run side by side for as long as you want. That is deliberate: the safest way to switch is to let the old entities keep filling while you confirm the new ones are correct, and only then move your dashboards over.
+
+## What carries over and what does not
+
+| Thing | Carries over? | Why |
+|---|---|---|
+| Device discovery | No, but it is quick | You enter your credentials once and your devices are found again. Nothing is read from the other integration. |
+| Entity ids | No | Every entity here gets a new id, built by Home Assistant from the device name and the entity name. |
+| Long-term statistics | No | Statistics are stored per entity id. New ids start new statistics. The old ones stay where they are. |
+| Detailed history | No | Same reason, and it is short-lived on every entity anyway: the recorder purges it after ten days by default. |
+| Automations and scripts | No, they need editing | They reference entity ids, so each one has to point at the new id. |
+| Dashboards | No, they need editing | Same reason. Cards reference entity ids. |
+| Helpers, template sensors, utility meters | No, they need editing | Same reason. A utility meter also restarts its own counting when you re-point it. |
+| Energy dashboard slots | No, they need re-selecting | Each slot points at one entity id and has to be pointed at the new one. |
+| The device itself and its cloud account | Yes | Nothing on the device or in your EcoFlow account is changed by any of this. |
+
+The reason none of it carries over is worth one sentence, because it also explains why no integration could do better here. An entity's identity in Home Assistant is its unique id, and in this integration a unique id is the device serial number plus an internal key for the reading. That string is specific to this integration, so it can never accidentally collide with another integration's entities, and equally it can never claim them. There is no supported way for one integration to adopt another's entities, and any attempt to fake one would put your history at risk rather than preserve it.
+
+## The recommended sequence
+
+Work through this in order. Steps 1 to 4 change nothing you rely on, so you can stop after any of them and be exactly where you started.
+
+1. **Install this integration and add your devices.** Leave the other integration installed and running. Both will poll or receive data independently.
+
+2. **Let it run for a few hours.** Check that the new entities are filling with plausible values and that they agree with what you already see. Battery state of charge, grid power and PV power are the fastest way to tell.
+
+3. **Compare the readings you actually care about.** Some values are named differently, some are split more finely, and some exist here that did not exist before. The [entity reference](README.md) lists everything each device exposes, so you can find the new home for each old reading before you need it.
+
+4. **Write down the pairs.** For every old entity id that appears in an automation, a dashboard card or the energy dashboard, note the new entity id next to it. This is the only genuinely tedious part of the switch and doing it on paper first makes the rest mechanical. Developer Tools, then States, filtered by your device name, gives you the full list of new ids in one place.
+
+5. **Move the dashboards.** Edit each card and swap the entity. Nothing breaks while you do this, because the old entities still exist and still update.
+
+6. **Move the automations, scripts and helpers.** Same swap. Reload automations afterwards and check that none of them logs an unknown entity.
+
+7. **Re-point the energy dashboard.** See the section below, because this one has a consequence the others do not.
+
+8. **Only now, remove the other integration.** Its entities disappear at that point. The two kinds of recorded data behave differently and it is worth knowing which is which: the detailed history behind a sensor is purged on the recorder's own schedule regardless of any of this, ten days by default, so it is short-lived either way. The long-term statistics that feed the energy dashboard are not deleted when an entity goes away, they stay in the database, but with no entity left to select they are no longer reachable from the dashboard. If you still want to look back through the old figures, the way to keep that possible is to leave the other integration installed for now. There is no rush to this step.
+
+If something in step 2 or 3 does not look right, that is the point to open an issue rather than to continue. A wrong reading found before the migration costs you nothing.
+
+## Renaming entity ids by hand
+
+Home Assistant lets you change an entity id in the entity's settings dialog. It is tempting to rename the new entities to match the old ones so that everything keeps working untouched. This does something useful and something less useful than it looks, and it is worth being precise about which is which.
+
+What it does: from the moment of the rename, the new entity records under the old id. Automations and cards that reference the old id find it again. Future long-term statistics accumulate under the old id.
+
+What it does not do: it does not merge the old recorded history with the new. Home Assistant moves the statistics that belong to the entity being renamed, not the statistics of a different entity that used to carry that id. While the old integration's entity is still present and still owns that id, the rename is refused outright with "Entity with this ID is already registered".
+
+That leaves renaming into an id whose old entity has been removed, and there the two sets of statistics meet: the orphaned ones from the old entity are still in the database under that name, and the rename now files the new entity's figures under the same name. This is not a case worth being adventurous in. If you want the old id back, do it early, before the new entity has accumulated anything you would miss, and check the energy dashboard afterwards rather than assuming.
+
+There is also a cost. An id renamed by hand no longer matches what this integration produces, which makes it harder to answer a question about your setup later, both for you and for anyone helping you. Two situations where the rename is nonetheless the right call: a very large dashboard, where one rename saves editing dozens of cards, and a template sensor chain built on top of a specific id.
+
+If you do rename, do it after the old integration is removed. Disabling its entity is not enough: a disabled entity still holds its id in the registry, so the rename is refused just the same.
+
+## The energy dashboard
+
+The energy dashboard is the one place where the switch has a visible, permanent effect, so it deserves its own step.
+
+Go to Settings, Dashboards, Energy, and re-point every slot your EcoFlow hardware fills. Depending on your setup that is some combination of:
+
+- Grid consumption and grid return
+- Solar production, one entry per string or per tracker
+- Home battery, both the energy going in and the energy coming out
+
+Pick the new entities in each slot and save.
+
+What happens next is expected and is not a fault: the totals in the energy dashboard restart from the switch-over point. The energy dashboard sums a statistic per entity, and the new entity has no statistic before today. Yesterday and last month keep showing the old figures for as long as the old entity is still there. Your year-to-date total is effectively cut at the day you switched.
+
+Once the old entity is gone, its statistics are not deleted with it, but there is no entity left to select in a dashboard slot, so the old figures are no longer reachable from the energy dashboard. That is the practical reason for step 8 of the sequence above: remove the old integration last, and only when you no longer need to look back through it.
+
+There is no way around this that does not involve editing the statistics database directly, which is not something to do casually and not something this integration can do for you.
+
+One practical suggestion: if you are not in a hurry, switch the energy dashboard at the start of a month or a billing period. The break in the numbers then falls on a boundary you already think in, instead of in the middle of a period you wanted to compare.
+
+## What is genuinely lost
+
+Being plain about it: you lose the recorded history of the readings, and you spend an evening editing references.
+
+The history loss is real and permanent for the energy dashboard totals. Everything else is inconvenience rather than loss. Where a counter is reported by the device itself, it comes back at its true value as soon as the new entity starts reading it, because the device never stopped counting. Where a counter is accumulated inside Home Assistant, it starts again from zero. Automations and dashboards are work, not risk, because you do that work while the old integration is still running and can undo any of it by putting the old entity back.
+
+If you would rather not lose the long-term figures at all, the honest answer is to keep both integrations installed and let the old entities sit there recording nothing further. They cost very little, they keep the old statistics attached to an entity you can still select, and you can remove them a year from now when the comparison no longer matters to you. The detailed history, as opposed to those long-term figures, is a different matter: the recorder purges it after ten days by default on every entity you own, so there was never a year of it to save.

--- a/tests/test_entity_documentation.py
+++ b/tests/test_entity_documentation.py
@@ -1,0 +1,1254 @@
+"""Drift gate between the entity definitions in const.py and the public
+entity reference under documentation/entities/ (PLAN-129 item 2.3).
+
+The join key is the entity's ``name`` (the English display label): the first
+column of every table in the documentation files is that exact string,
+compared case-insensitively (see _key()) because several tables in this repo
+already differ from const.py by capitalisation only - e.g. Delta 3's
+"AC 1 non-essential" (doc) vs "AC 1 Non-Essential" (const.py). A gate strict
+on case would only ever flag those two, which is not a rename or a removal;
+the interesting drift this file exists to catch is entities appearing or
+disappearing, not their capitalisation.
+
+Four checks, in order of importance:
+
+1. No orphaned documentation row: every entity name in a documentation table
+   exists as a `name` on some definition mapped to that file.
+2. No undocumented entity: every `name` on a mapped definition list appears
+   in its file's tables.
+3. Every table that names entities is actually routed to a platform: a table
+   whose section header carries no platform keyword and which has no `Type`
+   column of its own is invisible to checks 1 and 2 - this test catches that
+   directly, instead of relying on someone noticing a table went silent.
+4. The mapping itself is complete: every definition list construction
+   discovered in const.py, and every file under documentation/entities/, is
+   named by FAMILY_TO_FILE (the catalog file for that family) or
+   FAMILY_TO_EXTRA_ORPHAN_FILES (a file documenting a subset of a family's
+   entities, without being required to carry the full list). A new list or a
+   new file nobody wired in fails loudly instead of passing unchecked.
+
+To make this pass after adding, renaming or removing an entity: update the
+matching row in the entity's documentation file. To add a new device family:
+add its const.py list(s) to FAMILY_TO_FILE together with the doc file that
+catalogs it.
+
+Both real-word exceptions (a device that legitimately does not document an
+entity, or a doc row that legitimately does not name a literal entity) are
+recorded as explicit, reasoned exclusions below - never as a silent skip.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from custom_components.ecoflow_energy import const
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCS_DIR = REPO_ROOT / "documentation" / "entities"
+
+# Platform name -> the dataclass its const.py list holds.
+DEF_CLASSES: dict[str, type] = {
+    "sensors": const.EcoFlowSensorDef,
+    "binary_sensors": const.EcoFlowBinarySensorDef,
+    "switches": const.EcoFlowSwitchDef,
+    "numbers": const.EcoFlowNumberDef,
+    "selects": const.EcoFlowSelectDef,
+}
+
+# Longest suffix first, so "_BINARY_SENSORS" is tried before "_SENSORS" (a
+# name ending "_BINARY_SENSORS" also ends "_SENSORS").
+_SUFFIX_TO_PLATFORM: dict[str, str] = {
+    "_BINARY_SENSORS": "binary_sensors",
+    "_SENSORS": "sensors",
+    "_SWITCHES": "switches",
+    "_NUMBERS": "numbers",
+    "_SELECTS": "selects",
+}
+_SUFFIXES_LONGEST_FIRST = sorted(_SUFFIX_TO_PLATFORM, key=len, reverse=True)
+
+
+def _discover_definition_lists() -> dict[str, dict[str, list]]:
+    """Introspect const.py module attributes: {family: {platform: [Def...]}}.
+
+    A module attribute counts if its name ends in one of the five platform
+    suffixes and it is a list. If the list is non-empty, its first element
+    must be an instance of the platform's dataclass - this rejects an
+    unrelated list that happens to share a name suffix by accident.
+    """
+    result: dict[str, dict[str, list]] = {}
+    for attr_name in dir(const):
+        if attr_name.startswith("_"):
+            continue
+        value = getattr(const, attr_name)
+        if not isinstance(value, list):
+            continue
+        platform = None
+        family = None
+        for suffix in _SUFFIXES_LONGEST_FIRST:
+            if attr_name.endswith(suffix) and len(attr_name) > len(suffix):
+                platform = _SUFFIX_TO_PLATFORM[suffix]
+                family = attr_name[: -len(suffix)]
+                break
+        if platform is None or family is None:
+            continue
+        if value and not isinstance(value[0], DEF_CLASSES[platform]):
+            continue
+        result.setdefault(family, {})[platform] = value
+    return result
+
+
+DEFINITION_LISTS = _discover_definition_lists()
+
+# Domain knowledge: which doc file documents which const.py family. Kept as
+# an explicit mapping (never derived from the family name itself) so a typo
+# or a new device shows up as a failure in test_mapping_is_complete rather
+# than silently mapping to nothing.
+FAMILY_TO_FILE: dict[str, str] = {
+    "POWEROCEAN": "powerocean.md",
+    "DELTA2MAX": "delta-2-max.md",
+    "SMARTPLUG": "smart-plug.md",
+    "STREAM": "stream.md",
+    "STREAMAC5000": "stream-ac-5000.md",
+    "DELTA3": "delta-3-max-plus.md",
+    "POWERSTREAM": "powerstream.md",
+    "SMARTMETER": "smart-meter.md",
+    "SOLARTRACKER": "solar-tracker.md",
+    "WAVE3": "wave-3.md",
+}
+
+# Doc files that document a SUBSET of a family's entities under their own
+# heading, rather than being that family's catalog. stream-ac-pro.md is a
+# supplementary wire-protocol reference (confirmed cmd_id/field numbers for
+# the Stream AC Pro's controls) whose "Entity" columns name real STREAM_*
+# entities - so every row it has must still resolve to one (test 1 runs
+# against it), but it is never required to carry the family's full entity
+# list (test 2 does not run against it) because stream.md already is that
+# catalog. One-directional on purpose: mapping it into FAMILY_TO_FILE
+# instead would make every STREAM entity absent from this three-table file
+# report as undocumented, which is not the drift this gate exists to catch.
+FAMILY_TO_EXTRA_ORPHAN_FILES: dict[str, tuple[str, ...]] = {
+    "STREAM": ("stream-ac-pro.md",),
+}
+
+
+def _key(name: str) -> str:
+    return name.strip().lower()
+
+
+# ---------------------------------------------------------------------------
+# Markdown table parsing
+# ---------------------------------------------------------------------------
+
+_PLATFORM_KEYWORDS: tuple[tuple[str, str], ...] = (
+    ("climate", "climate"),
+    ("binary sensor", "binary_sensors"),
+    ("switch", "switches"),
+    ("number", "numbers"),
+    ("select", "selects"),
+    ("sensor", "sensors"),  # after "binary sensor" - would also match it
+)
+
+_TYPE_COLUMN_MAP: dict[str, str] = {
+    "sensor": "sensors",
+    "binary sensor": "binary_sensors",
+    "switch": "switches",
+    "number": "numbers",
+    "select": "selects",
+    "climate": "climate",
+}
+
+_TABLE_SEP_RE = re.compile(r"^\|?[\s:|-]+\|?$")
+
+# Sections whose table rows are a human template ("Pack N ...", "Slave N
+# ..."), not literal per-instance entity names - the real per-instance
+# names (Pack 1 SoC, Slave 2 Voltage, ...) are excluded from the
+# "undocumented" check instead, by pattern (see EXCLUDE_FROM_UNDOCUMENTED).
+#
+# Each entry skips every table under that "## " header, not just one: the
+# powerocean.md entry alone covers TWO tables ("Core sensors per pack", 7
+# rows, and "Diagnostic sensors per pack (all disabled)", 10 rows) that both
+# sit under the single "## Sensors - Battery Packs" header. The rows these
+# two entries skip are not unchecked forever - TEMPLATE_FAMILIES below reads
+# them directly (bypassing this skip) to build a real per-instance equality
+# check against const.py, instead of the open-ended pattern exclusion this
+# skip alone would otherwise require.
+SKIP_SECTIONS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("powerocean.md", "Sensors - Battery Packs (up to 5x BP5000)"),
+        ("delta-2-max.md", "Sensors - Expansion Battery Packs (disabled)"),
+    }
+)
+
+
+def _classify_header(header_text: str) -> str | None:
+    lowered = header_text.lower()
+    for keyword, platform in _PLATFORM_KEYWORDS:
+        if keyword in lowered:
+            return platform
+    return None
+
+
+def _clean_cell(text: str) -> str:
+    return text.strip().strip("*").strip("`").strip()
+
+
+@dataclass(frozen=True)
+class _ParsedDoc:
+    # {platform: [(raw_entity_name, 1-based source line), ...]}
+    documented: dict[str, list[tuple[str, int]]]
+    # (1-based header line, section header) for every table whose first
+    # column is named "Entity" but whose rows _parse_doc_tables drops on
+    # the floor - see the class docstring below.
+    unclassified_entity_tables: list[tuple[int, str]]
+
+
+def _parse_doc_tables(path: Path) -> _ParsedDoc:
+    """Return the per-platform rows of every table in ``path``, plus every
+    table this parser could not route anywhere.
+
+    Walks H2 (``## ``) sections top to bottom. A table's rows are attributed
+    to the platform named by its section header (matched by keyword, so
+    "## Sensors - Battery" still counts as "sensors"). If the table itself
+    carries a "Type" column, that column decides the platform per row
+    instead - this is how PowerOcean's mixed "Controls" and "Scheduled
+    Charge Tasks" tables (Entity | Type | ...) get their rows routed
+    correctly even though their section headers name neither platform.
+
+    A table can therefore fall through both routes: no keyword in its
+    section header AND no "Type" column of its own. Its rows are silently
+    absent from every check - not an orphan, not undocumented, just gone.
+    That is exactly what happened to stream.md's Stream Micro table before
+    it was fixed to carry a "Type" column: a renamed entity in it passed
+    the whole suite. Rather than special-case that one table, every table
+    whose header starts with an "Entity" column is checked here for having
+    *some* route to a platform; test_every_entity_table_is_classified turns
+    a non-empty ``unclassified_entity_tables`` into a failure.
+
+    Names are returned raw (not deduplicated, not case-normalised, not
+    compression-expanded) - callers decide how to match them, because the
+    two checks need different tolerance (see _expand_compressed_name).
+    """
+    documented: dict[str, list[tuple[str, int]]] = {p: [] for p in DEF_CLASSES}
+    documented["climate"] = []
+    unclassified: list[tuple[int, str]] = []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    section_platform: str | None = None
+    section_header = ""
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        if line.startswith("## "):
+            section_header = line[3:].strip()
+            section_platform = _classify_header(section_header)
+            i += 1
+            continue
+        is_table_start = (
+            line.strip().startswith("|")
+            and i + 1 < n
+            and _TABLE_SEP_RE.match(lines[i + 1].strip()) is not None
+        )
+        if is_table_start:
+            if (path.name, section_header) in SKIP_SECTIONS:
+                i += 2
+                while i < n and lines[i].strip().startswith("|"):
+                    i += 1
+                continue
+            header_cells = [_clean_cell(c) for c in line.strip().strip("|").split("|")]
+            type_idx = next(
+                (
+                    idx
+                    for idx, cell in enumerate(header_cells)
+                    if cell.lower() == "type"
+                ),
+                None,
+            )
+            if (
+                type_idx is None
+                and section_platform is None
+                and header_cells
+                and header_cells[0].lower() == "entity"
+            ):
+                unclassified.append((i + 1, section_header))
+            i += 2  # header + separator
+            while i < n and lines[i].strip().startswith("|"):
+                cells = [_clean_cell(c) for c in lines[i].strip().strip("|").split("|")]
+                if cells and cells[0] and cells[0] not in ("-", ""):
+                    name = cells[0]
+                    if type_idx is not None and type_idx < len(cells):
+                        platform = _TYPE_COLUMN_MAP.get(cells[type_idx].lower())
+                    else:
+                        platform = section_platform
+                    if platform is not None:
+                        documented[platform].append((name, i + 1))
+                i += 1
+            continue
+        i += 1
+    return _ParsedDoc(documented, unclassified)
+
+
+_DOC_TABLE_CACHE: dict[str, _ParsedDoc] = {}
+
+
+def _parsed_doc(filename: str) -> _ParsedDoc:
+    if filename not in _DOC_TABLE_CACHE:
+        _DOC_TABLE_CACHE[filename] = _parse_doc_tables(DOCS_DIR / filename)
+    return _DOC_TABLE_CACHE[filename]
+
+
+def _doc_tables(filename: str) -> dict[str, list[tuple[str, int]]]:
+    return _parsed_doc(filename).documented
+
+
+_TRAILING_PAREN_RE = re.compile(r"^(.+) \((\w+)\)$")
+
+
+def _expand_compressed_name(raw: str) -> set[str]:
+    """A cell may compress several full entity names into one documentation
+    row. Three conventions are used across these files:
+
+    1. Full-phrase alternation, space-slash-space: "Max Cell Temp / Min
+       Cell Temp" is "Max Cell Temp" and "Min Cell Temp", each side already
+       a complete name.
+    2. A single alternating word/segment with a shared prefix and/or suffix
+       around it: "Battery Max/Min Cell Temp" is "Battery Max Cell Temp"
+       and "Battery Min Cell Temp"; "Grid Phase A/B/C Voltage" is three
+       per-phase sensors; "PCS AC/DC Error Code" is two.
+    3. A trailing parenthetical qualifier moved out of word order: "Cell
+       Temp (Max)" is "Max Cell Temp" (stream-ac-5000.md's Battery
+       Diagnostics table).
+
+    Returns every name the row could plausibly expand to, always including
+    the raw text itself. Callers only ever treat a candidate as a match once
+    it is independently confirmed against a real, known entity name - an
+    unused candidate here (e.g. from the wrong convention firing) is inert,
+    never a false positive.
+    """
+    candidates = {raw}
+
+    paren_match = _TRAILING_PAREN_RE.match(raw)
+    if paren_match:
+        base, qualifier = paren_match.groups()
+        candidates.add(f"{qualifier} {base.strip()}")
+
+    if "/" not in raw:
+        return candidates
+
+    # Convention 1: every side of " / " is already a complete name.
+    if " / " in raw:
+        parts = [p.strip() for p in raw.split(" / ") if p.strip()]
+        if len(parts) > 1:
+            candidates.update(parts)
+
+    # Convention 2: exactly one word token itself carries the "/" - split
+    # that token and distribute the words around it as a shared prefix and
+    # suffix. Skip a bare "/" token (that's convention 1's job).
+    words = raw.split()
+    for idx, word in enumerate(words):
+        if word == "/" or "/" not in word:
+            continue
+        options = [o.strip() for o in word.split("/") if o.strip()]
+        if len(options) < 2:
+            continue
+        prefix = " ".join(words[:idx])
+        suffix = " ".join(words[idx + 1 :])
+        for option in options:
+            candidates.add(" ".join(part for part in (prefix, option, suffix) if part))
+
+    return candidates
+
+
+def _expand_slash_list(text: str) -> set[str]:
+    """Expand a per-instance template field's suffix text into the literal
+    suffixes it stands for - the counterpart to _expand_compressed_name used
+    only by the TEMPLATE_FAMILIES checks below (Pack N / Slave N).
+
+    Handles two shapes that _expand_compressed_name does not, because both
+    are made of MULTI-WORD phrases rather than the single alternating word
+    that function's convention 2 covers:
+
+    1. A ' / '-joined list of phrases sharing a common trailing suffix -
+       "Input / Output" -> {"Input", "Output"} (no shared suffix: every part
+       has the same word count as the last, so nothing is split off).
+       "Remaining / Full Capacity" -> {"Remaining Capacity", "Full Capacity"}
+       (the last part carries one extra trailing word, "Capacity", which
+       becomes the shared suffix appended to every part).
+       "Max MOSFET / HV MOSFET / LV MOSFET Temp" -> {"Max MOSFET Temp", "HV
+       MOSFET Temp", "LV MOSFET Temp"} (same rule, three parts).
+       This only fires when every part except the last has an EQUAL word
+       count - the one shape observed in this repo's doc tables. A ' / '
+       list that does not fit (parts of varying, non-trailing-suffix
+       lengths) falls through unexpanded, which fails the equality check
+       loudly rather than guessing.
+    2. Delegates to _expand_compressed_name's own word-level "/" convention
+       for the remaining case ("Max/Min Cell Temp", "Design/Full Capacity"),
+       since that one is already correct for a single word carrying the
+       slash.
+
+    A plain text with no slash at all comes back unchanged, as a
+    single-element set.
+    """
+    if " / " in text:
+        parts = [p.strip() for p in text.split(" / ") if p.strip()]
+        if len(parts) > 1:
+            lead_counts = {len(p.split()) for p in parts[:-1]}
+            if len(lead_counts) == 1:
+                k = lead_counts.pop()
+                last_words = parts[-1].split()
+                if len(last_words) >= k:
+                    suffix = " ".join(last_words[k:])
+                    own_texts = [*parts[:-1], " ".join(last_words[:k])]
+                    return {f"{own} {suffix}".strip() for own in own_texts}
+
+    return _expand_compressed_name(text) - {text} or {text}
+
+
+@dataclass(frozen=True)
+class TemplateFamily:
+    """A documentation section that writes one row per FIELD ("Pack N SoC")
+    instead of one row per real per-instance entity ("Pack 1 SoC" ..
+    "Pack 5 SoC") - see the module docstring, item 1 (finding 1, PLAN-129
+    step 2). The instance count is read from the document's own prose
+    (range_pattern) instead of hard-coded, so a 6th const.py instance the
+    doc still calls 5 fails loudly instead of matching an open-ended regex.
+    """
+
+    doc_file: str
+    family: str
+    platform: str
+    prefix: str  # e.g. "Pack " - literal text directly before the instance number
+    section_header: str  # exact "## " text; the table(s) this reads from
+    range_pattern: re.Pattern[
+        str
+    ]  # searched over the whole file text; group(1) = highest instance number
+
+
+TEMPLATE_FAMILIES: tuple[TemplateFamily, ...] = (
+    TemplateFamily(
+        "powerocean.md",
+        "POWEROCEAN",
+        "sensors",
+        "Pack ",
+        "Sensors - Battery Packs (up to 5x BP5000)",
+        re.compile(r"up to (\d+)x BP5000"),
+    ),
+    TemplateFamily(
+        "delta-2-max.md",
+        "DELTA2MAX",
+        "sensors",
+        "Slave ",
+        "Sensors - Expansion Battery Packs (disabled)",
+        re.compile(r"Two expansion packs \(Slave 1, Slave (\d+)\)"),
+    ),
+)
+
+
+def _read_template_rows(path: Path, section_header: str) -> list[str]:
+    """Raw first-column text of every row in every table under
+    `section_header` in `path` - the counterpart to SKIP_SECTIONS, which
+    drops these same rows from the platform-routed checks because they are
+    field templates ("Pack N SoC"), not literal entity names. Used only to
+    build the per-instance expected-name set below.
+    """
+    lines = path.read_text(encoding="utf-8").splitlines()
+    rows: list[str] = []
+    in_section = False
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        if line.startswith("## "):
+            in_section = line[3:].strip() == section_header
+            i += 1
+            continue
+        is_table_start = (
+            in_section
+            and line.strip().startswith("|")
+            and i + 1 < n
+            and _TABLE_SEP_RE.match(lines[i + 1].strip()) is not None
+        )
+        if is_table_start:
+            i += 2
+            while i < n and lines[i].strip().startswith("|"):
+                cells = [_clean_cell(c) for c in lines[i].strip().strip("|").split("|")]
+                if cells and cells[0] and cells[0] not in ("-", ""):
+                    rows.append(cells[0])
+                i += 1
+            continue
+        i += 1
+    return rows
+
+
+def _template_expected_names(tf: TemplateFamily) -> tuple[set[str], range]:
+    doc_text = (DOCS_DIR / tf.doc_file).read_text(encoding="utf-8")
+    match = tf.range_pattern.search(doc_text)
+    assert match, (
+        f"could not find the instance-count range for {tf.family}/{tf.platform} "
+        f"in {tf.doc_file} using {tf.range_pattern.pattern!r} - the document "
+        f"text changed shape; update the range_pattern rather than guessing "
+        f"a number"
+    )
+    instance_range = range(1, int(match.group(1)) + 1)
+
+    raw_rows = _read_template_rows(DOCS_DIR / tf.doc_file, tf.section_header)
+    assert raw_rows, (
+        f"no template rows found under '{tf.section_header}' in {tf.doc_file}"
+    )
+    placeholder = f"{tf.prefix}N "
+    suffixes: set[str] = set()
+    for raw in raw_rows:
+        assert raw.startswith(placeholder), (
+            f"template row {raw!r} in {tf.doc_file} does not start with "
+            f"{placeholder!r} - TEMPLATE_FAMILIES' prefix is stale"
+        )
+        suffixes.update(_expand_slash_list(raw[len(placeholder) :]))
+
+    expected = {
+        f"{tf.prefix}{i} {suffix}" for i in instance_range for suffix in suffixes
+    }
+    return expected, instance_range
+
+
+@pytest.mark.parametrize(
+    "tf", TEMPLATE_FAMILIES, ids=lambda tf: f"{tf.family}_{tf.platform}"
+)
+def test_template_family_matches_const_py(tf: TemplateFamily):
+    """The generative counterpart to the Pack N / Slave N exclusions in
+    EXCLUDE_FROM_UNDOCUMENTED: instead of trusting any name matching
+    '^Pack \\d+ ' as documented, expand the doc's own template rows over the
+    doc's own stated instance range and require the result to be EXACTLY
+    the const.py names in that (family, platform) - not a subset. A 6th
+    PowerOcean pack in const.py, or a doc row whose field text no longer
+    matches a real suffix, fails this instead of silently matching the
+    open-ended regex.
+    """
+    expected, instance_range = _template_expected_names(tf)
+    actual = {
+        d.name
+        for d in DEFINITION_LISTS[tf.family][tf.platform]
+        if re.match(rf"^{re.escape(tf.prefix)}\d+ ", d.name)
+    }
+    missing = expected - actual
+    extra = actual - expected
+    assert not missing and not extra, (
+        f"{tf.family}_{tf.platform.upper()}'s '{tf.prefix}N' template "
+        f"(instance range {instance_range.start}-{instance_range.stop - 1}, "
+        f"read from {tf.doc_file}) does not match const.py exactly.\n"
+        f"missing from const.py: {sorted(missing)}\n"
+        f"in const.py but not implied by the template: {sorted(extra)}"
+    )
+
+
+_SCHEDULE_RANGE_PATTERN = re.compile(r"up to Schedule (\d+)")
+
+
+@pytest.mark.parametrize(
+    "platform", ["sensors", "binary_sensors", "switches", "numbers"]
+)
+def test_schedule_template_matches_const_py(platform: str):
+    """Same idea as test_template_family_matches_const_py, but the Schedule
+    table is a different shape: it already carries a 'Type' column and its
+    one literal row names real instance 1 ('Schedule 1 Enabled', ...) rather
+    than a placeholder ('Schedule N Enabled') - so this reads that row
+    straight from the already-parsed, already-platform-routed doc tables
+    instead of a raw section scan, and spans all four platforms the
+    Scheduled Charge Tasks table produces.
+    """
+    doc_text = (DOCS_DIR / "powerocean.md").read_text(encoding="utf-8")
+    match = _SCHEDULE_RANGE_PATTERN.search(doc_text)
+    assert match, "could not find 'up to Schedule N' in powerocean.md"
+    instance_range = range(1, int(match.group(1)) + 1)
+
+    rows = _doc_tables("powerocean.md")[platform]
+    schedule_1_rows = [name for name, _line in rows if name.startswith("Schedule 1 ")]
+    assert schedule_1_rows, (
+        f"no literal 'Schedule 1 ...' row routed to platform {platform!r} in "
+        f"powerocean.md"
+    )
+    suffixes = {name[len("Schedule 1 ") :] for name in schedule_1_rows}
+
+    expected = {f"Schedule {i} {suffix}" for i in instance_range for suffix in suffixes}
+    actual = {
+        d.name
+        for d in DEFINITION_LISTS["POWEROCEAN"][platform]
+        if re.match(r"^Schedule \d+ ", d.name)
+    }
+    missing = expected - actual
+    extra = actual - expected
+    assert not missing and not extra, (
+        f"POWEROCEAN_{platform.upper()}'s Schedule template (instance range "
+        f"{instance_range.start}-{instance_range.stop - 1}, read from "
+        f"powerocean.md) does not match const.py exactly.\n"
+        f"missing from const.py: {sorted(missing)}\n"
+        f"in const.py but not implied by the template: {sorted(extra)}"
+    )
+
+
+def _row_is_orphan_free(raw: str, known_keys: set[str]) -> bool:
+    """A documentation row names a real entity, or - when it compresses
+    several names into one row - names only real entities.
+
+    This is deliberately not "any of _expand_compressed_name's candidates
+    matches". That function unions every convention's guesses into one flat
+    set so test_no_undocumented_entity can ask "does some row plausibly
+    cover this definition" - a permissive OR, correct for that direction.
+    Orphan-checking asks the opposite question, "does this row plausibly
+    document something real", and OR is wrong for it: a row compressing
+    three names ("WiFi / Ethernet / 4G Status") passed as long as ONE of
+    the three existed, so deleting the other two left it silently green.
+
+    A row with no compression convention (the common case) still only has
+    to match itself - the raw text and the trailing-paren rewrite both name
+    ONE entity under two spellings, so either is enough. Convention 1
+    (" / ", full-phrase alternation) and convention 2 (one word carrying the
+    "/") both compress MULTIPLE independent entities into a single row, so
+    every part they produce must resolve - hence the ``all()`` below, and
+    the early return the moment one of those conventions fires.
+    """
+    if _key(raw) in known_keys:
+        return True
+
+    paren_match = _TRAILING_PAREN_RE.match(raw)
+    if paren_match:
+        base, qualifier = paren_match.groups()
+        if _key(f"{qualifier} {base.strip()}") in known_keys:
+            return True
+
+    if " / " in raw:
+        parts = [p.strip() for p in raw.split(" / ") if p.strip()]
+        if len(parts) > 1:
+            return all(_key(p) in known_keys for p in parts)
+
+    words = raw.split()
+    for idx, word in enumerate(words):
+        if word == "/" or "/" not in word:
+            continue
+        options = [o.strip() for o in word.split("/") if o.strip()]
+        if len(options) < 2:
+            continue
+        prefix = " ".join(words[:idx])
+        suffix = " ".join(words[idx + 1 :])
+        expanded = [
+            " ".join(part for part in (prefix, option, suffix) if part)
+            for option in options
+        ]
+        return all(_key(e) in known_keys for e in expanded)
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Reasoned exclusions - real, checked-by-hand gaps between const.py and the
+# docs. Every entry names the (family, platform) it applies to, a pattern on
+# the *name*, and why. None of these paper over a rename or a deletion; the
+# discipline above (regex-based, not a literal enumeration) is deliberate so
+# a new device or a new schedule slot does not need a new line here.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Exclusion:
+    family: str
+    platform: str
+    pattern: re.Pattern[str]
+    reason: str
+
+
+# Entities in const.py that are correctly *not* found as a literal doc row.
+EXCLUDE_FROM_UNDOCUMENTED: tuple[Exclusion, ...] = (
+    Exclusion(
+        "POWEROCEAN",
+        "sensors",
+        re.compile(r"^Pack \d+ "),
+        "documented via the 'Pack N ...' template row in "
+        "'## Sensors - Battery Packs (up to 5x BP5000)', not as five "
+        "literal per-pack rows",
+    ),
+    Exclusion(
+        "POWEROCEAN",
+        "sensors",
+        re.compile(r"^Schedule ([2-9]|[1-9]\d+) "),
+        "only 'Schedule 1 ...' is a literal table row in "
+        "'## Scheduled Charge Tasks'; slots 2-8 are covered by the prose "
+        "'Further schedules follow the same pattern ... up to Schedule 8'",
+    ),
+    Exclusion(
+        "POWEROCEAN",
+        "binary_sensors",
+        re.compile(r"^Schedule ([2-9]|[1-9]\d+) "),
+        "same schedule-pattern prose as the sensors above",
+    ),
+    Exclusion(
+        "POWEROCEAN",
+        "numbers",
+        re.compile(r"^Schedule ([2-9]|[1-9]\d+) "),
+        "same schedule-pattern prose as the sensors above",
+    ),
+    Exclusion(
+        "POWEROCEAN",
+        "switches",
+        re.compile(r"^Schedule ([2-9]|[1-9]\d+) "),
+        "same schedule-pattern prose as the sensors above",
+    ),
+    Exclusion(
+        "DELTA2MAX",
+        "sensors",
+        re.compile(r"^Slave \d+ "),
+        "documented via the 'Slave N ...' template row in "
+        "'## Sensors - Expansion Battery Packs (disabled)', not as two "
+        "literal per-pack rows",
+    ),
+    Exclusion(
+        "DELTA2MAX",
+        "sensors",
+        re.compile(r"^(PD|Inverter|BMS|MPPT) (Error|Fault) Code$"),
+        "the doc row 'PD / Inverter / BMS / MPPT Error/Fault Code' "
+        "compresses two independent alternations - which source pairs with "
+        "which suffix is not recoverable from the text alone, so this is a "
+        "manual exclusion rather than a general decompression rule",
+    ),
+    Exclusion(
+        "DELTA3",
+        "binary_sensors",
+        re.compile(r"^Port Priority Active$"),
+        "FINDING: named only in the '## Port priority' prose ('The Port "
+        "Priority Active binary sensor reports whether it is currently in "
+        "effect'), never as a table row - delta-3-max-plus.md has no "
+        "'## Binary Sensors' section at all",
+    ),
+    Exclusion(
+        "STREAM",
+        "switches",
+        re.compile(r"^AC Outlet [12]$"),
+        "FINDING: stream.md's '## Switches' section reads 'None. The AC "
+        "outlets are exposed read-only as binary sensors...', but "
+        "STREAM_SWITCHES defines AC Outlet 1/2 as enhanced_only switches. "
+        "The doc line predates that write path; see stream-ac-pro.md's "
+        "'## Outlet Controls' for the same two switches documented as "
+        "controls, under a different file",
+    ),
+    Exclusion(
+        "STREAMAC5000",
+        "sensors",
+        re.compile(r"^BMS SoC$"),
+        "FINDING: const.py names key bms_soc_precise_pct 'BMS SoC'; the doc "
+        "row for the same pack-level BMS reading (line 27 of "
+        "stream-ac-5000.md, 'straight from the BMS ... this unit's own "
+        "rather than the system figure') is titled 'Precise SoC' instead. "
+        "Same reading, two different labels - a rename on one side that "
+        "never reached the other",
+    ),
+    Exclusion(
+        "POWEROCEAN",
+        "sensors",
+        re.compile(r"^PV Inverter Power$"),
+        "FINDING: the row exists at powerocean.md:148 but a blank line "
+        "plus a blockquote note sit between it and its table's header/"
+        "separator (lines 132-133) - GFM terminates a table at the first "
+        "non-'|' line, so this row does not render as part of the MPPT "
+        "table at all on the published page, only as literal pipe-delimited "
+        "text",
+    ),
+    Exclusion(
+        "STREAM",
+        "sensors",
+        re.compile(r"^PV [1-4] Energy$"),
+        "FINDING: the doc row 'PV 1 Energy to PV 4 Energy' in "
+        "'## Sensors - Energy Dashboard' is an English range, not a '/'"
+        "-joined compression - _expand_compressed_name does not parse "
+        "'X to Y' ranges, so this stays a manual exclusion",
+    ),
+    Exclusion(
+        "STREAM",
+        "sensors",
+        re.compile(r"^Battery (Charge|Discharge) Capacity$"),
+        "FINDING: documented only in prose directly under the Energy "
+        "Dashboard table ('Also available as disabled diagnostics: "
+        "**Battery Charge Capacity** and **Battery Discharge Capacity** "
+        "(Ah)'), never as a table row - same shape as the DELTA3 'Port "
+        "Priority Active' entry above",
+    ),
+)
+
+# Documentation rows that are correctly *not* a literal const.py name.
+EXCLUDE_FROM_ORPHAN: tuple[Exclusion, ...] = (
+    Exclusion(
+        "DELTA2MAX",
+        "sensors",
+        re.compile(r"^PD / Inverter / BMS / MPPT Error/Fault Code$"),
+        "compresses two independent alternations (source x suffix) that "
+        "are not recoverable from the text alone - see the matching "
+        "EXCLUDE_FROM_UNDOCUMENTED entry for the four real names",
+    ),
+    Exclusion(
+        "STREAMAC5000",
+        "sensors",
+        re.compile(r"^Precise SoC$"),
+        "FINDING: doc name for const.py's 'BMS SoC' (key "
+        "bms_soc_precise_pct) - see the matching EXCLUDE_FROM_UNDOCUMENTED "
+        "entry",
+    ),
+    Exclusion(
+        "STREAM",
+        "sensors",
+        re.compile(r"^PV 1 Energy to PV 4 Energy$"),
+        "range notation in '## Sensors - Energy Dashboard' standing for "
+        "four literal entities (PV 1 Energy .. PV 4 Energy), not a literal "
+        "name itself",
+    ),
+)
+
+
+def _matches_any(
+    name: str, family: str, platform: str, exclusions: tuple[Exclusion, ...]
+) -> bool:
+    return any(
+        exc.family == family and exc.platform == platform and exc.pattern.match(name)
+        for exc in exclusions
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: the mapping itself is complete
+# ---------------------------------------------------------------------------
+
+
+def test_every_const_family_is_mapped_to_a_doc_file():
+    families = set(DEFINITION_LISTS)
+    mapped = set(FAMILY_TO_FILE)
+    unmapped = families - mapped
+    assert not unmapped, (
+        f"const.py defines definition lists for {sorted(unmapped)} that "
+        f"FAMILY_TO_FILE in this test does not map to a documentation file"
+    )
+    stale = mapped - families
+    assert not stale, (
+        f"FAMILY_TO_FILE names {sorted(stale)}, but const.py no longer "
+        f"defines a definition list for that family"
+    )
+
+
+def test_every_doc_file_is_named_by_the_mapping():
+    doc_files = {p.name for p in DOCS_DIR.glob("*.md")}
+    extra_files = {f for files in FAMILY_TO_EXTRA_ORPHAN_FILES.values() for f in files}
+    mapped_files = set(FAMILY_TO_FILE.values()) | extra_files
+    missing = doc_files - mapped_files
+    assert not missing, (
+        f"documentation/entities/ has {sorted(missing)}, which neither "
+        f"FAMILY_TO_FILE nor FAMILY_TO_EXTRA_ORPHAN_FILES accounts for"
+    )
+    stale = mapped_files - doc_files
+    assert not stale, (
+        f"the mapping names {sorted(stale)}, but that file no longer "
+        f"exists under documentation/entities/"
+    )
+
+
+def test_every_entity_table_is_classified():
+    """Catches the general form of the Stream Micro gap: a table with an
+    "Entity" first column that _parse_doc_tables cannot route to any
+    platform - no keyword in its section header, no "Type" column of its
+    own - is invisible to test_no_undocumented_entity and
+    test_no_orphaned_documentation_row alike. Both pass on a table that
+    carries no weight at all; a rename or removal inside it is invisible.
+    """
+    failures = [
+        f"  {path.name}:{line} (section '{header}')"
+        for path in sorted(DOCS_DIR.glob("*.md"))
+        for line, header in _parsed_doc(path.name).unclassified_entity_tables
+    ]
+    assert not failures, (
+        "table(s) with an 'Entity' column carry no platform to route their "
+        "rows to - add a 'Type' column to the table, or give its section a "
+        "'## ' header naming a platform (sensor/binary sensor/switch/"
+        "number/select):\n" + "\n".join(failures)
+    )
+
+
+def test_climate_entity_is_the_documented_wave3_thermostat():
+    """The 'climate' bucket in _PLATFORM_KEYWORDS / _TYPE_COLUMN_MAP is
+    collected by _parse_doc_tables like any other platform, but no
+    DEFINITION_LISTS family exists for it - the WAVE 3's one climate entity
+    is built directly in custom_components/ecoflow_energy/climate.py rather
+    than from a const.py list, so tests 1 and 2 cannot run against it the
+    way they do sensors/binary_sensors/switches/numbers/selects. Leaving it
+    collected and unread would hide a rename, a duplicate, or a second
+    climate row landing unnoticed. This is the narrow, honest substitute:
+    across every doc file, there is exactly one climate row, and it is
+    WAVE 3's.
+    """
+    climate_rows = [
+        (path.name, name)
+        for path in sorted(DOCS_DIR.glob("*.md"))
+        for name, _line in _doc_tables(path.name)["climate"]
+    ]
+    assert climate_rows == [("wave-3.md", "WAVE 3")], (
+        "expected exactly one climate-platform row across "
+        "documentation/entities/, WAVE 3's own thermostat card in "
+        f"wave-3.md; found {climate_rows}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests 1 and 2, per (family, platform)
+# ---------------------------------------------------------------------------
+
+_FAMILY_PLATFORM_PAIRS = [
+    (family, platform)
+    for family, platforms in DEFINITION_LISTS.items()
+    for platform in platforms
+    if family in FAMILY_TO_FILE
+]
+
+
+def _format_missing_row(definition, platform: str) -> str:
+    """Render a definition as a copy-paste-able row in the common
+    'Entity | Unit | Description' shape most tables in this repo use."""
+    name = definition.name
+    unit = getattr(definition, "unit", None)
+    if platform in ("sensors", "numbers") and unit:
+        return f"| {name} | {unit} | TODO |"
+    return f"| {name} | TODO |"
+
+
+@pytest.mark.parametrize("family,platform", _FAMILY_PLATFORM_PAIRS)
+def test_no_undocumented_entity(family: str, platform: str):
+    """Every const.py `name` on this list must appear in its doc file.
+
+    A documented key counts if it matches the definition's name directly, or
+    matches one of that row's compression candidates (see
+    _expand_compressed_name) - so "Grid Phase A/B/C Voltage" documents
+    "Grid Phase A Voltage" without a literal row for each phase.
+    """
+    filename = FAMILY_TO_FILE[family]
+    rows = _doc_tables(filename)[platform]
+    documented_keys: set[str] = set()
+    for raw_name, _line in rows:
+        documented_keys.update(_key(c) for c in _expand_compressed_name(raw_name))
+
+    definitions = DEFINITION_LISTS[family][platform]
+    missing = [
+        d
+        for d in definitions
+        if _key(d.name) not in documented_keys
+        and not _matches_any(d.name, family, platform, EXCLUDE_FROM_UNDOCUMENTED)
+    ]
+    if missing:
+        formatted = "\n".join(_format_missing_row(d, platform) for d in missing)
+        pytest.fail(
+            f"{family}_{platform.upper()} defines {len(missing)} entit"
+            f"{'y' if len(missing) == 1 else 'ies'} not documented in "
+            f"documentation/entities/{filename}. Add under the matching "
+            f"section (copy-paste, fill in the real values):\n{formatted}"
+        )
+
+
+@pytest.mark.parametrize("family,platform", _FAMILY_PLATFORM_PAIRS)
+def test_no_orphaned_documentation_row(family: str, platform: str):
+    """Every documented entity name must exist as a `name` on this list.
+
+    Checks the family's catalog file (FAMILY_TO_FILE) and every file that
+    documents a subset of it (FAMILY_TO_EXTRA_ORPHAN_FILES) - a row in
+    either one is only accepted when _row_is_orphan_free confirms every
+    entity it names (there can be more than one compressed into a single
+    row) is real.
+    """
+    filenames = (FAMILY_TO_FILE[family], *FAMILY_TO_EXTRA_ORPHAN_FILES.get(family, ()))
+    definitions = DEFINITION_LISTS[family][platform]
+    known_keys = {_key(d.name) for d in definitions}
+
+    orphans: list[tuple[str, str, int]] = []
+    for filename in filenames:
+        for raw_name, line in _doc_tables(filename)[platform]:
+            if _row_is_orphan_free(raw_name, known_keys):
+                continue
+            if _matches_any(raw_name, family, platform, EXCLUDE_FROM_ORPHAN):
+                continue
+            orphans.append((filename, raw_name, line))
+
+    if orphans:
+        entry_name = f"{family}_{platform.upper()}"
+        listing = "\n".join(
+            f"  {filename}:{line}: '{raw_name}' has no {entry_name} entry"
+            for filename, raw_name, line in sorted(orphans, key=lambda t: (t[0], t[2]))
+        )
+        pytest.fail(
+            f"{len(orphans)} {platform} row(s) mapped to {family} document "
+            f"no matching entry in {entry_name}:\n{listing}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Finding 5: documentation/README.md's Entity Reference counts are prose,
+# gated by nothing. Every count below is computed from the REAL per-platform
+# def-getter functions (sensor.py/binary_sensor.py/switch.py/number.py/
+# select.py's `_get_*_defs`) combined with const.filter_defs_for_serial -
+# the exact functions and filter Home Assistant itself calls at entity-setup
+# time - for a representative serial per device, never from DEFINITION_LISTS
+# directly. That is what makes this a real gate instead of a restatement:
+# DEFINITION_LISTS ignores the enhanced_only/control-prefix/serial-exclusion
+# filtering the doc's counts already account for (Stream's non-BK31 units
+# get 1 number, not STREAM_NUMBERS' 4; Stream Micro gets 21 of STREAM_
+# SENSORS' 55).
+# ---------------------------------------------------------------------------
+
+from custom_components.ecoflow_energy.binary_sensor import (  # noqa: E402
+    _get_binary_sensor_defs,
+)
+from custom_components.ecoflow_energy.number import _get_number_defs  # noqa: E402
+from custom_components.ecoflow_energy.select import _get_select_defs  # noqa: E402
+from custom_components.ecoflow_energy.sensor import _get_sensor_defs  # noqa: E402
+from custom_components.ecoflow_energy.switch import _get_switch_defs  # noqa: E402
+
+README_DOC_PATH = REPO_ROOT / "documentation" / "README.md"
+
+_COUNT_UNIT_TO_PLATFORM: dict[str, str] = {
+    "sensor": "sensors",
+    "sensors": "sensors",
+    "binary sensor": "binary_sensors",
+    "binary sensors": "binary_sensors",
+    "switch": "switches",
+    "switches": "switches",
+    "number": "numbers",
+    "numbers": "numbers",
+    "select": "selects",
+    "selects": "selects",
+    "climate": "climate",
+}
+_COUNT_RE = re.compile(
+    r"(\d+)\s+(binary sensors?|sensors?|switches?|numbers?|selects?|climate)\b"
+)
+
+
+def _parse_counts(segment: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for value, unit in _COUNT_RE.findall(segment):
+        platform = _COUNT_UNIT_TO_PLATFORM[unit]
+        counts[platform] = counts.get(platform, 0) + int(value)
+    return counts
+
+
+def _bullet_segment(doc_text: str, label: str) -> str:
+    """The Entity Reference bullet for `label`, from just after the closing
+    ')' of its markdown link to the end of the line."""
+    pattern = re.compile(
+        rf"^- \[{re.escape(label)}\]\([^)]*\)\s*-\s*(.*)$", re.MULTILINE
+    )
+    match = pattern.search(doc_text)
+    assert match, f"no Entity Reference bullet for {label!r} in documentation/README.md"
+    return match.group(1)
+
+
+def _primary_and_footnote(segment: str) -> tuple[str, str]:
+    """Split a bullet's text at its first '(`...`' parenthetical (the
+    serial-prefix list) into the primary count segment and whatever follows
+    the matching close paren (a footnote clause, if any)."""
+    idx = segment.find("(`")
+    if idx == -1:
+        return segment, ""
+    depth = 0
+    i = idx
+    while i < len(segment):
+        if segment[i] == "(":
+            depth += 1
+        elif segment[i] == ")":
+            depth -= 1
+            if depth == 0:
+                break
+        i += 1
+    footnote = segment[i + 1 :] if i < len(segment) else ""
+    return segment[:idx], footnote
+
+
+def _real_counts(device_type: str, device_sn: str) -> dict[str, int]:
+    """The entity count Home Assistant would actually create for
+    `device_type`/`device_sn`, per platform - the real def-getter functions
+    plus the same filter_defs_for_serial call the platforms make."""
+    filt = const.filter_defs_for_serial
+    return {
+        "sensors": len(filt(_get_sensor_defs(device_type), device_sn)),
+        "binary_sensors": len(filt(_get_binary_sensor_defs(device_type), device_sn)),
+        "switches": len(filt(_get_switch_defs(device_type, device_sn), device_sn)),
+        "numbers": len(filt(_get_number_defs(device_type, device_sn), device_sn)),
+        "selects": len(filt(_get_select_defs(device_type, device_sn), device_sn)),
+    }
+
+
+# (bullet label, device_type, representative serial) - devices whose bullet
+# has no footnote clause and no non-const.py platform (climate), so their
+# whole stated count can be checked as one primary segment. Stream, Delta 3
+# Max Plus and WAVE 3 have their own dedicated tests below instead.
+_ENTITY_REFERENCE_SIMPLE_DEVICES: tuple[tuple[str, str, str], ...] = (
+    ("PowerOcean", const.DEVICE_TYPE_POWEROCEAN, "HJ31XXXXXXXXXXXX"),
+    ("Delta 2 Max", const.DEVICE_TYPE_DELTA, "R351XXXXXXXXXXXX"),
+    ("Smart Plug", const.DEVICE_TYPE_SMARTPLUG, "HW52XXXXXXXXXXXX"),
+    ("Stream Micro", const.DEVICE_TYPE_STREAM, "BK01XXXXXXXXXXXX"),
+    ("PowerStream", const.DEVICE_TYPE_POWERSTREAM, "HW51XXXXXXXXXXXX"),
+    ("STREAM AC 5000", const.DEVICE_TYPE_STREAM_AC5000, "ES22XXXXXXXXXXXX"),
+    ("Smart Meter", const.DEVICE_TYPE_SMART_METER, "BK21XXXXXXXXXXXX"),
+    ("Solar Tracker", const.DEVICE_TYPE_SOLAR_TRACKER, "HZ31XXXXXXXXXXXX"),
+)
+
+
+@pytest.mark.parametrize(
+    "label,device_type,device_sn",
+    _ENTITY_REFERENCE_SIMPLE_DEVICES,
+    ids=[label for label, _dt, _sn in _ENTITY_REFERENCE_SIMPLE_DEVICES],
+)
+def test_readme_entity_reference_counts_match_const_py(
+    label: str, device_type: str, device_sn: str
+):
+    segment, _footnote = _primary_and_footnote(
+        _bullet_segment(README_DOC_PATH.read_text(encoding="utf-8"), label)
+    )
+    stated = _parse_counts(segment)
+    assert stated, f"no entity counts parsed from the {label!r} bullet: {segment!r}"
+    actual = _real_counts(device_type, device_sn)
+    mismatches = {
+        p: (stated_n, actual[p])
+        for p, stated_n in stated.items()
+        if stated_n != actual[p]
+    }
+    assert not mismatches, (
+        f"documentation/README.md's {label!r} bullet states {stated}, but "
+        f"the real entity count for serial {device_sn!r} is {actual} - "
+        f"mismatched platforms (stated, actual): {mismatches}"
+    )
+
+
+def test_readme_stream_primary_and_footnote_counts_match_const_py():
+    """Stream's bullet states a base count (any BK-serial, no controls) plus
+    a footnote delta for BK31 (adds the write-capable numbers/switches) -
+    both sides checked against the real per-serial counts."""
+    doc_text = README_DOC_PATH.read_text(encoding="utf-8")
+    primary, footnote = _primary_and_footnote(_bullet_segment(doc_text, "Stream"))
+    base = _real_counts(const.DEVICE_TYPE_STREAM, "BK11XXXXXXXXXXXX")
+    bk31 = _real_counts(const.DEVICE_TYPE_STREAM, "BK31XXXXXXXXXXXX")
+
+    stated_primary = _parse_counts(primary)
+    assert stated_primary, (
+        f"no counts parsed from Stream's primary segment: {primary!r}"
+    )
+    mismatches = {p: (n, base[p]) for p, n in stated_primary.items() if n != base[p]}
+    assert not mismatches, (
+        f"Stream primary count mismatch (stated, actual): {mismatches}"
+    )
+
+    stated_footnote = _parse_counts(footnote)
+    assert stated_footnote, f"no counts parsed from Stream's footnote: {footnote!r}"
+    delta = {p: bk31[p] - base[p] for p in bk31}
+    mismatches = {p: (n, delta[p]) for p, n in stated_footnote.items() if n != delta[p]}
+    assert not mismatches, (
+        f"Stream BK31 footnote mismatch (stated, actual delta): {mismatches}"
+    )
+
+
+def test_readme_delta3_primary_and_footnote_counts_match_const_py():
+    """Delta 3 Max Plus's bullet states a base count (P231/P321/D3N1/D3M1
+    without port priority) plus a footnote delta for D3M serials (adds the
+    port-priority switches/numbers/binary sensor)."""
+    doc_text = README_DOC_PATH.read_text(encoding="utf-8")
+    primary, footnote = _primary_and_footnote(
+        _bullet_segment(doc_text, "Delta 3 Max Plus")
+    )
+    base = _real_counts(const.DEVICE_TYPE_DELTA3, "P231XXXXXXXXXXXX")
+    d3m = _real_counts(const.DEVICE_TYPE_DELTA3, "D3M1XXXXXXXXXXXX")
+
+    stated_primary = _parse_counts(primary)
+    assert stated_primary, (
+        f"no counts parsed from Delta 3 Max Plus's primary segment: {primary!r}"
+    )
+    mismatches = {p: (n, base[p]) for p, n in stated_primary.items() if n != base[p]}
+    assert not mismatches, (
+        f"Delta 3 Max Plus primary count mismatch (stated, actual): {mismatches}"
+    )
+
+    stated_footnote = _parse_counts(footnote)
+    assert stated_footnote, (
+        f"no counts parsed from Delta 3 Max Plus's footnote: {footnote!r}"
+    )
+    delta = {p: d3m[p] - base[p] for p in d3m}
+    mismatches = {p: (n, delta[p]) for p, n in stated_footnote.items() if n != delta[p]}
+    assert not mismatches, (
+        f"Delta 3 Max Plus D3M footnote mismatch (stated, actual delta): {mismatches}"
+    )
+
+
+def test_readme_wave3_counts_match_const_py():
+    """WAVE 3's bullet states '1 climate' alongside the const.py-backed
+    platforms; climate.py builds that one thermostat directly rather than
+    from a DEFINITION_LISTS list (see test_climate_entity_is_the_documented_
+    wave3_thermostat above), so it is checked as a fixed fact here instead
+    of computed from const.py."""
+    doc_text = README_DOC_PATH.read_text(encoding="utf-8")
+    segment, _footnote = _primary_and_footnote(_bullet_segment(doc_text, "WAVE 3"))
+    stated = _parse_counts(segment)
+    climate = stated.pop("climate", None)
+    assert climate == 1, (
+        f"WAVE 3 bullet states {climate} climate entities, expected exactly 1"
+    )
+    actual = _real_counts(const.DEVICE_TYPE_WAVE3, "AC71XXXXXXXXXXXX")
+    mismatches = {p: (n, actual[p]) for p, n in stated.items() if n != actual[p]}
+    assert not mismatches, (
+        f"WAVE 3 bullet count mismatch (stated, actual): {mismatches}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 6: a positive control for this gate itself. Every claim about how
+# strict test_no_undocumented_entity / test_no_orphaned_documentation_row /
+# test_every_entity_table_is_classified actually are had been checked by
+# hand, three times, by three different people - none of that survives the
+# next edit to this file. This plants one of each defect in a throwaway doc
+# file and a throwaway definition list and asserts each check catches it.
+# ---------------------------------------------------------------------------
+
+
+def test_gate_catches_an_orphaned_row(tmp_path: Path):
+    doc = tmp_path / "synthetic.md"
+    doc.write_text(
+        "## Sensors\n\n"
+        "| Entity | Unit | Description |\n"
+        "|:---|:---:|:---|\n"
+        "| Real Sensor | W | the one real entity |\n"
+        "| Ghost Sensor | W | names nothing in known_keys |\n",
+        encoding="utf-8",
+    )
+    parsed = _parse_doc_tables(doc)
+    known_keys = {_key("Real Sensor")}
+    orphans = [
+        raw
+        for raw, _line in parsed.documented["sensors"]
+        if not _row_is_orphan_free(raw, known_keys)
+    ]
+    assert orphans == ["Ghost Sensor"]
+
+
+def test_gate_catches_an_undocumented_entity():
+    class _FakeDef:
+        def __init__(self, name: str):
+            self.name = name
+
+    documented_keys = {_key("Real Sensor")}
+    definitions = [_FakeDef("Real Sensor"), _FakeDef("Missing Sensor")]
+    missing = [d for d in definitions if _key(d.name) not in documented_keys]
+    assert [d.name for d in missing] == ["Missing Sensor"]
+
+
+def test_gate_catches_an_unclassified_entity_table(tmp_path: Path):
+    doc = tmp_path / "synthetic.md"
+    doc.write_text(
+        "## Something With No Platform Keyword\n\n"
+        "| Entity | Description |\n"
+        "|:---|:---|\n"
+        "| Whatever | never routed anywhere |\n",
+        encoding="utf-8",
+    )
+    parsed = _parse_doc_tables(doc)
+    assert parsed.unclassified_entity_tables == [
+        (3, "Something With No Platform Keyword")
+    ]


### PR DESCRIPTION
The entity documents under `documentation/entities/` were written by hand and nothing ever compared them with `const.py`. A renamed entity left a stale row behind, a new one was documented or not depending on who remembered, and neither direction was visible to anyone.

## The gate

`tests/test_entity_documentation.py` now checks both directions and runs in CI:

- no documented row without a matching definition
- no definition without a documented row
- every table in every document lands in a platform section, so a table can no longer be skipped in silence
- the mapping between definition families and document files is complete in both directions, so a new definition list or a new document that nobody wired in fails rather than passing unchecked
- the per-device counts in `documentation/README.md` match `const.py`

When it fails it prints the missing rows in the documents' own table syntax, so filling a gap is copy-paste rather than transcription.

Where a document writes one template row instead of five literal ones, the instance range is read **from the document** ("up to 5x BP5000", "Slave 1, Slave 2") and compared with `const.py` for exact equality. Expanding the template from whatever definitions happen to exist would have been circular and would have passed for any number of packs; this way a sixth pack in `const.py` fails the test, because the document still says five.

## Documents corrected

Four things were already out of step and are fixed here rather than excused:

- `stream-ac-pro.md` listed `AC Outlet 1 State` and `AC Outlet 2 State`, which are not entity names. They document the wire field behind the `AC Outlet 1` and `AC Outlet 2` binary sensors, and its table now carries a `Type` column so the two SoC limits are marked as the numbers they are.
- `stream.md`'s Stream Micro section was a `Group | Entities` table packing several names per cell, which no reader could match against anything. It is now a normal per-entity section.
- `powerocean.md` wrote `WiFi / Ethernet / 4G Status`, a compression that resolved only through `4G Status`; the other two names matched nothing at all and could have been deleted without any test noticing.
- Four further mismatches are recorded in the test as findings with their reasons rather than fixed here, because each is a documentation question rather than a naming one.

## README

The "How It Compares" table had an "Others" column describing what other integrations do. That column judged projects this one does not test and cannot speak for, and it is removed. Two of its claims about *this* integration were wrong as well: an account sign-in is required in Enhanced Mode, and the energy figures adopt the device's own lifetime counters where it reports them. The section is now called "How It Works" and describes only this integration.

Highlights gains the HACS default listing, which nothing anywhere said, and the sensor count is now given as the largest device (235) instead of "over 200 per device", which was true of one family out of ten.

## Migration guide

`documentation/migration-from-another-integration.md` is new: what carries over when someone switches from a different EcoFlow integration, what has to be re-pointed by hand, and an order of steps that keeps the old entities running until the new ones are confirmed. It names no other project and compares nothing.

Its claims about the recorder are checked against the installed Home Assistant rather than assumed. Two that read as obvious are false: removing an integration does not delete its long-term statistics, and disabling an entity does not free its entity id.

## Verification

- `pytest tests/test_entity_documentation.py` - 96 passed
- full suite - 3427 passed, 1 skipped
- the gate was mutation-probed in both directions on four different documents, and the template check was probed by adding a sixth battery pack that the document does not mention
- no change under `custom_components/`, so no version bump and no CHANGELOG entry
