### PR TITLE
Mask a neighbour's name and short id beside a serial in the diagnostics download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [1.21.0] - 2026-09-08
 
+### Fixed
+
+- The diagnostics download masks two more things a device says about its neighbours: the name and the short id that sit beside a serial in the same record. On a PowerPulse 2 those read `Ecoflow_0378` and `BD1954BF` and were left in plain text in a download the owner had shared, while the serial next to them was masked. The masking now treats a serial as the boundary: any string of eight or more characters that shares a protobuf record with a serial is replaced by `X`, whatever its spelling, so a name an owner typed is covered as well. Measured over every capture on file: the four values are the only fields touched, and no reading, length or header field changes. The fixture check that guards this repository sees the same shape now.
+
 ### Changed
 
 - Nothing about the software changes for anyone using it. Internally, the table that decides which protobuf message a device's frame is read as now exists once per device type instead of once for the whole integration. Until now a single table answered for every device, and two device families that use the same command numbers for different messages were kept apart only by the order in which the code happens to ask, which no test could check. Each family now has its own table and the caller has to say which device it is decoding for, so one family can never read another family's message by accident. Every frame in the recordings on file was replayed before and after the change and produced exactly the same readings.

--- a/custom_components/ecoflow_energy/ecoflow/frame_capture.py
+++ b/custom_components/ecoflow_energy/ecoflow/frame_capture.py
@@ -202,16 +202,35 @@ def _mask_delimited_identifiers(payload: bytes) -> bytes:
 # cap would mask the tail of a long value and leave its front standing,
 # which is worse than either choice (ADR-016, amendment).
 #
-# Two couplings this pass depends on, both already relied on by
-# `_JOINED_HEX_RUN`: it runs after `_SERIAL_RUN`, so the anchor it finds is
-# usually a run of `X` - which still matches `_SERIAL_RUN` only because
-# `_MASK_BYTE` is inside `[A-Z0-9]`; and a whole field the delimited pass
-# has already masked matches the candidate shape and is re-masked `X` for
-# `X`, which changes nothing.
+# This pass runs before the free-running ones, right after the named
+# secrets, and the order is load-bearing. `_SERIAL_RUN` is greedy and knows
+# nothing about fields: when the byte after a serial is itself in
+# `[A-Z0-9]` it is swallowed too, and for a length-delimited field that byte
+# is the tag - fields 6, 8, 9, 10 and 11 carry the tags `2`, `B`, `J`, `R`
+# and `Z`. A tag turned to `X` reads as a varint, and the walk loses the
+# rest of that message, name included. Measured: a name at field 8 after
+# the serial survived when this pass ran last, and is masked when it runs
+# first. Every pass is `X` for `X` idempotent, so the order costs nothing.
 #
-# Found 2026-09-09 in a reporter's diagnostics download, in message `2/133`
-# of a PowerPulse 2, six frames, while the serial beside them was masked
-# (PLAN-133, ADR-025).
+# Two couplings remain, both already relied on by `_JOINED_HEX_RUN`: the
+# anchor accepts a run of `X` as well as a real serial - a named secret
+# masked one line earlier, or a fixture already masked on disk, still
+# anchors, and the fixture gate walks masked files with this same helper -
+# which holds only because `_MASK_BYTE` is inside `[A-Z0-9]`; and a
+# 12-character identifier this pass masks is what the delimited pass would
+# have masked anyway, `X` for `X`.
+#
+# A field that holds a whole sub-message is a candidate too when every one
+# of its bytes happens to fall in the alphabet, and would be masked whole,
+# children included. No such field exists on file; it is recorded rather
+# than guarded against, because a guard would need to parse the value to
+# decide, and a value that parses as a message is exactly what a name
+# cannot be told from.
+#
+# Found 2026-09-09 in a reporter's diagnostics downloads, in message `2/133`
+# of a PowerPulse 2: 9 frames in two downloads, 18 occurrences of four
+# distinct values, while the serial beside them was masked (PLAN-133,
+# ADR-025).
 _ANCHORED_STRING = re.compile(rb"[A-Za-z0-9_-]{8,}")
 _ANCHOR_DEPTH = 6
 
@@ -318,22 +337,24 @@ def _mask_anchored_strings(payload: bytes) -> bytes:
 def _plain_passes(payload: bytes, secrets: list[str]) -> bytes:
     """Every mask this module applies, over bytes that are already plain.
 
-    Named identifiers are masked first, then anything else shaped like a
+    Named identifiers are masked first, then any string that shares a
+    protobuf message with a serial, then anything else shaped like a
     serial, then anything written as a UUID, then a lower-case hex run a
     hyphen joins to a serial-shaped run, then the city half of any time zone
-    the device reports, then anything a device presents as a whole
-    length-delimited field of identifier-shaped characters, and last any
-    string that shares a protobuf message with a serial. The second pass
-    matters because a frame also carries the serial of every battery pack
-    and of any attached accessory, and the caller cannot name what it has
-    not discovered yet. The third and fourth catch identifiers too short, or
-    too oddly shaped, for the second to risk matching: a UUID by its own
-    hyphenated shape, and a hex run by the serial it is joined to - which is
-    how a 12-character one reached a public issue attachment before anyone
-    noticed. The seventh catches what no shape can: a neighbour's name and
-    short id, by their position beside its serial. Masking preserves length,
-    so byte offsets survive every pass and a field-layout analysis still
-    works.
+    the device reports, and last anything a device presents as a whole
+    length-delimited field of identifier-shaped characters. The second pass
+    catches what no shape can: a neighbour's name and short id, by their
+    position beside its serial - and it runs before the free-running passes
+    because those can mask the tag byte after a serial and blind a walk
+    that reads fields. The third matters because a frame also carries the
+    serial of every battery pack and of any attached accessory, and the
+    caller cannot name what it has not discovered yet. The fourth and fifth
+    catch identifiers too short, or too oddly shaped, for the third to risk
+    matching: a UUID by its own hyphenated shape, and a hex run by the
+    serial it is joined to - which is how a 12-character one reached a
+    public issue attachment before anyone noticed. Masking preserves
+    length, so byte offsets survive every pass and a field-layout analysis
+    still works.
 
     "Plain" is the operative word: none of these passes can see a string
     once the device has XOR-masked it. `sanitize_frame` is what runs this
@@ -348,14 +369,14 @@ def _plain_passes(payload: bytes, secrets: list[str]) -> bytes:
             raw = variant.encode("ascii", "ignore")
             if raw and raw in sanitized:
                 sanitized = sanitized.replace(raw, _MASK_BYTE * len(raw))
+    sanitized = _mask_anchored_strings(sanitized)
     sanitized = _SERIAL_RUN.sub(lambda m: _MASK_BYTE * len(m.group()), sanitized)
     sanitized = _UUID_RUN.sub(lambda m: _MASK_BYTE * len(m.group()), sanitized)
     sanitized = _JOINED_HEX_RUN.sub(lambda m: _MASK_BYTE * len(m.group()), sanitized)
     sanitized = _TIME_ZONE.sub(
         lambda m: m.group(1) + _MASK_BYTE * len(m.group(2)), sanitized
     )
-    sanitized = _mask_delimited_identifiers(sanitized)
-    return _mask_anchored_strings(sanitized)
+    return _mask_delimited_identifiers(sanitized)
 
 
 # The device does not always send a string plainly. Some commands mark their

--- a/custom_components/ecoflow_energy/ecoflow/frame_capture.py
+++ b/custom_components/ecoflow_energy/ecoflow/frame_capture.py
@@ -172,6 +172,149 @@ def _mask_delimited_identifiers(payload: bytes) -> bytes:
     return bytes(out)
 
 
+# A device also sends a record about a neighbour: a serial, and beside it a
+# short id and a name. On file the id is eight upper-case hex characters and
+# the name is `Ecoflow_` plus four digits - a lower-case run and an
+# underscore - so neither is reachable by any shape above: eight is under
+# `_IDENT_MIN`, and the alphabet the delimited pass tests is upper case only.
+# Widening that alphabet was measured and rejected: it costs a key string
+# (`plug_and_play`, nine times in the same device's frames) and still reaches
+# no name under twelve characters. A name an owner typed has no spelling to
+# catch at all.
+#
+# What such a record does have is the serial, and the serial is the boundary
+# (ADR-016). Within one protobuf message - the fields read from one delimited
+# span - a whole delimited field that is serial-shaped anchors the message,
+# and every other whole delimited field of eight or more characters from
+# `[A-Za-z0-9_-]` in that same message is masked. Nothing is masked in a
+# message without an anchor, so the key string above survives and so does
+# ordinary binary. Measured 2026-09-09 over 20,324 hex blobs of every family
+# on file: 18 of 18 values reached, 0 other fields touched. The other whole
+# fields that share a message with a serial anywhere on file are `ios`,
+# `android` (seven characters, which is why the floor is eight), `V0.0.0`
+# (the dot stays outside the alphabet for it), `Europe/Berlin` (the slash
+# likewise) and fields that are not printable at all.
+#
+# The walk descends into every delimited span as if it were a message, to
+# `_ANCHOR_DEPTH` levels below the payload it receives, because the record
+# sits three levels down (frame, header, `pdata`, record list) and the
+# collateral above was measured at six. A candidate has no upper bound: a
+# cap would mask the tail of a long value and leave its front standing,
+# which is worse than either choice (ADR-016, amendment).
+#
+# Two couplings this pass depends on, both already relied on by
+# `_JOINED_HEX_RUN`: it runs after `_SERIAL_RUN`, so the anchor it finds is
+# usually a run of `X` - which still matches `_SERIAL_RUN` only because
+# `_MASK_BYTE` is inside `[A-Z0-9]`; and a whole field the delimited pass
+# has already masked matches the candidate shape and is re-masked `X` for
+# `X`, which changes nothing.
+#
+# Found 2026-09-09 in a reporter's diagnostics download, in message `2/133`
+# of a PowerPulse 2, six frames, while the serial beside them was masked
+# (PLAN-133, ADR-025).
+_ANCHORED_STRING = re.compile(rb"[A-Za-z0-9_-]{8,}")
+_ANCHOR_DEPTH = 6
+
+
+def _delimited_spans_by_message(payload: bytes) -> list[list[tuple[int, int]]]:
+    """The whole delimited fields of every message the walk can read.
+
+    One inner list per message, each entry a `(start, end)` span into
+    `payload` itself, so a caller can test and mask in place. The payload is
+    depth 0; every delimited span is read as a message of its own down to
+    `_ANCHOR_DEPTH`, and a span below the cap is not descended into. Each
+    descent is into a strictly shorter span, so the walk ends, and the cap
+    bounds it at `_ANCHOR_DEPTH + 1` visits per byte.
+
+    Within a message the walk is tolerant the way `_header_fields` is: it
+    reads fields until the first one it cannot read and keeps what it read,
+    because a frame is at its most interesting when it does not parse, and
+    a truncated later field must not cost an intact earlier one its record.
+    A field number of zero is not valid protobuf and ends the message too,
+    which is what keeps a string read as a message from yielding much.
+    Wrapped so a malformed payload can never raise: on any failure the
+    messages read so far are returned, and a capture path never affects
+    ingest.
+    """
+    from .proto.decoder import _read_varint
+
+    messages: list[list[tuple[int, int]]] = []
+    try:
+        mv = memoryview(payload)
+        pending: list[tuple[int, int, int]] = [(0, len(mv), 0)]
+        while pending:
+            start, end, depth = pending.pop()
+            spans: list[tuple[int, int]] = []
+            i = start
+            while i < end:
+                key, i = _read_varint(mv, i)
+                if key is None:
+                    break
+                fn, wt = key >> 3, key & 0x07
+                if fn == 0:
+                    break
+                if wt == 0:
+                    val, i = _read_varint(mv, i)
+                    if val is None:
+                        break
+                elif wt == 2:
+                    length, i = _read_varint(mv, i)
+                    if length is None:
+                        break
+                    field_end = i + length
+                    if field_end > end:
+                        break
+                    spans.append((i, field_end))
+                    if depth < _ANCHOR_DEPTH and length:
+                        pending.append((i, field_end, depth + 1))
+                    i = field_end
+                elif wt == 1:
+                    i += 8
+                elif wt == 5:
+                    i += 4
+                else:
+                    break
+            if spans:
+                messages.append(spans)
+    except Exception:  # noqa: BLE001
+        pass
+    return messages
+
+
+def _anchored_string_fields(payload: bytes) -> list[tuple[int, int]]:
+    """Spans of every string that sits beside a serial in its own message.
+
+    A message is anchored when one of its whole delimited fields matches
+    `_SERIAL_RUN`; an anchor is never itself a candidate. In an anchored
+    message every other whole delimited field that matches
+    `_ANCHORED_STRING` is returned. A message without an anchor yields
+    nothing, whatever it carries. The fixture gate imports this so it sees
+    exactly what the product sees.
+    """
+    found: list[tuple[int, int]] = []
+    for spans in _delimited_spans_by_message(payload):
+        anchored = any(_SERIAL_RUN.fullmatch(payload, s, e) for s, e in spans)
+        if not anchored:
+            continue
+        for s, e in spans:
+            if _SERIAL_RUN.fullmatch(payload, s, e):
+                continue
+            if _ANCHORED_STRING.fullmatch(payload, s, e):
+                found.append((s, e))
+    return found
+
+
+def _mask_anchored_strings(payload: bytes) -> bytes:
+    """Mask every string `_anchored_string_fields` finds, length preserved."""
+    spans = _anchored_string_fields(payload)
+    if not spans:
+        return payload
+    out = bytearray(payload)
+    for start, end in spans:
+        out[start:end] = _MASK_BYTE * (end - start)
+    return bytes(out)
+
+
 def _plain_passes(payload: bytes, secrets: list[str]) -> bytes:
     """Every mask this module applies, over bytes that are already plain.
 
@@ -179,15 +322,18 @@ def _plain_passes(payload: bytes, secrets: list[str]) -> bytes:
     serial, then anything written as a UUID, then a lower-case hex run a
     hyphen joins to a serial-shaped run, then the city half of any time zone
     the device reports, then anything a device presents as a whole
-    length-delimited field of identifier-shaped characters. The second pass
+    length-delimited field of identifier-shaped characters, and last any
+    string that shares a protobuf message with a serial. The second pass
     matters because a frame also carries the serial of every battery pack
     and of any attached accessory, and the caller cannot name what it has
     not discovered yet. The third and fourth catch identifiers too short, or
     too oddly shaped, for the second to risk matching: a UUID by its own
     hyphenated shape, and a hex run by the serial it is joined to - which is
     how a 12-character one reached a public issue attachment before anyone
-    noticed. Masking preserves length, so byte offsets survive every pass
-    and a field-layout analysis still works.
+    noticed. The seventh catches what no shape can: a neighbour's name and
+    short id, by their position beside its serial. Masking preserves length,
+    so byte offsets survive every pass and a field-layout analysis still
+    works.
 
     "Plain" is the operative word: none of these passes can see a string
     once the device has XOR-masked it. `sanitize_frame` is what runs this
@@ -208,7 +354,8 @@ def _plain_passes(payload: bytes, secrets: list[str]) -> bytes:
     sanitized = _TIME_ZONE.sub(
         lambda m: m.group(1) + _MASK_BYTE * len(m.group(2)), sanitized
     )
-    return _mask_delimited_identifiers(sanitized)
+    sanitized = _mask_delimited_identifiers(sanitized)
+    return _mask_anchored_strings(sanitized)
 
 
 # The device does not always send a string plainly. Some commands mark their

--- a/tests/test_fixture_identifiers.py
+++ b/tests/test_fixture_identifiers.py
@@ -19,7 +19,12 @@ import re
 from pathlib import Path
 
 import pytest
-from ecoflow_energy.ecoflow.frame_capture import _encrypted_regions, _xor
+from ecoflow_energy.ecoflow.frame_capture import (
+    _anchored_string_fields,
+    _encrypted_regions,
+    _xor,
+    sanitize_frame,
+)
 from ecoflow_energy.ecoflow.proto_encoding import (
     encode_field_bytes,
     encode_field_varint,
@@ -78,17 +83,65 @@ def test_the_fixture_tree_is_not_empty() -> None:
     assert len(files) >= 6, [str(p) for p in files]
 
 
+def _leaks(raw: bytes) -> list[str]:
+    """Every identifier a masked frame should no longer carry, as messages.
+
+    One entry per finding rather than the first failed assertion, so a single
+    dirty frame reports everything wrong with it in one run. Covers the same
+    ground the fixture gate used to check inline: a UUID or MAC anywhere in
+    the frame text, an unmasked identifier run, the same three checks again on
+    every region an `enc_type == 1` header XOR-hides (PLAN-128), and a
+    neighbour's name or short id sitting beside its own serial
+    (`_anchored_string_fields`, PLAN-133, ADR-025).
+    """
+    findings: list[str] = []
+    text = raw.decode("latin1")
+    if _UUID.search(text):
+        findings.append("unmasked UUID")
+    if _MAC.search(text):
+        findings.append("unmasked MAC")
+    for run in _RUN.findall(text):
+        if run in _PLACEHOLDERS:
+            continue
+        if set(run) != {"X"}:
+            findings.append(f"unmasked run {run!r}")
+
+    for start, end in _anchored_string_fields(raw):
+        value = raw[start:end]
+        if set(value) == {ord("X")}:
+            continue
+        decoded = value.decode("latin1")
+        if decoded in _PLACEHOLDERS:
+            continue
+        findings.append(f"unmasked string beside a serial {decoded!r}")
+
+    # The mask under the mask: unmask every region the header itself declares
+    # XOR-ed and run the same checks over that plaintext. A region with no
+    # `seq` has no key to derive and is left alone here too - `sanitize_frame`
+    # cannot mask what it cannot decrypt either.
+    for region in _encrypted_regions(raw):
+        if region.key is None:
+            continue
+        region_text = _xor(raw[region.start : region.end], region.key).decode("latin1")
+        if _UUID.search(region_text):
+            findings.append("unmasked UUID under the mask")
+        if _MAC.search(region_text):
+            findings.append("unmasked MAC under the mask")
+        for run in _RUN.findall(region_text):
+            if run in _PLACEHOLDERS:
+                continue
+            if set(run) != {"X"}:
+                findings.append(f"unmasked run under the mask {run!r}")
+
+    return findings
+
+
 @pytest.mark.parametrize("path", _fixture_files(), ids=lambda p: p.name)
 def test_no_identifier_survived_masking(path: Path) -> None:
-    """No serial, UUID, MAC or account id may reach a public fixture.
+    """No serial, UUID, MAC, account id, or neighbour string may reach a public fixture.
 
-    A header whose `enc_type` field is 1 XOR-masks its own `pdata` (or, on a
-    single-header frame, the shared payload) with the low byte of its own
-    `seq` field (PLAN-128). None of the checks above can see a string once
-    that mask sits on top of it, so every region `_encrypted_regions` finds
-    is un-XOR-ed with the header's own key and re-checked with the same
-    `_UUID`/`_MAC`/`_RUN` patterns. Measured on this corpus: 0 new failures
-    over 164 hex blobs and 67 `enc_type == 1` headers.
+    Measured on this corpus: 164 hex blobs across the fixture tree, 67
+    `enc_type == 1` headers, 0 leaks from any of the checks `_leaks` runs.
     """
     text_of_file = path.read_bytes().decode("latin1")
     try:
@@ -110,36 +163,10 @@ def test_no_identifier_survived_masking(path: Path) -> None:
         hex_payload = frame.get("hex") or frame.get("frame_hex")
         if not hex_payload:
             continue
-        text = bytes.fromhex(hex_payload).decode("latin1")
-        where = f"{path.name}[{index}]"
-        assert not _UUID.search(text), f"{where}: unmasked UUID"
-        assert not _MAC.search(text), f"{where}: unmasked MAC"
-        for run in _RUN.findall(text):
-            if run in _PLACEHOLDERS:
-                continue
-            assert set(run) == {"X"}, f"{where}: unmasked run {run!r}"
-
-        # The mask under the mask: unmask every region the header itself
-        # declares XOR-ed and run the same three checks over that plaintext.
-        # A region with no `seq` has no key to derive and is left alone here
-        # too - `sanitize_frame` cannot mask what it cannot decrypt either.
         raw_frame = bytes.fromhex(hex_payload)
-        for region in _encrypted_regions(raw_frame):
-            if region.key is None:
-                continue
-            region_text = _xor(raw_frame[region.start : region.end], region.key).decode(
-                "latin1"
-            )
-            assert not _UUID.search(region_text), (
-                f"{where}: unmasked UUID under the mask"
-            )
-            assert not _MAC.search(region_text), f"{where}: unmasked MAC under the mask"
-            for run in _RUN.findall(region_text):
-                if run in _PLACEHOLDERS:
-                    continue
-                assert set(run) == {"X"}, (
-                    f"{where}: unmasked run under the mask {run!r}"
-                )
+        where = f"{path.name}[{index}]"
+        findings = _leaks(raw_frame)
+        assert findings == [], f"{where}: {findings}"
 
         # Only where the field is an actual MQTT topic. Several fixtures reuse
         # the same key for the message type ("property", "get_reply"), which
@@ -208,3 +235,51 @@ def test_the_region_check_has_a_positive_control() -> None:
     plain = _xor(frame[region.start : region.end], region.key)
 
     assert _UUID.search(plain.decode("latin1"))
+
+
+def _wrap_as_record(record: bytes) -> bytes:
+    """Nest a record three levels deep, the way a real frame carries it.
+
+    `frame -> header -> pdata -> record list` (PLAN-133, ADR-025): a payload
+    handed straight to `_leaks` is depth 0, and the record only becomes a
+    message of its own once the walk has descended three delimited fields.
+    """
+    return encode_field_bytes(1, encode_field_bytes(1, encode_field_bytes(1, record)))
+
+
+def test_the_gate_sees_a_string_beside_a_serial() -> None:
+    """Positive control: a name and a short id beside an anchor both leak.
+
+    The anchor here is an already-masked serial (`X` * 16) rather than a real
+    one, on purpose: that is what a real frame looks like after the serial
+    pass has already run and before the anchored-string pass runs after it,
+    which is the exact order `_plain_passes` uses.
+    """
+    record = (
+        encode_field_varint(1, 1)
+        + encode_field_bytes(2, b"3D1A32AC")
+        + encode_field_bytes(3, b"X" * 16)
+        + encode_field_bytes(5, b"Ecoflow_0379")
+    )
+    frame = _wrap_as_record(record)
+
+    findings = _leaks(frame)
+    assert len(findings) == 2, findings
+    assert any("3D1A32AC" in finding for finding in findings), findings
+    assert any("Ecoflow_0379" in finding for finding in findings), findings
+
+    assert _leaks(sanitize_frame(frame, [])) == []
+
+
+def test_the_gate_is_quiet_without_a_serial() -> None:
+    """Negative control: the same shapes without an anchor leak nothing.
+
+    Without a whole field that fullmatches a serial, `_anchored_string_fields`
+    yields no candidates at all, however identifier-shaped its neighbours are.
+    """
+    record = encode_field_bytes(2, b"plug_and_play") + encode_field_bytes(
+        3, b"3D1A32AC"
+    )
+    frame = _wrap_as_record(record)
+
+    assert _leaks(frame) == []

--- a/tests/test_fixture_identifiers.py
+++ b/tests/test_fixture_identifiers.py
@@ -122,7 +122,8 @@ def _leaks(raw: bytes) -> list[str]:
     for region in _encrypted_regions(raw):
         if region.key is None:
             continue
-        region_text = _xor(raw[region.start : region.end], region.key).decode("latin1")
+        region_raw = _xor(raw[region.start : region.end], region.key)
+        region_text = region_raw.decode("latin1")
         if _UUID.search(region_text):
             findings.append("unmasked UUID under the mask")
         if _MAC.search(region_text):
@@ -132,6 +133,16 @@ def _leaks(raw: bytes) -> list[str]:
                 continue
             if set(run) != {"X"}:
                 findings.append(f"unmasked run under the mask {run!r}")
+        for start, end in _anchored_string_fields(region_raw):
+            value = region_raw[start:end]
+            if set(value) == {ord("X")}:
+                continue
+            decoded = value.decode("latin1")
+            if decoded in _PLACEHOLDERS:
+                continue
+            findings.append(
+                f"unmasked string beside a serial under the mask {decoded!r}"
+            )
 
     return findings
 
@@ -268,6 +279,37 @@ def test_the_gate_sees_a_string_beside_a_serial() -> None:
     assert any("3D1A32AC" in finding for finding in findings), findings
     assert any("Ecoflow_0379" in finding for finding in findings), findings
 
+    assert _leaks(sanitize_frame(frame, [])) == []
+
+
+def test_the_gate_sees_a_string_beside_a_serial_under_the_mask() -> None:
+    """Positive control for the region branch of the anchored check.
+
+    The product masks a neighbour's name under the XOR mask by running the
+    same passes over the unmasked region (ADR-023, ADR-025); the gate has
+    to see it there too, or it would accept a fixture the product would
+    have cleaned. Same record as above, carried as the XOR-ed `pdata` of a
+    header that declares `enc_type = 1` and its own `seq`.
+    """
+    key = 0x99
+    record = (
+        encode_field_varint(1, 1)
+        + encode_field_bytes(2, b"3D1A32AC")
+        + encode_field_bytes(3, b"X" * 16)
+        + encode_field_bytes(5, b"Ecoflow_0379")
+    )
+    plain = encode_field_bytes(1, record)
+    header = bytearray()
+    header.extend(encode_field_varint(6, 1))
+    header.extend(encode_field_varint(14, key))
+    header.extend(encode_field_bytes(1, bytes(b ^ key for b in plain)))
+    frame = encode_field_bytes(1, bytes(header))
+
+    findings = [f for f in _leaks(frame) if "beside a serial under the mask" in f]
+
+    assert len(findings) == 2, findings
+    assert any("3D1A32AC" in f for f in findings), findings
+    assert any("Ecoflow_0379" in f for f in findings), findings
     assert _leaks(sanitize_frame(frame, [])) == []
 
 

--- a/tests/test_frame_capture.py
+++ b/tests/test_frame_capture.py
@@ -459,6 +459,65 @@ class TestAnchoredStringMasking:
         assert self.FIELD2 not in result
         assert self.FIELD5 not in result
 
+    def test_a_name_after_the_serial_with_an_alphanumeric_tag_is_masked(self) -> None:
+        """Field 8 follows the serial with the tag byte `B`, which is in
+        `[A-Z0-9]`: the free-running serial pass would swallow that tag and
+        blind the walk to the rest of the message. The anchored pass runs
+        before it for exactly this case. Red when the pass moves back behind
+        `_SERIAL_RUN`.
+        """
+        record = (
+            encode_field_varint(1, 1)
+            + encode_field_bytes(3, self.SN.encode())
+            + encode_field_bytes(8, self.FIELD5)
+        )
+        frame = self._wrap(3, record)
+
+        result = sanitize_frame(frame, [])
+
+        assert self.FIELD5 not in result
+        at = frame.index(self.FIELD5)
+        assert result[at : at + len(self.FIELD5)] == b"X" * len(self.FIELD5)
+        assert self.SN.encode() not in result
+
+    def test_a_dotted_or_slashed_sibling_of_eight_characters_survives(self) -> None:
+        """The alphabet is the boundary for these, not the floor: both are
+        long enough to be candidates and are kept only because `.` and `/`
+        are outside `[A-Za-z0-9_-]`. Red when either character joins it.
+        """
+        record = (
+            encode_field_varint(1, 1)
+            + encode_field_bytes(2, b"V1.0.1.2")
+            + encode_field_bytes(3, self.SN.encode())
+            + encode_field_bytes(4, b"Asia/Tokyo")
+        )
+        frame = self._wrap(3, record)
+
+        result = _mask_anchored_strings(frame)
+
+        assert result == frame
+
+    def test_the_anchor_itself_is_not_a_candidate(self) -> None:
+        """A serial matches the candidate shape too, and is left to the
+        serial pass: the anchored pass never touches it, so two serials in
+        one message anchor each other and both survive this pass intact.
+        Red when the anchor exclusion is dropped.
+        """
+        other = "HJ31OTHERPACK001"
+        record = (
+            encode_field_varint(1, 1)
+            + encode_field_bytes(2, self.FIELD2)
+            + encode_field_bytes(3, self.SN.encode())
+            + encode_field_bytes(4, other.encode())
+        )
+        frame = self._wrap(3, record)
+
+        result = _mask_anchored_strings(frame)
+
+        assert self.SN.encode() in result
+        assert other.encode() in result
+        assert self.FIELD2 not in result
+
     def test_the_anchor_does_not_reach_across_messages(self) -> None:
         anchored = self._record(field2=None, field3=self.SN.encode())
         unanchored = encode_field_varint(1, 2) + encode_field_bytes(2, b"Guest_Network")
@@ -541,6 +600,10 @@ class TestAnchoredStringMasking:
 
         assert self.FIELD5 not in result_at_cap
         assert result_below_cap == below_cap
+        # The cap is the depth the collateral was measured at (ADR-025
+        # decision 3), so moving it is a measurement, not an edit. Pinned
+        # here because the two assertions above move with the constant.
+        assert _ANCHOR_DEPTH == 6
 
 
 class TestUUIDMasking:

--- a/tests/test_frame_capture.py
+++ b/tests/test_frame_capture.py
@@ -13,9 +13,14 @@ from ecoflow_energy.const import (
     RAW_FRAME_MAX_BYTES,
 )
 from ecoflow_energy.ecoflow.frame_capture import (
+    _ANCHOR_DEPTH,
+    _SERIAL_RUN,
     WRITE_CLASS_RESERVE,
     TypedFrameBuffer,
+    _anchored_string_fields,
+    _delimited_spans_by_message,
     _encrypted_regions,
+    _mask_anchored_strings,
     _plain_passes,
     _slot,
     _xor,
@@ -313,6 +318,229 @@ class TestDelimitedIdentifierMasking:
         result = sanitize_frame(payload, [])
 
         assert result == b"\x12\x10" + b"X" * 16
+
+
+class TestAnchoredStringMasking:
+    """The seventh pass: a neighbour's name and short id, masked by position.
+
+    Neither the delimited pass nor any shape pattern above it can see these
+    values on their own - the id is eight hex characters, under `_IDENT_MIN`,
+    and the name mixes a lower-case run with an underscore, outside every
+    alphabet above. The serial beside them is the boundary: within one
+    protobuf message, a whole field that is serial-shaped anchors every
+    other whole field of eight or more identifier-shaped characters
+    (PLAN-133, ADR-025).
+    """
+
+    SN = "HJ31TESTBAM40TX5"
+    FIELD2 = b"3D1A32AC"
+    FIELD5 = b"Ecoflow_0379"
+
+    @staticmethod
+    def _wrap(depth: int, payload: bytes) -> bytes:
+        """Nest `payload` `depth` delimited levels deep in field 1.
+
+        Matches how far `_delimited_spans_by_message` must descend before it
+        reads `payload` as a message of its own.
+        """
+        for _ in range(depth):
+            payload = encode_field_bytes(1, payload)
+        return payload
+
+    @classmethod
+    def _record(
+        cls,
+        *,
+        field2: bytes | None = FIELD2,
+        field3: bytes | None = None,
+        field5: bytes | None = FIELD5,
+    ) -> bytes:
+        """One record: a sequence number, then the fields under test."""
+        out = encode_field_varint(1, 1)
+        if field2 is not None:
+            out += encode_field_bytes(2, field2)
+        if field3 is not None:
+            out += encode_field_bytes(3, field3)
+        if field5 is not None:
+            out += encode_field_bytes(5, field5)
+        return out
+
+    @classmethod
+    def _depth3_frame(cls, **field_kwargs: bytes | None) -> bytes:
+        """A record wrapped 3 delimited levels down: frame, header, pdata."""
+        record = cls._record(field3=cls.SN.encode(), **field_kwargs)
+        return cls._wrap(3, record)
+
+    def test_the_record_the_other_passes_missed_is_masked(self) -> None:
+        frame = self._depth3_frame()
+        field2_offset = frame.index(self.FIELD2)
+        field5_offset = frame.index(self.FIELD5)
+
+        result = sanitize_frame(frame, [])
+
+        assert self.FIELD2 not in result
+        assert self.FIELD5 not in result
+        assert result[field2_offset : field2_offset + len(self.FIELD2)] == (
+            b"X" * len(self.FIELD2)
+        )
+        assert result[field5_offset : field5_offset + len(self.FIELD5)] == (
+            b"X" * len(self.FIELD5)
+        )
+
+    def test_the_earlier_passes_alone_leave_both_values(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The control: without this pass, neither value is touched."""
+        import ecoflow_energy.ecoflow.frame_capture as frame_capture_module
+
+        monkeypatch.setattr(frame_capture_module, "_mask_anchored_strings", lambda p: p)
+        frame = self._depth3_frame()
+
+        result = sanitize_frame(frame, [])
+
+        assert b"X" * len(self.SN) in result
+        assert self.FIELD2 in result
+        assert self.FIELD5 in result
+
+    def test_the_eight_character_hex_id_is_masked(self) -> None:
+        frame = self._depth3_frame(field5=None)
+        offset = frame.index(self.FIELD2)
+
+        result = sanitize_frame(frame, [])
+
+        assert self.FIELD2 not in result
+        assert result[offset : offset + 8] == b"X" * 8
+
+    def test_the_name_with_an_underscore_is_masked(self) -> None:
+        frame = self._depth3_frame(field2=None)
+        offset = frame.index(self.FIELD5)
+
+        result = sanitize_frame(frame, [])
+
+        assert self.FIELD5 not in result
+        assert result[offset : offset + 12] == b"X" * 12
+
+    def test_a_string_without_a_serial_beside_it_survives(self) -> None:
+        """`653` is not serial-shaped, so the message has no anchor at all."""
+        record = encode_field_varint(1, 1)
+        record += encode_field_bytes(2, self.FIELD2)
+        record += encode_field_bytes(3, b"653")
+        record += encode_field_bytes(7, b"plug_and_play")
+        frame = self._wrap(3, record)
+
+        assert sanitize_frame(frame, []) == frame
+
+    def test_a_sibling_outside_the_shape_survives(self) -> None:
+        """Under the floor, and outside the alphabet, in the same message.
+
+        The serial goes last: right after its raw run, `_SERIAL_RUN` (an
+        earlier, free-running pass) would otherwise swallow the very next
+        tag byte too, whenever that byte happens to also read as
+        `[A-Z0-9]` - corrupting the field this test means to check.
+        """
+        record = encode_field_varint(1, 1)
+        record += encode_field_bytes(6, b"android")
+        record += encode_field_bytes(8, b"V0.0.0")
+        record += encode_field_bytes(3, self.SN.encode())
+        frame = self._wrap(3, record)
+
+        result = sanitize_frame(frame, [])
+
+        assert b"android" in result
+        assert b"V0.0.0" in result
+
+    def test_a_serial_already_masked_is_still_the_anchor(self) -> None:
+        """A serial `_SERIAL_RUN` already turned into filler still matches."""
+        record = self._record(field3=b"X" * len(self.SN))
+        frame = self._wrap(3, record)
+
+        result = _mask_anchored_strings(frame)
+
+        assert self.FIELD2 not in result
+        assert self.FIELD5 not in result
+
+    def test_the_anchor_does_not_reach_across_messages(self) -> None:
+        anchored = self._record(field2=None, field3=self.SN.encode())
+        unanchored = encode_field_varint(1, 2) + encode_field_bytes(2, b"Guest_Network")
+        pdata = encode_field_bytes(9, anchored) + encode_field_bytes(10, unanchored)
+        frame = self._wrap(2, pdata)
+
+        result = sanitize_frame(frame, [])
+
+        assert self.FIELD5 not in result
+        assert b"Guest_Network" in result
+
+    def test_masking_preserves_length_and_the_bytes_around_it(self) -> None:
+        """Isolate the pass: `sanitize_frame` would also mask the serial
+        between the two spans through the free-running shape pass, which
+        would make the "everything else is untouched" claim false for the
+        wrong reason.
+        """
+        frame = self._depth3_frame()
+        field2_offset = frame.index(self.FIELD2)
+        field5_offset = frame.index(self.FIELD5)
+
+        result = _mask_anchored_strings(frame)
+
+        assert len(result) == len(frame)
+        assert result[:field2_offset] == frame[:field2_offset]
+        between_start = field2_offset + len(self.FIELD2)
+        assert result[between_start:field5_offset] == frame[between_start:field5_offset]
+        after_start = field5_offset + len(self.FIELD5)
+        assert result[after_start:] == frame[after_start:]
+
+    def test_a_truncated_frame_comes_out_no_worse(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # (a) cut inside the record itself: no exception, and whatever the
+        # six earlier passes already masked must not be undone.
+        frame = self._depth3_frame()
+        cut = frame[:-4]
+
+        result = sanitize_frame(cut, [])
+        assert result == _plain_passes(cut, [])
+
+        import ecoflow_energy.ecoflow.frame_capture as frame_capture_module
+
+        monkeypatch.setattr(frame_capture_module, "_mask_anchored_strings", lambda p: p)
+        six_passes_only = sanitize_frame(cut, [])
+        for index, byte in enumerate(six_passes_only):
+            if byte == ord("X"):
+                assert result[index] == ord("X")
+        monkeypatch.undo()
+
+        # (b) a two-header frame whose second header is cut short: the
+        # intact first header's record is still masked. The second header
+        # uses different values so the assertions below can only pass if
+        # they came from the intact first one.
+        header1 = self._wrap(3, self._record(field3=self.SN.encode()))
+        header2 = self._wrap(
+            3,
+            self._record(
+                field2=b"AABBCCDD", field3=self.SN.encode(), field5=b"Other_0001"
+            ),
+        )[:-6]
+        two_header_frame = header1 + header2
+
+        result2 = sanitize_frame(two_header_frame, [])
+
+        assert self.FIELD5 not in result2
+        assert self.FIELD2 not in result2
+
+    def test_a_record_at_the_depth_cap_is_masked_and_one_below_is_not(self) -> None:
+        """Isolate the pass itself: `sanitize_frame` would still mask the
+        serial at any depth through the free-running shape pass, which would
+        hide whether the anchored pass reached the record at all.
+        """
+        record = self._record(field3=self.SN.encode())
+        at_cap = self._wrap(_ANCHOR_DEPTH, record)
+        below_cap = self._wrap(_ANCHOR_DEPTH + 1, record)
+
+        result_at_cap = _mask_anchored_strings(at_cap)
+        result_below_cap = _mask_anchored_strings(below_cap)
+
+        assert self.FIELD5 not in result_at_cap
+        assert result_below_cap == below_cap
 
 
 class TestUUIDMasking:
@@ -881,6 +1109,37 @@ class TestEncryptedRegionMasking:
         header = _decode_first_header(result)
         assert _unmask_pdata(header) == b"X" * 16
 
+    def test_an_anchored_record_under_the_mask_is_masked(self) -> None:
+        """A neighbour's name beside a serial is masked under the XOR mask too.
+
+        The seventh pass runs inside `_plain_passes`, so a region a header
+        declares masked gets it by the same route as the six before it
+        (ADR-025 decision 5). Red when the pass is called from
+        `sanitize_frame` over the raw frame instead of from the helper.
+        """
+        record = (
+            encode_field_varint(1, 1)
+            + encode_field_bytes(2, b"3D1A32AC")
+            + encode_field_bytes(3, b"HJ31TESTBAM40TX5")
+            + encode_field_bytes(5, b"Ecoflow_0379")
+        )
+        plain = encode_field_bytes(1, record)
+        frame = _enc_header(2, 133, pdata_plain=plain, seq=self._KEY)
+
+        result = sanitize_frame(frame, [])
+
+        assert len(result) == len(frame)
+        regions = _encrypted_regions(frame)
+        assert len(regions) == 1 and regions[0].key == self._KEY, regions
+        region = regions[0]
+        unmasked = _xor(result[region.start : region.end], self._KEY)
+        for value in (b"3D1A32AC", b"HJ31TESTBAM40TX5", b"Ecoflow_0379"):
+            assert value not in unmasked
+            at = plain.index(value)
+            assert unmasked[at : at + len(value)] == b"X" * len(value), value
+        assert result[: region.start] == frame[: region.start]
+        assert result[region.end :] == frame[region.end :]
+
 
 class TestMaskingDoesNotCorruptRealFrames:
     """The guard the history of this mask asks for.
@@ -1091,6 +1350,37 @@ class TestMaskingDoesNotCorruptRealFrames:
         # regions unmasked. The floor sits below that with headroom, not on
         # it, so one fixture removed does not silently pass.
         assert checked >= 61, checked
+
+    def test_no_string_beside_a_serial_survives_in_a_tracked_frame(self) -> None:
+        """The guard for PLAN-133: nothing beside a serial is left standing.
+
+        Walks every tracked frame through `sanitize_frame`, then asks the
+        product's own walker what still sits beside a serial - on the frame
+        and under every region it unmasks - and requires every answer to be
+        a run of X. The floor counts ANCHORED MESSAGES the walker found, not
+        frames visited: a walker that silently stopped finding serials would
+        satisfy an empty loop just as well as a clean one.
+        """
+        anchored = 0
+        for name, raw in self._captures():
+            sanitized = sanitize_frame(raw, [])
+            views = [sanitized]
+            for region in _encrypted_regions(sanitized):
+                if region.key is None:
+                    continue
+                views.append(_xor(sanitized[region.start : region.end], region.key))
+            for view in views:
+                for spans in _delimited_spans_by_message(view):
+                    if any(_SERIAL_RUN.fullmatch(view, s, e) for s, e in spans):
+                        anchored += 1
+                for start, end in _anchored_string_fields(view):
+                    assert set(view[start:end]) == {ord("X")}, (name, view[start:end])
+
+        # Measured on this corpus on 2026-09-09: 162 anchored messages over
+        # 162 frames - every frame's header carries the device serial, so
+        # the header itself is the anchored message. The floor sits below
+        # that with headroom, so one fixture removed does not silently pass.
+        assert anchored >= 150, anchored
 
 
 class TestIsProtoFrame:


### PR DESCRIPTION
## Related Issue

None public. The affected files are a reporter's diagnostics downloads, shared by mail; the reporter was told the gap would be closed.

## Summary

The diagnostics masking now covers a device's neighbours. A PowerPulse 2 reports, in message `2/133`, a record per neighbour: a serial, an eight-character hex id and a name such as `Ecoflow_0378`. The serial was masked in the download and the two fields beside it were not, because neither matches any shape the masking tests for: eight characters is under the delimited floor of twelve, and the name mixes lower case with an underscore.

The serial is now the boundary. Within one protobuf message, a whole delimited field that is serial-shaped anchors every other whole field of eight or more characters from `[A-Za-z0-9_-]`, which is masked X for X. The pass runs inside `_plain_passes`, so it also applies under the XOR mask, and it runs before the free-running passes, because the serial pass is greedy and would otherwise swallow an alphanumeric tag byte after a serial and blind the walk.

Measured over every capture and fixture on file (20,324 hex blobs, 2,379 frames through the corpus sweep): the four values from the two downloads are the only fields reached, 0 length, header or parser reading changes, 0 findings in the tracked fixtures.

## Changes

- `frame_capture.py`: `_delimited_spans_by_message` (tolerant walk, six levels, never raises), `_anchored_string_fields`, `_mask_anchored_strings`; the seventh pass in `_plain_passes`, placed second.
- `tests/test_frame_capture.py`: `TestAnchoredStringMasking` (14 cases), an under-the-mask case, a corpus floor test that counts anchored messages rather than frames.
- `tests/test_fixture_identifiers.py`: the per-frame checks move into `_leaks`, which gains the anchored check on the frame and under every region, with a positive and a negative control.
- CHANGELOG entry under 1.21.0, Fixed.

Every new test has a mutation that turns it red: pass removed, floor lowered, alphabet widened, anchor exclusion dropped, depth cap moved, walk not descending, pass moved back behind the serial pass, gate branch removed.

## Checklist

- [x] Tests pass (`pytest`)
- [x] CHANGELOG.md updated
- [x] Version bumped in `manifest.json` (if code change) - already 1.21.0 for this cycle
- [ ] README updated (if new sensors, features, or behavior changes) - not needed, no entity or behaviour change
- [x] No secrets or real device serial numbers in code
