### PR TITLE
docs: date the 1.21.0 entry for the full release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.21.0] - 2026-09-08
+## [1.21.0] - 2026-09-11
 
 ### Added
 


### PR DESCRIPTION
The 1.21.0 entry carried the date of its first pre-release, 2026-09-08. The full release goes out today, so the entry carries today's date. Docs only.