### PR TITLE
Give every device type its own protobuf command table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.21.0] - 2026-09-08
+
+### Changed
+
+- (pending)
+
 ## [1.20.0] - 2026-09-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- (pending)
+- Nothing about the software changes for anyone using it. Internally, the table that decides which protobuf message a device's frame is read as now exists once per device type instead of once for the whole integration. Until now a single table answered for every device, and two device families that use the same command numbers for different messages were kept apart only by the order in which the code happens to ask, which no test could check. Each family now has its own table and the caller has to say which device it is decoding for, so one family can never read another family's message by accident. Every frame in the recordings on file was replayed before and after the change and produced exactly the same readings.
 
 ## [1.20.0] - 2026-09-07
 

--- a/custom_components/ecoflow_energy/coordinator/mqtt_ingest.py
+++ b/custom_components/ecoflow_energy/coordinator/mqtt_ingest.py
@@ -582,11 +582,13 @@ class MqttIngestMixin(_Base):
 
         if b"\x0a" in payload[:4]:
             try:
-                # Device-type routing comes first: (cmd_func, cmd_id) pairs are
-                # not unique across device classes. The Stream AC Pro uses the
-                # very same (254, 21) main status frame as the Delta 3
-                # generation, so a generic registry lookup would hand a Stream
-                # frame to the Delta 3 parser and drop the Stream telemetry.
+                # These families keep their own parsers and never reach the
+                # command registry: (cmd_func, cmd_id) pairs are not unique
+                # across device classes, and the Stream AC Pro uses the very
+                # same (254, 21) main status frame as the Delta 3 generation.
+                # Since ADR-024 the registry is keyed per device type as well,
+                # so the split below is the parser choice, not the guard that
+                # keeps one family from reading another family's message.
                 if self.device_type == DEVICE_TYPE_STREAM:
                     return parse_stream_proto_message(payload)
                 # Same reason: an ES22 shares (32, 2) and (32, 50) with the

--- a/custom_components/ecoflow_energy/coordinator/mqtt_ingest.py
+++ b/custom_components/ecoflow_energy/coordinator/mqtt_ingest.py
@@ -611,7 +611,9 @@ class MqttIngestMixin(_Base):
                 if self.device_type == DEVICE_TYPE_POWEROCEAN:
                     return self._parse_powerocean_proto_frame(payload)
 
-                result = decode_proto_runtime_frame(payload)
+                result = decode_proto_runtime_frame(
+                    payload, device_type=self.device_type
+                )
                 self._record_unknown_fields(result.mapped)
                 raw = {k: v for k, v in result.mapped.items() if not k.startswith("_")}
                 # Delta 3 generation: status frame and battery heartbeat.
@@ -683,7 +685,9 @@ class MqttIngestMixin(_Base):
         # The envelope decode stays guarded because the get_reply caller has no
         # guard of its own and runs on the Paho thread.
         try:
-            results = decode_proto_runtime_headers(payload)
+            results = decode_proto_runtime_headers(
+                payload, device_type=self.device_type
+            )
         except Exception:
             _LOGGER.debug(
                 "PowerOcean protobuf decode error for %s",

--- a/custom_components/ecoflow_energy/ecoflow/proto/runtime.py
+++ b/custom_components/ecoflow_energy/ecoflow/proto/runtime.py
@@ -256,7 +256,8 @@ def _registry_for(device_type: str) -> dict[tuple[int, int], CmdConfig]:
         if device_type not in _LOGGED_UNKNOWN_DEVICE_TYPES:
             _LOGGED_UNKNOWN_DEVICE_TYPES.add(device_type)
             _LOGGER.debug(
-                "No protobuf command registry table for device type %s",
+                "Device type %s has no protobuf command registry table; "
+                "its frames are read by its own parser or not at all",
                 device_type,
             )
         return {}

--- a/custom_components/ecoflow_energy/ecoflow/proto/runtime.py
+++ b/custom_components/ecoflow_energy/ecoflow/proto/runtime.py
@@ -5,11 +5,12 @@ Each command tuple maps to a CmdConfig that defines message class, flags, field
 renames, and zero-fill rules. The generic decode loop handles all message types
 uniformly.
 
-Contract: the registry is device-type agnostic. A command tuple is NOT unique
-across device classes - the Stream AC Pro and the Delta 3 generation both use
-(254, 21) as their main status frame. Callers must therefore route by device
-type BEFORE consuming a decode result, and must never treat a registry hit as
-proof that the frame belongs to the device they are decoding for.
+Contract: the registry is namespaced by device type (ADR-024). A command
+tuple is NOT unique across device classes - the Stream AC Pro and the Delta 3
+generation both use (254, 21) as their main status frame - so every table
+lives under its own `DEVICE_TYPE_*` key and every entry point below requires
+the caller's device type as a keyword argument. There is no default and no
+union lookup: a caller that cannot name its device type cannot decode.
 """
 
 from __future__ import annotations
@@ -22,6 +23,7 @@ from google.protobuf.json_format import MessageToDict
 from google.protobuf.message import DecodeError
 from google.protobuf.unknown_fields import UnknownFieldSet
 
+from ..const import DEVICE_TYPE_DELTA3, DEVICE_TYPE_POWEROCEAN
 from .decoder import decode_header_message
 
 _LOGGER = logging.getLogger(__name__)
@@ -62,14 +64,16 @@ class CmdConfig:
     decode_empty_payload: bool = False
 
 
-def _build_cmd_registry() -> dict[tuple[int, int], CmdConfig]:
-    """Build (cmd_func, cmd_id) -> CmdConfig registry.
+def _build_cmd_registry() -> dict[str, dict[tuple[int, int], CmdConfig]]:
+    """Build device_type -> (cmd_func, cmd_id) -> CmdConfig registry (ADR-024).
 
-    Lazy-loaded to avoid an import-time pb2 dependency. The key is the full
-    command tuple because cmd_id values are only unique within a command
-    family: PowerOcean uses cmd_func=96, the Delta 3 generation uses 254
-    (system status) and 32 (battery heartbeat), and their cmd_id ranges
-    overlap.
+    Lazy-loaded to avoid an import-time pb2 dependency. Each device type owns
+    a full table of its own; nothing is shared between PowerOcean and Delta 3
+    here, because cmd_id values are only unique within a command family:
+    PowerOcean uses cmd_func=96, the Delta 3 generation uses 254 (system
+    status) and 32 (battery heartbeat), and their cmd_id ranges overlap. The
+    device-type namespace is what keeps a Delta 3 frame from ever reaching a
+    PowerOcean CmdConfig, or the reverse.
     """
     try:
         from . import ecocharge_pb2 as pb2
@@ -79,6 +83,14 @@ def _build_cmd_registry() -> dict[tuple[int, int], CmdConfig]:
         )
         return {}
 
+    return {
+        DEVICE_TYPE_POWEROCEAN: _build_powerocean_table(pb2),
+        DEVICE_TYPE_DELTA3: _build_delta3_table(pb2),
+    }
+
+
+def _build_powerocean_table(pb2: Any) -> dict[tuple[int, int], CmdConfig]:
+    """PowerOcean's (cmd_func, cmd_id) -> CmdConfig table."""
     return {
         (96, 33): CmdConfig(
             msg_class=pb2.JTS1EnergyStreamReport,
@@ -183,7 +195,12 @@ def _build_cmd_registry() -> dict[tuple[int, int], CmdConfig]:
             flags={"_is_timer_task_list": True},
             decode_empty_payload=True,
         ),
-        # --- Delta 3 generation ---
+    }
+
+
+def _build_delta3_table(pb2: Any) -> dict[tuple[int, int], CmdConfig]:
+    """Delta 3 generation's (cmd_func, cmd_id) -> CmdConfig table."""
+    return {
         # Main status frame: full every 120 s, incremental about every 2 s.
         (254, 21): CmdConfig(
             msg_class=pb2.Delta3DisplayProperty,
@@ -203,9 +220,9 @@ def _build_cmd_registry() -> dict[tuple[int, int], CmdConfig]:
         # This tuple is NOT Delta 3 exclusive, and the entry does not make it
         # so: the Stream family uses (32, 50) for its own battery message,
         # where field 25 is the precise state of charge rather than a float
-        # SoC. Stream frames never reach this registry because `mqtt_ingest`
-        # routes by device type first - which is exactly the routing contract
-        # in this module's docstring, and the reason it exists.
+        # SoC. A Stream frame cannot land in this table at all - it is looked
+        # up under DEVICE_TYPE_STREAM, which owns its own parser and never
+        # reaches this registry (ADR-024).
         (32, 50): CmdConfig(
             msg_class=pb2.Delta3BmsHeartbeat,
             parse_path="typed_runtime:delta3_bms_heartbeat",
@@ -214,8 +231,36 @@ def _build_cmd_registry() -> dict[tuple[int, int], CmdConfig]:
     }
 
 
-_CMD_REGISTRY: dict[tuple[int, int], CmdConfig] | None = None
+_CMD_REGISTRY: dict[str, dict[tuple[int, int], CmdConfig]] | None = None
+_LOGGED_UNKNOWN_DEVICE_TYPES: set[str] = set()
 _FULL_POWER_KEYS = frozenset({"solar", "home_direct", "batt_pb", "grid_raw_f2"})
+
+
+def _registry_for(device_type: str) -> dict[tuple[int, int], CmdConfig]:
+    """Return the (cmd_func, cmd_id) table for one device type (ADR-024).
+
+    An unregistered tuple inside a known table is skipped silently, exactly
+    as before this split. A device type with no table at all is treated the
+    same way and returns an empty dict - never a union of every table, and
+    never a raise. The production callers run on the Paho thread inside a
+    broad `except Exception`, where a raise would cost the whole frame
+    instead of just the one command it could not place. A device type
+    missing its table is logged once per process, not once per frame, so a
+    steady stream of frames from an unmapped device does not spam the log.
+    """
+    global _CMD_REGISTRY
+    if _CMD_REGISTRY is None:
+        _CMD_REGISTRY = _build_cmd_registry()
+    table = _CMD_REGISTRY.get(device_type)
+    if table is None:
+        if device_type not in _LOGGED_UNKNOWN_DEVICE_TYPES:
+            _LOGGED_UNKNOWN_DEVICE_TYPES.add(device_type)
+            _LOGGER.debug(
+                "No protobuf command registry table for device type %s",
+                device_type,
+            )
+        return {}
+    return table
 
 
 def _empty_mapped() -> dict[str, Any]:
@@ -339,7 +384,7 @@ def _header_carries_no_pdata(header: dict[str, Any]) -> bool:
 
 
 def _typed_map_from_candidates(
-    header: dict[str, Any], candidates: list[tuple[bytes, str]]
+    header: dict[str, Any], candidates: list[tuple[bytes, str]], device_type: str
 ) -> tuple[dict[str, Any], str, bytes, str] | None:
     """Pick the first candidate that yields a usable mapping.
 
@@ -351,7 +396,7 @@ def _typed_map_from_candidates(
     """
     ranked_fallback: tuple[dict[str, Any], str, bytes, str] | None = None
     for source, reason_code in candidates:
-        typed = _typed_runtime_map([header], source)
+        typed = _typed_runtime_map([header], source, device_type)
         if typed is None:
             continue
         mapped, parse_path = typed
@@ -418,13 +463,11 @@ def unknown_field_summary(msg: Any) -> dict[int, Any]:
 
 
 def _typed_runtime_map(
-    headers: list[dict], source: bytes
+    headers: list[dict], source: bytes, device_type: str
 ) -> tuple[dict[str, Any], str] | None:
     """Declarative decode: command tuple -> MessageToDict -> rename -> flags."""
-    global _CMD_REGISTRY
-    if _CMD_REGISTRY is None:
-        _CMD_REGISTRY = _build_cmd_registry()
-    if not _CMD_REGISTRY:
+    registry = _registry_for(device_type)
+    if not registry:
         return None
 
     cmd_func = _header_value(headers, "cmd_func")
@@ -433,7 +476,7 @@ def _typed_runtime_map(
     if not isinstance(cmd_func, int) or not isinstance(cmd_id, int):
         return None
 
-    config = _CMD_REGISTRY.get((cmd_func, cmd_id))
+    config = registry.get((cmd_func, cmd_id))
     if config is None:
         return None
 
@@ -516,6 +559,8 @@ def _typed_runtime_map(
 def decode_proto_runtime_headers(
     payload_bytes: bytes,
     decoded_frame: tuple[list[dict], bytes | None] | None = None,
+    *,
+    device_type: str,
 ) -> list[ProtoRuntimeDecodeResult]:
     """Decode every typed header in one EcoFlow protobuf envelope.
 
@@ -526,16 +571,17 @@ def decode_proto_runtime_headers(
 
     `decoded_frame` lets a caller that already ran ``decode_header_message``
     hand the result over, so the envelope is not decoded twice per message.
+
+    `device_type` is required and keyword-only (ADR-024): it selects which
+    device type's table is consulted, and there is no default that would fall
+    back to searching every table.
     """
     if decoded_frame is not None:
         headers, payload = decoded_frame
     else:
         headers, payload = decode_header_message(payload_bytes)
 
-    global _CMD_REGISTRY
-    if _CMD_REGISTRY is None:
-        _CMD_REGISTRY = _build_cmd_registry()
-    registry = _CMD_REGISTRY or {}
+    registry = _registry_for(device_type)
 
     decoded: list[ProtoRuntimeDecodeResult] = []
     for header in headers or []:
@@ -575,7 +621,7 @@ def decode_proto_runtime_headers(
         ):
             candidates = [(b"", "typed_source_header_pdata_empty")]
 
-        best = _typed_map_from_candidates(header, candidates)
+        best = _typed_map_from_candidates(header, candidates, device_type)
         if best is None:
             continue
         mapped, parse_path, source, reason_code = best
@@ -593,10 +639,18 @@ def decode_proto_runtime_headers(
     return decoded
 
 
-def decode_proto_runtime_frame(payload_bytes: bytes) -> ProtoRuntimeDecodeResult:
-    """Decode one EcoFlow protobuf frame, preserving the legacy first result API."""
+def decode_proto_runtime_frame(
+    payload_bytes: bytes, *, device_type: str
+) -> ProtoRuntimeDecodeResult:
+    """Decode one EcoFlow protobuf frame, preserving the legacy first result API.
+
+    `device_type` is required and keyword-only (ADR-024), same contract as
+    `decode_proto_runtime_headers`.
+    """
     headers, payload = decode_header_message(payload_bytes)
-    decoded = decode_proto_runtime_headers(payload_bytes, (headers, payload))
+    decoded = decode_proto_runtime_headers(
+        payload_bytes, (headers, payload), device_type=device_type
+    )
     if decoded:
         first = decoded[0]
         # Keep the complete header list for callers that reuse it for generic
@@ -614,10 +668,8 @@ def decode_proto_runtime_frame(payload_bytes: bytes) -> ProtoRuntimeDecodeResult
     cmd_func = _header_value(headers, "cmd_func")
     cmd_id = _header_value(headers, "cmd_id")
 
-    global _CMD_REGISTRY
-    if _CMD_REGISTRY is None:
-        _CMD_REGISTRY = _build_cmd_registry()
-    typed_eligible = (cmd_func, cmd_id) in (_CMD_REGISTRY or {})
+    registry = _registry_for(device_type)
+    typed_eligible = (cmd_func, cmd_id) in registry
 
     if payload is not None:
         source = payload
@@ -648,7 +700,7 @@ def decode_proto_runtime_frame(payload_bytes: bytes) -> ProtoRuntimeDecodeResult
         source = payload_bytes
         reason_code = "typed_source_full_frame"
 
-    typed = _typed_runtime_map(headers, source)
+    typed = _typed_runtime_map(headers, source, device_type)
     if typed is not None:
         mapped, parse_path = typed
         return ProtoRuntimeDecodeResult(

--- a/custom_components/ecoflow_energy/manifest.json
+++ b/custom_components/ecoflow_energy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/shuette42/ecoflow-energy-ha/issues",
   "requirements": [],
-  "version": "1.20.0"
+  "version": "1.21.0"
 }

--- a/tests/ha/test_powerocean_bundled_frames.py
+++ b/tests/ha/test_powerocean_bundled_frames.py
@@ -5,7 +5,10 @@ from unittest.mock import patch
 import pytest
 
 from custom_components.ecoflow_energy.coordinator.mqtt_ingest import MqttIngestMixin
-from custom_components.ecoflow_energy.ecoflow.const import device_log_tag
+from custom_components.ecoflow_energy.ecoflow.const import (
+    DEVICE_TYPE_POWEROCEAN,
+    device_log_tag,
+)
 from custom_components.ecoflow_energy.ecoflow.proto.ecocharge_pb2 import (
     JTS1BpHeartbeatReport,
     JTS1EmsChangeReport,
@@ -24,6 +27,9 @@ class _PowerOceanParser(MqttIngestMixin):
     """Minimal parser host for the frame merge test."""
 
     device_sn = "R374MASKEDTEST"
+    # The registry is keyed per device type since ADR-024, and the mixin
+    # reads this attribute on the frame path.
+    device_type = DEVICE_TYPE_POWEROCEAN
     # The mixin logs through the coordinator tag, so the stub carries the
     # same masked form the real coordinator computes.
     device_tag = device_log_tag(device_sn)

--- a/tests/test_delta3_idle_shutdown.py
+++ b/tests/test_delta3_idle_shutdown.py
@@ -26,6 +26,7 @@ from ecoflow_energy.const import (
     DELTA3_IDLE_SHUTDOWNS,
     DELTA3_SELECTS,
 )
+from ecoflow_energy.ecoflow.const import DEVICE_TYPE_DELTA3
 from ecoflow_energy.ecoflow.delta3_commands import (
     DELTA3_SELECT_FIELDS,
     build_proto_command,
@@ -60,7 +61,7 @@ def _frame(inner: bytes) -> bytes:
 
 
 def _decode(frame: bytes) -> dict:
-    result = decode_proto_runtime_frame(frame)
+    result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_DELTA3)
     return {k: v for k, v in result.mapped.items() if not k.startswith("_")}
 
 

--- a/tests/test_delta3_port_priority.py
+++ b/tests/test_delta3_port_priority.py
@@ -352,7 +352,9 @@ class TestDelta3PlusIsReadByTheExistingParser:
 
         merged: dict = {}
         for frame in json.loads(cls.FRAMES.read_text())["frames"]:
-            result = decode_proto_runtime_frame(bytes.fromhex(frame["hex"]))
+            result = decode_proto_runtime_frame(
+                bytes.fromhex(frame["hex"]), device_type=DEVICE_TYPE_DELTA3
+            )
             raw = {k: v for k, v in result.mapped.items() if not k.startswith("_")}
             flags = result.mapped
             if flags.get("_is_delta3_display"):

--- a/tests/test_delta3_proto_parser.py
+++ b/tests/test_delta3_proto_parser.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ecoflow_energy.ecoflow.const import DEVICE_TYPE_DELTA3, DEVICE_TYPE_POWEROCEAN
 from ecoflow_energy.ecoflow.parsers.delta3_http import parse_delta3_http_quota
 from ecoflow_energy.ecoflow.parsers.delta3_proto import (
     parse_delta3_bms_heartbeat,
@@ -115,7 +116,7 @@ EQUIVALENT_HTTP_QUOTA: dict = {
 
 def _decode(frame: bytes) -> dict:
     """Run a frame through the runtime decoder and strip internal flags."""
-    result = decode_proto_runtime_frame(frame)
+    result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_DELTA3)
     return {k: v for k, v in result.mapped.items() if not k.startswith("_")}
 
 
@@ -124,7 +125,7 @@ class TestDisplayPropertyFrame:
 
     def test_frame_is_routed_to_the_delta3_decoder(self):
         frame = _build_frame(254, 21, _build_display_message().SerializeToString())
-        result = decode_proto_runtime_frame(frame)
+        result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_DELTA3)
         assert result.parse_path == "typed_runtime:delta3_display_property"
         assert result.mapped["_is_delta3_display"] is True
 
@@ -239,7 +240,9 @@ class TestCmsHeartbeatFrame:
         return _build_frame(32, 2, msg.SerializeToString())
 
     def test_frame_is_routed_to_the_delta3_decoder(self):
-        result = decode_proto_runtime_frame(self._frame())
+        result = decode_proto_runtime_frame(
+            self._frame(), device_type=DEVICE_TYPE_DELTA3
+        )
         assert result.parse_path == "typed_runtime:delta3_cms_heartbeat"
         assert result.mapped["_is_delta3_cms_heartbeat"] is True
 
@@ -308,7 +311,9 @@ class TestBmsHeartbeat:
         return _build_frame(32, 50, self._message().SerializeToString())
 
     def test_frame_is_routed_to_the_bms_decoder(self):
-        result = decode_proto_runtime_frame(self._frame())
+        result = decode_proto_runtime_frame(
+            self._frame(), device_type=DEVICE_TYPE_DELTA3
+        )
         assert result.parse_path == "typed_runtime:delta3_bms_heartbeat"
         assert result.mapped["_is_delta3_bms_heartbeat"] is True
 
@@ -396,7 +401,7 @@ class TestRegistryKeysRemainStable:
         msg = JTS1EnergyStreamReport()
         msg.mppt_pwr = 1500.0
         frame = _build_frame(96, 33, msg.SerializeToString())
-        result = decode_proto_runtime_frame(frame)
+        result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_POWEROCEAN)
         assert result.parse_path == "typed_runtime:energy_stream_report"
         assert result.mapped["solar"] == 1500.0
 
@@ -404,7 +409,7 @@ class TestRegistryKeysRemainStable:
         msg = Delta3DisplayProperty()
         msg.pow_in_sum_w = 100.0
         frame = _build_frame(254, 22, msg.SerializeToString())
-        result = decode_proto_runtime_frame(frame)
+        result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_DELTA3)
         assert result.parse_path == "typed_runtime:no_match"
 
 
@@ -424,7 +429,7 @@ class TestMultiHeaderEnvelope:
             + _build_frame(32, 2, heartbeat.SerializeToString())
         )
 
-        decoded = decode_proto_runtime_headers(frame)
+        decoded = decode_proto_runtime_headers(frame, device_type=DEVICE_TYPE_DELTA3)
 
         assert [item.parse_path for item in decoded] == [
             "typed_runtime:delta3_display_property",
@@ -434,7 +439,7 @@ class TestMultiHeaderEnvelope:
         assert decoded[1].mapped["v1p0"]["lcd_show_soc"] == 85
 
         # The legacy single-result API keeps the whole header list.
-        first = decode_proto_runtime_frame(frame)
+        first = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_DELTA3)
         assert first.parse_path == "typed_runtime:delta3_display_property"
         assert len(first.headers) == 3
 
@@ -451,7 +456,7 @@ class TestMultiHeaderEnvelope:
             + encode_field_bytes(2, display.SerializeToString())
         )
 
-        result = decode_proto_runtime_frame(frame)
+        result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_DELTA3)
 
         assert result.parse_path == "typed_runtime:delta3_display_property"
         assert result.parse_reason_code == "typed_source_payload_field"
@@ -506,7 +511,7 @@ class TestAcChargePowerLimit:
         )
         frame = bytes.fromhex(json.loads(fixture.read_text())["frame_hex"])
 
-        result = decode_proto_runtime_frame(frame)
+        result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_DELTA3)
         parsed = parse_delta3_display_property(
             {k: v for k, v in result.mapped.items() if not k.startswith("_")}
         )
@@ -594,7 +599,9 @@ def _bms_reports(frame: bytes) -> list[dict]:
     """Every BMS heartbeat in one envelope, in the order the device sent them."""
     return [
         {k: v for k, v in result.mapped.items() if not k.startswith("_")}
-        for result in decode_proto_runtime_headers(frame)
+        for result in decode_proto_runtime_headers(
+            frame, device_type=DEVICE_TYPE_DELTA3
+        )
         if result.mapped.get("_is_delta3_bms_heartbeat")
     ]
 

--- a/tests/test_delta3_proto_parser.py
+++ b/tests/test_delta3_proto_parser.py
@@ -408,6 +408,13 @@ class TestRegistryKeysRemainStable:
     def test_unknown_command_pair_is_ignored(self):
         msg = Delta3DisplayProperty()
         msg.pow_in_sum_w = 100.0
+        # Positive control: the registered neighbour of this cmd_id has to
+        # decode, or no_match below would also hold for an empty table.
+        control = decode_proto_runtime_frame(
+            _build_frame(254, 21, msg.SerializeToString()),
+            device_type=DEVICE_TYPE_DELTA3,
+        )
+        assert control.parse_path == "typed_runtime:delta3_display_property"
         frame = _build_frame(254, 22, msg.SerializeToString())
         result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_DELTA3)
         assert result.parse_path == "typed_runtime:no_match"

--- a/tests/test_delta3_screen_timeout.py
+++ b/tests/test_delta3_screen_timeout.py
@@ -22,6 +22,7 @@ from ecoflow_energy.const import (
     DELTA3_SCREEN_TIMEOUT_VALUES,
     DELTA3_SELECTS,
 )
+from ecoflow_energy.ecoflow.const import DEVICE_TYPE_DELTA3
 from ecoflow_energy.ecoflow.delta3_commands import (
     SCREEN_TIMEOUT_FIELD,
     SCREEN_TIMEOUT_PARAMS_KEY,
@@ -50,7 +51,7 @@ def _frame(inner: bytes) -> bytes:
 
 
 def _decode(frame: bytes) -> dict:
-    result = decode_proto_runtime_frame(frame)
+    result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_DELTA3)
     return {k: v for k, v in result.mapped.items() if not k.startswith("_")}
 
 

--- a/tests/test_powerocean_bundled_frames.py
+++ b/tests/test_powerocean_bundled_frames.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from ecoflow_energy.ecoflow.const import DEVICE_TYPE_POWEROCEAN
 from ecoflow_energy.ecoflow.parsers.powerocean_proto import (
     flatten_heartbeat,
     remap_bp_keys,
@@ -99,7 +100,9 @@ _PG_SECOND_UNIT_PDATA = bytes.fromhex(
 
 def test_powerglow_report_maps_all_four_heating_rod_readings() -> None:
     """A heating rod drawing power reports its two readings and two setpoints."""
-    results = decode_proto_runtime_headers(_build_header(212, 8, _PG_HEATING_PDATA))
+    results = decode_proto_runtime_headers(
+        _build_header(212, 8, _PG_HEATING_PDATA), device_type=DEVICE_TYPE_POWEROCEAN
+    )
 
     assert len(results) == 1
     assert results[0].mapped["_is_heating_rod_param"] is True
@@ -115,7 +118,9 @@ def test_powerglow_report_maps_all_four_heating_rod_readings() -> None:
 
 def test_powerglow_idle_report_is_a_real_zero_watts() -> None:
     """An idle rod reports 0 W rather than omitting the reading."""
-    results = decode_proto_runtime_headers(_build_header(212, 8, _PG_IDLE_PDATA))
+    results = decode_proto_runtime_headers(
+        _build_header(212, 8, _PG_IDLE_PDATA), device_type=DEVICE_TYPE_POWEROCEAN
+    )
     raw = {k: v for k, v in results[0].mapped.items() if not k.startswith("_")}
 
     assert remap_heating_rod_keys(raw) == {
@@ -133,7 +138,9 @@ def test_powerglow_target_power_is_not_an_echo_of_the_drawn_power() -> None:
     that separates the two fields, since they sit one watt apart whenever the
     rod is actually heating.
     """
-    results = decode_proto_runtime_headers(_build_header(212, 8, _PG_STANDBY_PDATA))
+    results = decode_proto_runtime_headers(
+        _build_header(212, 8, _PG_STANDBY_PDATA), device_type=DEVICE_TYPE_POWEROCEAN
+    )
     raw = {k: v for k, v in results[0].mapped.items() if not k.startswith("_")}
 
     assert remap_heating_rod_keys(raw) == {
@@ -152,7 +159,9 @@ def test_powerglow_field_map_holds_at_a_lower_draw() -> None:
     the layout - it is what keeps the whole-watt reading of fields 4 and 5 from
     resting on a single magnitude.
     """
-    results = decode_proto_runtime_headers(_build_header(212, 8, _PG_SECOND_UNIT_PDATA))
+    results = decode_proto_runtime_headers(
+        _build_header(212, 8, _PG_SECOND_UNIT_PDATA), device_type=DEVICE_TYPE_POWEROCEAN
+    )
     raw = {k: v for k, v in results[0].mapped.items() if not k.startswith("_")}
 
     assert remap_heating_rod_keys(raw) == {
@@ -165,7 +174,9 @@ def test_powerglow_field_map_holds_at_a_lower_draw() -> None:
 
 def test_powerglow_serial_never_reaches_a_sensor_key() -> None:
     """The rod's own serial identifies the report and is not published."""
-    results = decode_proto_runtime_headers(_build_header(212, 8, _PG_HEATING_PDATA))
+    results = decode_proto_runtime_headers(
+        _build_header(212, 8, _PG_HEATING_PDATA), device_type=DEVICE_TYPE_POWEROCEAN
+    )
     raw = {k: v for k, v in results[0].mapped.items() if not k.startswith("_")}
 
     assert raw["hr_sn"] == "X" * 16
@@ -216,7 +227,7 @@ def test_runtime_decodes_every_header_with_its_own_sequence() -> None:
         ),
     )
 
-    decoded = decode_proto_runtime_headers(bundle)
+    decoded = decode_proto_runtime_headers(bundle, device_type=DEVICE_TYPE_POWEROCEAN)
 
     assert [item.parse_path for item in decoded] == [
         "typed_runtime:energy_stream_report",
@@ -236,7 +247,7 @@ def test_single_header_runtime_api_remains_compatible() -> None:
     stream = JTS1EnergyStreamReport(mppt_pwr=1234.0, sys_load_pwr=200.0)
     frame = _build_header(96, 33, stream.SerializeToString())
 
-    result = decode_proto_runtime_frame(frame)
+    result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_POWEROCEAN)
 
     assert len(result.headers) == 1
     assert result.parse_path == "typed_runtime:energy_stream_report"
@@ -248,8 +259,8 @@ def test_empty_known_companion_header_is_guarded_not_decoded() -> None:
     """A zero-length known pdata does not create a bogus protobuf result."""
     frame = _build_header(96, 39, b"", seq=77, encrypted=True)
 
-    assert decode_proto_runtime_headers(frame) == []
-    result = decode_proto_runtime_frame(frame)
+    assert decode_proto_runtime_headers(frame, device_type=DEVICE_TYPE_POWEROCEAN) == []
+    result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_POWEROCEAN)
     assert result.parse_path == "typed_runtime:guarded_no_inner_payload"
     assert result.parse_reason_code == "typed_inner_payload_missing"
 
@@ -259,7 +270,7 @@ def test_pv_inverter_stream_has_sensor_key() -> None:
     message = JTS1EmsPVInvEnergyStreamReport(pv_inv_pwr=987.0)
     frame = _build_header(96, 39, message.SerializeToString())
 
-    result = decode_proto_runtime_headers(frame)[0]
+    result = decode_proto_runtime_headers(frame, device_type=DEVICE_TYPE_POWEROCEAN)[0]
 
     assert result.mapped["_is_pv_inv_energy_stream"] is True
     assert result.mapped["pv_inverter_power_w"] == 987.0
@@ -451,7 +462,7 @@ def test_multi_header_frame_with_outer_payload_still_decodes() -> None:
         + encode_field_bytes(2, stream.SerializeToString())
     )
 
-    result = decode_proto_runtime_frame(frame)
+    result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_POWEROCEAN)
 
     assert result.parse_path == "typed_runtime:energy_stream_report"
     assert result.parse_reason_code == "typed_source_payload_field"
@@ -469,7 +480,7 @@ def test_invalid_pdata_hex_falls_back_to_full_frame() -> None:
         "ecoflow_energy.ecoflow.proto.runtime.decode_header_message",
         return_value=([{"cmd_func": 96, "cmd_id": 33, "pdata": "zznothex"}], None),
     ):
-        result = decode_proto_runtime_frame(frame)
+        result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_POWEROCEAN)
 
     assert result.parse_reason_code == "typed_source_full_frame_invalid_pdata"
     assert result.parse_path == "typed_runtime:energy_stream_report"
@@ -490,7 +501,7 @@ def test_enc_type_flag_with_plaintext_pdata_still_decodes() -> None:
         xor_payload=False,
     ) + _build_header(96, 39, b"", seq=0x1333)
 
-    decoded = decode_proto_runtime_headers(frame)
+    decoded = decode_proto_runtime_headers(frame, device_type=DEVICE_TYPE_POWEROCEAN)
 
     assert len(decoded) == 1
     assert decoded[0].parse_path == "typed_runtime:energy_stream_report"
@@ -508,7 +519,7 @@ def test_cmd_func_and_cmd_id_come_from_the_same_header() -> None:
         96, 33, stream.SerializeToString()
     )
 
-    decoded = decode_proto_runtime_headers(frame)
+    decoded = decode_proto_runtime_headers(frame, device_type=DEVICE_TYPE_POWEROCEAN)
 
     assert len(decoded) == 1
     assert decoded[0].parse_path == "typed_runtime:energy_stream_report"
@@ -541,7 +552,7 @@ def test_real_r374_get_all_fixture_decodes_all_supported_headers() -> None:
     }
     assert {(96, 1), (96, 8), (96, 33), (96, 39)} <= command_pairs
 
-    decoded = decode_proto_runtime_headers(frame)
+    decoded = decode_proto_runtime_headers(frame, device_type=DEVICE_TYPE_POWEROCEAN)
     parse_paths = {result.parse_path for result in decoded}
 
     assert {
@@ -549,12 +560,21 @@ def test_real_r374_get_all_fixture_decodes_all_supported_headers() -> None:
         "typed_runtime:ems_change",
         "typed_runtime:energy_stream_report",
     } <= parse_paths
-    assert len(decode_proto_runtime_frame(frame).headers) == 19
+    assert (
+        len(
+            decode_proto_runtime_frame(
+                frame, device_type=DEVICE_TYPE_POWEROCEAN
+            ).headers
+        )
+        == 19
+    )
 
 
 def _ems_state_keys(frame: bytes) -> dict[str, object]:
     """Decode a bundle and return the cmd_id=17 report as sensor keys."""
-    for result in decode_proto_runtime_headers(frame):
+    for result in decode_proto_runtime_headers(
+        frame, device_type=DEVICE_TYPE_POWEROCEAN
+    ):
         if result.parse_path == "typed_runtime:ems_state":
             raw = {
                 key: value
@@ -574,7 +594,12 @@ def test_r374_fixture_carries_a_cmd_17_report() -> None:
     """
     frame = _R374_GET_ALL_FIXTURE.read_bytes()
 
-    paths = [result.parse_path for result in decode_proto_runtime_headers(frame)]
+    paths = [
+        result.parse_path
+        for result in decode_proto_runtime_headers(
+            frame, device_type=DEVICE_TYPE_POWEROCEAN
+        )
+    ]
 
     assert "typed_runtime:ems_state" in paths
     assert "typed_runtime:ems_change" in paths
@@ -665,7 +690,9 @@ def test_non_zero_lifetime_energy_total_is_still_converted() -> None:
 
 def _ems_change_keys(frame: bytes) -> dict[str, object]:
     """Decode a bundle and return the cmd_id=8 report as sensor keys."""
-    for result in decode_proto_runtime_headers(frame):
+    for result in decode_proto_runtime_headers(
+        frame, device_type=DEVICE_TYPE_POWEROCEAN
+    ):
         if result.parse_path == "typed_runtime:ems_change":
             raw = {
                 key: value
@@ -719,7 +746,9 @@ def test_module_inventory_decodes_every_serial_in_its_role() -> None:
     )
     assert len(payload) == 80
 
-    decoded = decode_proto_runtime_headers(_build_header(96, 3, payload))
+    decoded = decode_proto_runtime_headers(
+        _build_header(96, 3, payload), device_type=DEVICE_TYPE_POWEROCEAN
+    )
 
     assert len(decoded) == 1
     assert decoded[0].parse_path == "typed_runtime:error_change"

--- a/tests/test_powerocean_timer_task.py
+++ b/tests/test_powerocean_timer_task.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from base64 import b64encode
 
+from custom_components.ecoflow_energy.ecoflow.const import DEVICE_TYPE_POWEROCEAN
 from custom_components.ecoflow_energy.ecoflow.parsers.powerocean_proto import (
     remap_timer_task_keys,
 )
@@ -60,7 +61,9 @@ def _header(cmd_func: int, cmd_id: int, pdata: bytes) -> bytes:
 
 def _decode(pdata: bytes) -> dict:
     """Run one payload through the registry the way a real frame does."""
-    result = decode_proto_runtime_frame(_header(96, 10, pdata))
+    result = decode_proto_runtime_frame(
+        _header(96, 10, pdata), device_type=DEVICE_TYPE_POWEROCEAN
+    )
     assert result.mapped.get("_is_timer_task_list"), result.parse_path
     return {k: v for k, v in result.mapped.items() if not k.startswith("_")}
 

--- a/tests/test_powerpulse_edev_wallbox.py
+++ b/tests/test_powerpulse_edev_wallbox.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import pytest
 
+from custom_components.ecoflow_energy.ecoflow.const import DEVICE_TYPE_POWEROCEAN
 from custom_components.ecoflow_energy.ecoflow.parsers.powerocean_proto import (
     remap_pile_charging_keys,
 )
@@ -119,7 +120,7 @@ def _header(cmd_func: int, cmd_id: int, pdata: bytes) -> bytes:
 
 def _from_frame(frame: bytes) -> dict:
     """Run a complete MQTT frame through the real decode path."""
-    results = decode_proto_runtime_headers(frame)
+    results = decode_proto_runtime_headers(frame, device_type=DEVICE_TYPE_POWEROCEAN)
     mapped = [r.mapped for r in results if r.mapped.get("_is_pile_charging_param")]
     assert mapped, "the 241/3 header was not routed"
     raw = {k: v for k, v in mapped[0].items() if not k.startswith("_")}
@@ -214,7 +215,9 @@ class TestOtherAccessoriesAndEdges:
 
     def test_a_rod_only_frame_still_routes_but_yields_nothing(self) -> None:
         frame = _header(241, 3, HEATING_ROD_REPORT)
-        results = decode_proto_runtime_headers(frame)
+        results = decode_proto_runtime_headers(
+            frame, device_type=DEVICE_TYPE_POWEROCEAN
+        )
         mapped = [r.mapped for r in results if r.mapped.get("_is_pile_charging_param")]
         assert mapped, "the tuple is registered regardless of the accessory"
         raw = {k: v for k, v in mapped[0].items() if not k.startswith("_")}
@@ -227,7 +230,9 @@ class TestOtherAccessoriesAndEdges:
         diagnostics of every system with a rod - noise that would bury a
         real unknown field the next time one appears.
         """
-        (result,) = decode_proto_runtime_headers(_header(241, 3, HEATING_ROD_REPORT))
+        (result,) = decode_proto_runtime_headers(
+            _header(241, 3, HEATING_ROD_REPORT), device_type=DEVICE_TYPE_POWEROCEAN
+        )
         assert "_unknown_fields" not in result.mapped
         assert "third_plug_param_report" in result.mapped
 
@@ -266,7 +271,9 @@ class TestOtherAccessoriesAndEdges:
         assert remap_pile_charging_keys(raw) == {"ev_charge_power_w": 0.0}
 
     def test_the_command_tuple_is_routed_with_its_own_flag(self) -> None:
-        results = decode_proto_runtime_headers(FRAME_CHARGING_MID_ORDER)
+        results = decode_proto_runtime_headers(
+            FRAME_CHARGING_MID_ORDER, device_type=DEVICE_TYPE_POWEROCEAN
+        )
         flags = {
             k
             for r in results

--- a/tests/test_powerpulse_wallbox.py
+++ b/tests/test_powerpulse_wallbox.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import pytest
 
+from custom_components.ecoflow_energy.ecoflow.const import DEVICE_TYPE_POWEROCEAN
 from custom_components.ecoflow_energy.ecoflow.parsers.powerocean_proto import (
     remap_ev_charging_keys,
 )
@@ -42,7 +43,7 @@ FRAME_CHARGING = bytes.fromhex(
 
 def _from_frame(frame: bytes) -> dict:
     """Run a complete MQTT frame through the real decode path."""
-    results = decode_proto_runtime_headers(frame)
+    results = decode_proto_runtime_headers(frame, device_type=DEVICE_TYPE_POWEROCEAN)
     mapped = [r.mapped for r in results if r.mapped.get("_is_ev_charging_param")]
     assert mapped, "the 209/8 header was not routed"
     raw = {k: v for k, v in mapped[0].items() if not k.startswith("_")}
@@ -130,8 +131,10 @@ class TestRegistry:
 
         registry = _build_cmd_registry()
 
-        assert (209, 8) in registry
-        assert registry[(209, 8)].flags == {"_is_ev_charging_param": True}
+        assert (209, 8) in registry[DEVICE_TYPE_POWEROCEAN]
+        assert registry[DEVICE_TYPE_POWEROCEAN][(209, 8)].flags == {
+            "_is_ev_charging_param": True
+        }
 
     def test_unknown_status_value_is_dropped_not_passed_through(self) -> None:
         """An enum sensor raises on any value outside its options list, so a

--- a/tests/test_proto_decoder.py
+++ b/tests/test_proto_decoder.py
@@ -5,6 +5,7 @@ import importlib.machinery
 import logging
 import sys
 
+from ecoflow_energy.ecoflow.const import DEVICE_TYPE_POWEROCEAN
 from ecoflow_energy.ecoflow.energy_stream import (
     build_energy_stream_activate_payload,
     build_energy_stream_deactivate_payload,
@@ -67,7 +68,7 @@ class TestRuntimeDecoder:
         inner = msg.SerializeToString()
 
         frame = _build_frame(96, 33, inner)
-        result = decode_proto_runtime_frame(frame)
+        result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_POWEROCEAN)
 
         assert result.parse_path == "typed_runtime:energy_stream_report"
         assert result.mapped["solar"] == 3500.0
@@ -86,7 +87,7 @@ class TestRuntimeDecoder:
         inner = msg.SerializeToString()
         frame = _build_frame(96, 33, inner)
 
-        result = decode_proto_runtime_frame(frame)
+        result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_POWEROCEAN)
         assert result.mapped["solar"] == 0.0
         assert result.mapped["home_direct"] == 0.0
         assert result.mapped["batt_pb"] == 0.0
@@ -107,7 +108,9 @@ class TestRuntimeDecoder:
         # power cap - the concrete field this reporting was built for.
         inner += encode_field_varint(5064, 1000)
 
-        result = decode_proto_runtime_frame(_build_frame(96, 33, inner))
+        result = decode_proto_runtime_frame(
+            _build_frame(96, 33, inner), device_type=DEVICE_TYPE_POWEROCEAN
+        )
 
         assert result.mapped["_unknown_fields"] == {5064: 1000}
         assert result.mapped["_cmd_key"] == "96/33"
@@ -124,7 +127,9 @@ class TestRuntimeDecoder:
         msg.bp_soc = 50
         inner = msg.SerializeToString() + encode_field_bytes(4242, b"HJ32TESTSERIAL01")
 
-        result = decode_proto_runtime_frame(_build_frame(96, 33, inner))
+        result = decode_proto_runtime_frame(
+            _build_frame(96, 33, inner), device_type=DEVICE_TYPE_POWEROCEAN
+        )
 
         assert result.mapped["_unknown_fields"] == {4242: "16 bytes"}
         assert "HJ32TESTSERIAL01" not in str(result.mapped)
@@ -137,7 +142,9 @@ class TestRuntimeDecoder:
         for number in range(3000, 3100):
             inner += encode_field_varint(number, 1)
 
-        result = decode_proto_runtime_frame(_build_frame(96, 33, inner))
+        result = decode_proto_runtime_frame(
+            _build_frame(96, 33, inner), device_type=DEVICE_TYPE_POWEROCEAN
+        )
 
         assert len(result.mapped["_unknown_fields"]) == _UNKNOWN_FIELDS_MAX
 
@@ -151,7 +158,9 @@ class TestRuntimeDecoder:
         """
         inner = encode_field_varint(5064, 1000)
 
-        result = decode_proto_runtime_frame(_build_frame(96, 33, inner))
+        result = decode_proto_runtime_frame(
+            _build_frame(96, 33, inner), device_type=DEVICE_TYPE_POWEROCEAN
+        )
 
         assert "_unknown_fields" not in result.mapped
 
@@ -163,7 +172,7 @@ class TestRuntimeDecoder:
         inner = msg.SerializeToString()
         frame = _build_frame(96, 8, inner)
 
-        result = decode_proto_runtime_frame(frame)
+        result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_POWEROCEAN)
         assert result.parse_path == "typed_runtime:ems_change"
         assert result.mapped.get("ems_work_mode") == 3
         assert "ems_word_mode" not in result.mapped
@@ -172,7 +181,7 @@ class TestRuntimeDecoder:
         """Unknown cmd_id should return no_match."""
         inner = b"\x08\x01"  # random varint
         frame = _build_frame(96, 999, inner)
-        result = decode_proto_runtime_frame(frame)
+        result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_POWEROCEAN)
         assert result.parse_path == "typed_runtime:no_match"
         assert result.mapped["_is_energy_stream"] is False
 
@@ -193,7 +202,7 @@ class TestRuntimeDecoder:
         inner = msg.SerializeToString()
         frame = _build_frame(96, 13, inner)
 
-        result = decode_proto_runtime_frame(frame)
+        result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_POWEROCEAN)
         assert result.parse_path == "typed_runtime:ems_param_change"
         assert result.mapped.get("ems_app_surplus_pct") == 47
         assert "dev_soc" not in result.mapped
@@ -393,9 +402,10 @@ class TestPowerOceanCorpusFields:
         from ecoflow_energy.ecoflow.proto.runtime import _build_cmd_registry
 
         seen: dict[str, set[int]] = {}
-        for config in _build_cmd_registry().values():
-            for field in config.msg_class.DESCRIPTOR.fields:
-                seen.setdefault(field.name, set()).add(field.number)
+        for table in _build_cmd_registry().values():
+            for config in table.values():
+                for field in config.msg_class.DESCRIPTOR.fields:
+                    seen.setdefault(field.name, set()).add(field.number)
 
         clashes = {n: v for n, v in seen.items() if len(v) > 1 and n != "bp_soc"}
 
@@ -505,7 +515,7 @@ class TestFullPowerFrameFlag:
         msg.sys_grid_pwr = 500.0
         frame = _build_frame(96, 33, msg.SerializeToString())
 
-        result = decode_proto_runtime_frame(frame)
+        result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_POWEROCEAN)
 
         assert result.mapped["_is_full_power_frame"] is False
         # The zero-fill still runs: an absent power field is a real zero to
@@ -518,4 +528,9 @@ class TestFullPowerFrameFlag:
         msg.bp_soc = 50
         frame = _build_frame(96, 33, msg.SerializeToString())
 
-        assert decode_proto_runtime_frame(frame).mapped["_is_full_power_frame"] is False
+        assert (
+            decode_proto_runtime_frame(
+                frame, device_type=DEVICE_TYPE_POWEROCEAN
+            ).mapped["_is_full_power_frame"]
+            is False
+        )

--- a/tests/test_proto_decoder.py
+++ b/tests/test_proto_decoder.py
@@ -162,6 +162,9 @@ class TestRuntimeDecoder:
             _build_frame(96, 33, inner), device_type=DEVICE_TYPE_POWEROCEAN
         )
 
+        # Positive control: the frame has to have reached its registry entry,
+        # or the absent summary below would only prove that nothing decoded.
+        assert result.parse_path == "typed_runtime:energy_stream_report"
         assert "_unknown_fields" not in result.mapped
 
     def test_ems_change_report_rename(self):
@@ -180,6 +183,13 @@ class TestRuntimeDecoder:
     def test_unknown_cmd_id(self):
         """Unknown cmd_id should return no_match."""
         inner = b"\x08\x01"  # random varint
+        # Positive control: the same command family with a registered cmd_id
+        # must decode, so no_match below cannot come from an empty table.
+        control = decode_proto_runtime_frame(
+            _build_frame(96, 8, JTS1EmsChangeReport(bp_soc=80).SerializeToString()),
+            device_type=DEVICE_TYPE_POWEROCEAN,
+        )
+        assert control.parse_path == "typed_runtime:ems_change"
         frame = _build_frame(96, 999, inner)
         result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_POWEROCEAN)
         assert result.parse_path == "typed_runtime:no_match"
@@ -528,9 +538,9 @@ class TestFullPowerFrameFlag:
         msg.bp_soc = 50
         frame = _build_frame(96, 33, msg.SerializeToString())
 
-        assert (
-            decode_proto_runtime_frame(
-                frame, device_type=DEVICE_TYPE_POWEROCEAN
-            ).mapped["_is_full_power_frame"]
-            is False
-        )
+        result = decode_proto_runtime_frame(frame, device_type=DEVICE_TYPE_POWEROCEAN)
+
+        # Positive control: `_is_full_power_frame` is False in the empty
+        # mapping too, so the parse path has to say the frame was read.
+        assert result.parse_path == "typed_runtime:energy_stream_report"
+        assert result.mapped["_is_full_power_frame"] is False

--- a/tests/test_proto_registry_namespaces.py
+++ b/tests/test_proto_registry_namespaces.py
@@ -1,0 +1,130 @@
+"""Tests for the per-device-type command registry (ADR-024, PLAN-131).
+
+The registry used to be one flat ``dict[tuple[int, int], CmdConfig]`` shared
+by every device type. ADR-024 splits it into one table per device type,
+keyed on the same ``DEVICE_TYPE_*`` constant ``get_device_type()`` already
+returns, so a command tuple that means one thing for PowerOcean and another
+for the Delta 3 generation can never be looked up in the wrong table.
+
+These two tests guard the two ways that split could quietly come undone:
+a caller passing the wrong (or no) device type getting a hit anyway, and a
+table being keyed on something that is not a real device type.
+"""
+
+from __future__ import annotations
+
+from ecoflow_energy.ecoflow import const as ef_const
+from ecoflow_energy.ecoflow.const import DEVICE_TYPE_DELTA3, DEVICE_TYPE_POWEROCEAN
+from ecoflow_energy.ecoflow.proto.ecocharge_pb2 import (
+    Delta3DisplayProperty,
+    JTS1EnergyStreamReport,
+)
+from ecoflow_energy.ecoflow.proto.runtime import (
+    CmdConfig,
+    _build_cmd_registry,
+    decode_proto_runtime_headers,
+)
+from ecoflow_energy.ecoflow.proto_encoding import (
+    encode_field_bytes,
+    encode_field_varint,
+)
+
+
+def _build_frame(cmd_func: int, cmd_id: int, inner: bytes) -> bytes:
+    """Build a minimal HeaderMessage frame carrying one pdata payload."""
+    header = bytearray()
+    header.extend(encode_field_bytes(1, inner))  # pdata
+    header.extend(encode_field_varint(8, cmd_func))  # cmd_func
+    header.extend(encode_field_varint(9, cmd_id))  # cmd_id
+    return encode_field_bytes(1, bytes(header))
+
+
+def _powerocean_frame() -> bytes:
+    """A real PowerOcean energy-stream report, (cmd_func, cmd_id) = (96, 33)."""
+    msg = JTS1EnergyStreamReport()
+    msg.mppt_pwr = 1200.0
+    msg.bp_soc = 60
+    return _build_frame(96, 33, msg.SerializeToString())
+
+
+def _delta3_frame() -> bytes:
+    """A real Delta 3 status frame, (cmd_func, cmd_id) = (254, 21)."""
+    msg = Delta3DisplayProperty()
+    msg.pow_in_sum_w = 500.0
+    return _build_frame(254, 21, msg.SerializeToString())
+
+
+class TestPairedControl:
+    """A frame decodes under its own device type and nowhere else.
+
+    This is the alarm ADR-024 asks for: if the two tables were ever merged,
+    flattened, or given a union default, the "foreign device type" half of
+    each pair below would start succeeding, and would do so silently. Each
+    frame here has a real command tuple in the *other* family's table too
+    ((96, 33) is absent from Delta 3's table, (254, 21) is absent from
+    PowerOcean's), so a passing "foreign" assertion is not merely "no table
+    exists for this type" - it is "a real table exists and does not claim
+    this frame".
+    """
+
+    def test_powerocean_frame_decodes_only_under_its_own_device_type(self):
+        frame = _powerocean_frame()
+
+        own = decode_proto_runtime_headers(frame, device_type=DEVICE_TYPE_POWEROCEAN)
+        assert len(own) == 1
+        assert own[0].parse_path == "typed_runtime:energy_stream_report"
+
+        foreign = decode_proto_runtime_headers(frame, device_type=DEVICE_TYPE_DELTA3)
+        assert foreign == []
+
+    def test_delta3_frame_decodes_only_under_its_own_device_type(self):
+        frame = _delta3_frame()
+
+        own = decode_proto_runtime_headers(frame, device_type=DEVICE_TYPE_DELTA3)
+        assert len(own) == 1
+        assert own[0].parse_path == "typed_runtime:delta3_display_property"
+
+        foreign = decode_proto_runtime_headers(
+            frame, device_type=DEVICE_TYPE_POWEROCEAN
+        )
+        assert foreign == []
+
+
+class TestRegistryNamespaces:
+    """Every outer key is a real device type, and no tuple is claimed twice."""
+
+    def test_every_table_key_is_a_real_device_type(self):
+        registry = _build_cmd_registry()
+        # Sanity: the registry actually built (the pb2 import succeeded), so
+        # an empty dict here would hide the whole test behind a false pass.
+        assert registry
+
+        valid_device_types = {
+            value
+            for name, value in vars(ef_const).items()
+            if name.startswith("DEVICE_TYPE_")
+            and isinstance(value, str)
+            and value != ef_const.DEVICE_TYPE_UNKNOWN
+        }
+        for device_type in registry:
+            assert device_type in valid_device_types
+
+    def test_no_tuple_is_claimed_by_two_tables_with_different_configs(self):
+        registry = _build_cmd_registry()
+        assert registry
+
+        seen: dict[tuple[int, int], tuple[str, CmdConfig]] = {}
+        for device_type, table in registry.items():
+            for key, config in table.items():
+                if key in seen:
+                    other_type, other_config = seen[key]
+                    # Two families are allowed to mean the same message by the
+                    # same tuple only if they share the identical CmdConfig
+                    # object - a deliberate shared constant, not a coincidence
+                    # of two tables independently defining the same key.
+                    assert config is other_config, (
+                        f"{key} is claimed by both {other_type} and "
+                        f"{device_type} with two different CmdConfig objects"
+                    )
+                else:
+                    seen[key] = (device_type, config)

--- a/tests/test_proto_registry_namespaces.py
+++ b/tests/test_proto_registry_namespaces.py
@@ -13,8 +13,16 @@ table being keyed on something that is not a real device type.
 
 from __future__ import annotations
 
+import logging
+
+import pytest
 from ecoflow_energy.ecoflow import const as ef_const
-from ecoflow_energy.ecoflow.const import DEVICE_TYPE_DELTA3, DEVICE_TYPE_POWEROCEAN
+from ecoflow_energy.ecoflow.const import (
+    DEVICE_TYPE_DELTA3,
+    DEVICE_TYPE_POWEROCEAN,
+    DEVICE_TYPE_SMARTPLUG,
+)
+from ecoflow_energy.ecoflow.proto import runtime
 from ecoflow_energy.ecoflow.proto.ecocharge_pb2 import (
     Delta3DisplayProperty,
     JTS1EnergyStreamReport,
@@ -128,3 +136,53 @@ class TestRegistryNamespaces:
                     )
                 else:
                     seen[key] = (device_type, config)
+
+
+class TestDeviceTypeWithoutATable:
+    """A device type that has no table of its own must stay harmless.
+
+    The SmartPlug, the Delta generation and the PowerStream reach the same
+    decode entry point but are read by their own parsers afterwards. They
+    have no registry table, and what happens to them decides whether the
+    fallback in `coordinator/mqtt_ingest.py` still gets its headers.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _forget_logged_types(self):
+        """The dedupe set is process-global and never reset by the product.
+
+        Without this the log assertion below would only hold when this test
+        happens to run first, and the suite runs under `pytest-randomly`.
+        """
+        runtime._LOGGED_UNKNOWN_DEVICE_TYPES.clear()
+        yield
+        runtime._LOGGED_UNKNOWN_DEVICE_TYPES.clear()
+
+    def test_a_device_type_without_a_table_gets_an_empty_one(self):
+        assert runtime._registry_for(DEVICE_TYPE_SMARTPLUG) == {}
+        # Not a union of every table, which is the shape ADR-024 removes.
+        assert runtime._registry_for("not_a_device_type_at_all") == {}
+
+    def test_the_missing_table_is_logged_once_per_process(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger=runtime.__name__):
+            for _ in range(5):
+                runtime._registry_for(DEVICE_TYPE_SMARTPLUG)
+
+        lines = [
+            r for r in caplog.records if "no protobuf command" in r.message.lower()
+        ]
+        assert len(lines) == 1
+        assert DEVICE_TYPE_SMARTPLUG in str(lines[0].args)
+
+    def test_the_headers_survive_so_the_fallback_still_runs(self):
+        """`_parse_proto_device_data` is handed `result.headers` afterwards.
+
+        A frame from a device type with no table must therefore come back
+        with its header list intact rather than as nothing at all.
+        """
+        result = runtime.decode_proto_runtime_frame(
+            _powerocean_frame(), device_type=DEVICE_TYPE_SMARTPLUG
+        )
+
+        assert result.parse_path == "typed_runtime:no_match"
+        assert len(result.headers) == 1


### PR DESCRIPTION
## What this changes

The protobuf command registry was one flat `dict[(cmd_func, cmd_id), CmdConfig]` shared by every device. Two device families that mean different messages by the same tuple were kept apart only by the routing order in the coordinator and by a warning in a docstring, neither of which a test can check.

It is now `dict[device_type, dict[(cmd_func, cmd_id), CmdConfig]]`, keyed on the `DEVICE_TYPE_*` constant the classifier already derives from the serial prefix. `decode_proto_runtime_headers` and `decode_proto_runtime_frame` take `device_type` as a required keyword argument, so a caller cannot fall back to a global table by forgetting. Twelve tuples belong to the PowerOcean table, three to the Delta 3 table, and no `CmdConfig` changed.

Design and the alternatives that were rejected are in ADR-024. This is the binding first condition of ADR-008, ahead of giving the PowerPulse 2 its own device type in a later change.

## Why now

The collision is prospective rather than live: neither of the two tuples ADR-008 names is registered today, so nothing on file is mis-decoded. What exists is a shape. A new parser adding a tuple another family already owns produces a silently wrong decode with no test failing, and the next change is exactly that kind of parser.

## Evidence

Behaviour neutrality is measured, not asserted. Every one of the 1764 frames in the 52 recordings on file was replayed before and after: 678 of them decode, to 1307 headers, with zero differences in parse path or key set. The replay tool was itself checked against known answers first: deleting one tuple moves 53 frames out and changes 59, and registering one tuple in a second table raises the two-family counter from 0 to 112.

- 3434 tests pass, 1 skipped
- `ruff check`, `ruff format --check`, and both mypy runs clean

## Review findings

All fixed in the branch. Three local probe scripts called the decoder without the new keyword and would have raised on their first frame, which no gate would have reported since the lint and type gates read the integration and the tests only. Four tests asserted that something did not decode and would have held with their whole table deleted; each now decodes a frame that must hit the table first. The device type without a table of its own had no test at all and now has three, including the header list surviving, which is what the SmartPlug and Delta fallback rests on.
