### PR TITLE
Use dummy neighbour values in the masking tests and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- The diagnostics download masks two more things a device says about its neighbours: the name and the short id that sit beside a serial in the same record. On a PowerPulse 2 those read `Ecoflow_0378` and `BD1954BF` and were left in plain text in a download the owner had shared, while the serial next to them was masked. The masking now treats a serial as the boundary: any string of eight or more characters that shares a protobuf record with a serial is replaced by `X`, whatever its spelling, so a name an owner typed is covered as well. Measured over every capture on file: the four values are the only fields touched, and no reading, length or header field changes. The fixture check that guards this repository sees the same shape now.
+- The diagnostics download masks two more things a device says about its neighbours: the name and the short id that sit beside a serial in the same record. On a PowerPulse 2 those are a network name of the form `Ecoflow_` plus four digits and an eight-character hex id, and both were left in plain text in a download the owner had shared, while the serial next to them was masked. The masking now treats a serial as the boundary: any string of eight or more characters that shares a protobuf record with a serial is replaced by `X`, whatever its spelling, so a name an owner typed is covered as well. Measured over every capture on file: the four values are the only fields touched, and no reading, length or header field changes. The fixture check that guards this repository sees the same shape now.
 
 ### Changed
 

--- a/tests/test_fixture_identifiers.py
+++ b/tests/test_fixture_identifiers.py
@@ -268,16 +268,16 @@ def test_the_gate_sees_a_string_beside_a_serial() -> None:
     """
     record = (
         encode_field_varint(1, 1)
-        + encode_field_bytes(2, b"3D1A32AC")
+        + encode_field_bytes(2, b"A1B2C3D4")
         + encode_field_bytes(3, b"X" * 16)
-        + encode_field_bytes(5, b"Ecoflow_0379")
+        + encode_field_bytes(5, b"Ecoflow_1234")
     )
     frame = _wrap_as_record(record)
 
     findings = _leaks(frame)
     assert len(findings) == 2, findings
-    assert any("3D1A32AC" in finding for finding in findings), findings
-    assert any("Ecoflow_0379" in finding for finding in findings), findings
+    assert any("A1B2C3D4" in finding for finding in findings), findings
+    assert any("Ecoflow_1234" in finding for finding in findings), findings
 
     assert _leaks(sanitize_frame(frame, [])) == []
 
@@ -294,9 +294,9 @@ def test_the_gate_sees_a_string_beside_a_serial_under_the_mask() -> None:
     key = 0x99
     record = (
         encode_field_varint(1, 1)
-        + encode_field_bytes(2, b"3D1A32AC")
+        + encode_field_bytes(2, b"A1B2C3D4")
         + encode_field_bytes(3, b"X" * 16)
-        + encode_field_bytes(5, b"Ecoflow_0379")
+        + encode_field_bytes(5, b"Ecoflow_1234")
     )
     plain = encode_field_bytes(1, record)
     header = bytearray()
@@ -308,8 +308,8 @@ def test_the_gate_sees_a_string_beside_a_serial_under_the_mask() -> None:
     findings = [f for f in _leaks(frame) if "beside a serial under the mask" in f]
 
     assert len(findings) == 2, findings
-    assert any("3D1A32AC" in f for f in findings), findings
-    assert any("Ecoflow_0379" in f for f in findings), findings
+    assert any("A1B2C3D4" in f for f in findings), findings
+    assert any("Ecoflow_1234" in f for f in findings), findings
     assert _leaks(sanitize_frame(frame, [])) == []
 
 
@@ -320,7 +320,7 @@ def test_the_gate_is_quiet_without_a_serial() -> None:
     yields no candidates at all, however identifier-shaped its neighbours are.
     """
     record = encode_field_bytes(2, b"plug_and_play") + encode_field_bytes(
-        3, b"3D1A32AC"
+        3, b"A1B2C3D4"
     )
     frame = _wrap_as_record(record)
 

--- a/tests/test_frame_capture.py
+++ b/tests/test_frame_capture.py
@@ -333,8 +333,8 @@ class TestAnchoredStringMasking:
     """
 
     SN = "HJ31TESTBAM40TX5"
-    FIELD2 = b"3D1A32AC"
-    FIELD5 = b"Ecoflow_0379"
+    FIELD2 = b"A1B2C3D4"
+    FIELD5 = b"Ecoflow_1234"
 
     @staticmethod
     def _wrap(depth: int, payload: bytes) -> bytes:
@@ -1182,9 +1182,9 @@ class TestEncryptedRegionMasking:
         """
         record = (
             encode_field_varint(1, 1)
-            + encode_field_bytes(2, b"3D1A32AC")
+            + encode_field_bytes(2, b"A1B2C3D4")
             + encode_field_bytes(3, b"HJ31TESTBAM40TX5")
-            + encode_field_bytes(5, b"Ecoflow_0379")
+            + encode_field_bytes(5, b"Ecoflow_1234")
         )
         plain = encode_field_bytes(1, record)
         frame = _enc_header(2, 133, pdata_plain=plain, seq=self._KEY)
@@ -1196,7 +1196,7 @@ class TestEncryptedRegionMasking:
         assert len(regions) == 1 and regions[0].key == self._KEY, regions
         region = regions[0]
         unmasked = _xor(result[region.start : region.end], self._KEY)
-        for value in (b"3D1A32AC", b"HJ31TESTBAM40TX5", b"Ecoflow_0379"):
+        for value in (b"A1B2C3D4", b"HJ31TESTBAM40TX5", b"Ecoflow_1234"):
             assert value not in unmasked
             at = plain.index(value)
             assert unmasked[at : at + len(value)] == b"X" * len(value), value


### PR DESCRIPTION
## Related Issue

None.

## Summary

Follow-up to #382. The tests and the CHANGELOG entry for the anchored masking pass quoted the network name and the eight-character id from the reporter's own diagnostics download. Those are exactly the values the pass exists to keep out of public places, so they are replaced with dummies of the same shape (`Ecoflow_1234`, `A1B2C3D4`). No behaviour changes; the same 177 tests in the two files pass.

## Changes

- `tests/test_frame_capture.py`, `tests/test_fixture_identifiers.py`: dummy values
- `CHANGELOG.md`: the 1.21.0 entry describes the shape instead of quoting the values

## Checklist

- [x] Tests pass (`pytest`)
- [x] CHANGELOG.md updated
- [x] Version bumped in `manifest.json` (if code change) - no code change
- [x] README updated (if new sensors, features, or behavior changes) - not applicable
- [x] No secrets or real device serial numbers in code
