### PR TITLE
test: entity definition reachability, and a README section on connection recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,46 @@ automation:
 
 ---
 
+## When the Connection Drops
+
+<details>
+<summary><b>How the connection recovers on its own</b></summary>
+
+**While data is flowing.** In Enhanced Mode the device pushes its readings and the integration keeps that connection busy so the server does not close it. A PowerOcean is asked for its live stream again every 20 seconds, every device is asked for its latest values every 30 seconds, and a ping goes out every 60 seconds. A Smart Plug also gets a full snapshot every 120 seconds, because it reports in bursts with quiet stretches in between.
+
+**When the connection breaks.** The integration reconnects by itself, with a growing pause between attempts: 5 seconds, then 10, 20, 40, and from there a fixed 60 seconds. Each attempt uses a new client identity, which is what gets a session accepted again after the server has dropped the old one. After ten attempts it pauses for up to five minutes and then starts a fresh cycle. There is no attempt limit at which it stops trying.
+
+**What the entities do meanwhile.** Nothing disappears the moment data stops. The integration counts the age of the last reading and moves through three stages:
+
+| Stage | Age of the last reading | What you see |
+|:---|:---|:---|
+| Stale | over 35 seconds | Entities keep their values, reconnect attempts are running |
+| Degraded | over 5 minutes | Entities keep their values, and those values are visibly old |
+| Unavailable | over 10 minutes | Entities go unavailable in Home Assistant |
+
+Some devices report less often, and those get longer windows so a quiet device is not declared gone:
+
+| Device | Stale | Degraded | Unavailable |
+|:---|:---|:---|:---|
+| Smart Plug (with account sign-in) | 3 minutes | 6 minutes | 10 minutes |
+| WAVE 3 in standby | 4.5 minutes | 9 minutes | 10 minutes |
+| PowerPulse 2 | 20 minutes | 40 minutes | 60 minutes |
+
+A WAVE 3 that is running pushes every couple of seconds and uses the standard windows. The PowerPulse 2 windows always apply: it pushes when something changes and otherwise stays quiet for long stretches, charging or not.
+
+In Standard Mode the HTTP poll decides availability instead. Entities go unavailable when the polls themselves keep failing, not when a push pauses.
+
+**What clears it.** The next frame received from the device. The stage resets immediately, the entities pick up the new values, and nothing needs to be restarted or reloaded.
+
+**Where to look.** Every device has two diagnostic sensors:
+
+- **MQTT Status** reports the connection itself: `receiving` while frames arrive, `connected_stale` while the connection is open but the device is quiet, `disconnected` while a reconnect is pending.
+- **Connection Mode** reports which path is in use: `standard`, `enhanced`, or `enhanced_fallback` when the integration has fallen back to polling.
+
+</details>
+
+---
+
 ## Troubleshooting
 
 <details>

--- a/tests/test_entity_definitions.py
+++ b/tests/test_entity_definitions.py
@@ -29,8 +29,9 @@ key's reachability and read as covered while nothing dispatches it.
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 import pytest
 from ecoflow_energy import const as C

--- a/tests/test_entity_definitions.py
+++ b/tests/test_entity_definitions.py
@@ -1,0 +1,263 @@
+"""Entity definition reachability tests.
+
+Guards the contract between the definition blocks in const.py and the
+platform dispatchers that hand them to Home Assistant:
+
+1. No orphaned definition block. Every module-level list in const.py named
+   ``<FAMILY>_<PLATFORM>`` is returned by at least one dispatcher for at
+   least one (device type, serial, platform) combination, and every single
+   definition inside it is reachable for at least one serial.
+2. No device type without any entity. Every ``DEVICE_TYPE_*`` constant
+   yields at least one sensor. Sensors are the invariant rather than every
+   platform: the Smart Meter measures and reports, it stores nothing and
+   switches nothing, so it legitimately has no switches and no numbers
+   (see the device type block in ``ecoflow/const.py``).
+
+Not covered here, because it is covered elsewhere and duplicating it would
+give one failure two owners: the translation-key contract lives in
+``tests/test_entity_translations.py``, strings.json / en.json drift in
+``tests/test_translations.py``.
+
+A block counts as dispatched when a dispatcher returned the block object
+itself, or returned a non-empty selection whose definitions are all members
+of that block. The comparison is by definition-object identity rather than
+by key, because several device families name the same reading with the same
+key: a new block copied from an existing one would otherwise inherit that
+key's reachability and read as covered while nothing dispatches it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+from ecoflow_energy import const as C
+from ecoflow_energy.binary_sensor import _get_binary_sensor_defs
+from ecoflow_energy.ecoflow import const as EC
+from ecoflow_energy.number import _get_number_defs
+from ecoflow_energy.select import _get_select_defs
+from ecoflow_energy.sensor import _get_sensor_defs
+from ecoflow_energy.switch import _get_switch_defs
+
+COMPONENT_DIR = Path(__file__).resolve().parent.parent / "custom_components"
+CONST_PY = COMPONENT_DIR / "ecoflow_energy" / "const.py"
+BUTTON_PY = COMPONENT_DIR / "ecoflow_energy" / "button.py"
+
+PLATFORM_SUFFIXES = (
+    "SENSORS",
+    "BINARY_SENSORS",
+    "SWITCHES",
+    "NUMBERS",
+    "SELECTS",
+    "BUTTONS",
+)
+DEF_LIST_NAME = re.compile(rf"[A-Z0-9]+_({'|'.join(PLATFORM_SUFFIXES)})")
+# The same names as DEF_LIST_NAME would match, plus the ones that carry an
+# extra underscore and are therefore invisible to it.
+DEF_LIST_NAME_LOOSE = re.compile(
+    rf"^([A-Z0-9_]+_(?:{'|'.join(PLATFORM_SUFFIXES)}))\s*[:=]", re.MULTILINE
+)
+
+# The device type that stands for "not classified". It reaches no parser and
+# therefore no definition list; `_get_sensor_defs` returns [] for it.
+UNCLASSIFIED_DEVICE_TYPE = EC.DEVICE_TYPE_UNKNOWN
+
+
+def _button_defs(device_type: str, device_sn: str) -> list[Any]:
+    """Mirror the button platform's device-type branch.
+
+    ``button.py`` has no ``_get_button_defs`` helper - it selects the list
+    inline in ``async_setup_entry`` (the PowerPulse 2 branch). This shim
+    reproduces that one branch, and `test_button_platform_branch_is_the_only_one`
+    below fails if the platform ever grows a second one, so the shim cannot
+    drift away from it unnoticed.
+    """
+    if device_type == EC.DEVICE_TYPE_POWERPULSE2:
+        return C.POWERPULSE2_BUTTONS
+    return []
+
+
+# Every dispatcher is called as (device_type, device_sn); the two that ignore
+# the serial are wrapped so the call site stays uniform.
+DISPATCHERS: dict[str, Callable[[str, str], list[Any]]] = {
+    "SENSORS": lambda device_type, device_sn: _get_sensor_defs(device_type),
+    "BINARY_SENSORS": lambda device_type, device_sn: _get_binary_sensor_defs(
+        device_type
+    ),
+    "SWITCHES": _get_switch_defs,
+    "NUMBERS": _get_number_defs,
+    "SELECTS": _get_select_defs,
+    "BUTTONS": _button_defs,
+}
+
+# Dummy serials: a four-character prefix and filler, never a real serial.
+_FILLER = "0000000000000000"
+# The serial classes the dispatchers actually consult, plus the two cases in
+# no table at all: no serial (both control gates close on it) and a prefix on
+# no allowlist.
+SERIALS: tuple[str, ...] = ("", "ZZZZ" + _FILLER) + tuple(
+    prefix + _FILLER
+    for prefix in sorted(C.STREAM_AC5000_CONTROL_PREFIXES | C.STREAM_CONTROL_PREFIXES)
+)
+
+DEVICE_TYPES: dict[str, str] = {
+    name: getattr(EC, name)
+    for name in dir(EC)
+    if name.startswith("DEVICE_TYPE_") and isinstance(getattr(EC, name), str)
+}
+
+
+def _definition_blocks() -> dict[str, list[Any]]:
+    """Return every module-level definition list in const.py, by name."""
+    return {
+        name: getattr(C, name)
+        for name in dir(C)
+        if DEF_LIST_NAME.fullmatch(name) and isinstance(getattr(C, name), list)
+    }
+
+
+def _dispatcher_outputs() -> list[list[Any]]:
+    """Every list any dispatcher returns, over the full combination space."""
+    outputs: list[list[Any]] = []
+    for device_type in sorted(set(DEVICE_TYPES.values())):
+        for device_sn in SERIALS:
+            for dispatch in DISPATCHERS.values():
+                outputs.append(dispatch(device_type, device_sn))
+    return outputs
+
+
+BLOCKS = _definition_blocks()
+OUTPUTS = _dispatcher_outputs()
+REACHED_DEF_IDS = {id(definition) for output in OUTPUTS for definition in output}
+
+
+def _is_dispatched(block: list[Any]) -> bool:
+    """Whether any dispatcher hands this block, or a selection of it, to HA."""
+    member_ids = {id(definition) for definition in block}
+    for output in OUTPUTS:
+        if output is block:
+            return True
+        # `if output` first: the empty list every dispatcher returns for an
+        # unknown device type is a subset of everything, and would otherwise
+        # mark every block reachable.
+        if output and member_ids.issuperset({id(item) for item in output}):
+            return True
+    return False
+
+
+def test_definition_block_names_follow_the_convention() -> None:
+    """A definition block carries one family token, then the platform.
+
+    Discovery here and in `tests/test_entity_translations.py` walks
+    `dir(const)` with `[A-Z0-9]+_<PLATFORM>`, which matches one family token
+    and no more: `STREAMAC5000_SENSORS` is spelled without the underscore for
+    exactly this reason. A block named `STREAM_AC5000_SENSORS` would be
+    skipped by every one of those tests without failing any of them, so the
+    naming itself is checked before anything is built on it.
+    """
+    offenders = sorted(
+        name
+        for name in DEF_LIST_NAME_LOOSE.findall(CONST_PY.read_text())
+        if not DEF_LIST_NAME.fullmatch(name)
+    )
+    assert not offenders, (
+        "Entity definition blocks whose name carries more than one family "
+        f"token: {offenders}. Convention-based discovery cannot see them, so "
+        "they are checked by no reachability and no translation test. Join "
+        "the family into one token, as STREAMAC5000_SENSORS does."
+    )
+
+
+def test_source_declarations_match_runtime_discovery() -> None:
+    """The reflection above sees every block const.py declares.
+
+    Positive control for the two tests below: they walk `dir(const)`, and a
+    block the walk cannot see is a block they silently never check.
+    """
+    declared = {
+        name
+        for name in DEF_LIST_NAME_LOOSE.findall(CONST_PY.read_text())
+        if DEF_LIST_NAME.fullmatch(name)
+    }
+    assert declared == set(BLOCKS), (
+        "const.py declares definition blocks the runtime walk does not see, or "
+        f"the other way round. Only in source: {sorted(declared - set(BLOCKS))}. "
+        f"Only in runtime: {sorted(set(BLOCKS) - declared)}"
+    )
+
+
+def test_every_platform_suffix_has_a_dispatcher() -> None:
+    """No block family without a dispatcher to check it against."""
+    suffixes = set()
+    for name in BLOCKS:
+        match = DEF_LIST_NAME.fullmatch(name)
+        assert match is not None
+        suffixes.add(match.group(1))
+    missing = sorted(suffixes - set(DISPATCHERS))
+    assert not missing, f"Definition blocks with no dispatcher in this test: {missing}"
+
+
+def test_button_platform_branch_is_the_only_one() -> None:
+    """`_button_defs` mirrors button.py, so button.py may name only that list."""
+    named = set(re.findall(r"\b[A-Z0-9]+_BUTTONS\b", BUTTON_PY.read_text()))
+    assert named == {"POWERPULSE2_BUTTONS"}, (
+        "button.py selects button definitions inline and this test file mirrors "
+        f"that branch in `_button_defs`. button.py now names {sorted(named)} - "
+        "update the shim, or the new list is never checked for reachability."
+    )
+
+
+def test_no_orphaned_definition_block() -> None:
+    """Every definition block reaches Home Assistant through some dispatcher."""
+    orphans = [
+        f"{name}: no dispatcher returns it for any of {len(DEVICE_TYPES)} "
+        f"device types x {len(SERIALS)} serials"
+        for name, block in sorted(BLOCKS.items())
+        if not _is_dispatched(block)
+    ]
+    assert not orphans, "Orphaned entity definition blocks in const.py:\n" + "\n".join(
+        orphans
+    )
+
+
+def test_no_unreachable_definition_inside_a_block() -> None:
+    """Every single definition is reachable for at least one serial.
+
+    A definition can be dispatched-but-unreachable: the Stream number gate
+    returns a key subset for a serial outside STREAM_CONTROL_PREFIXES (see
+    the Stream branch of `_get_number_defs`), so the block is compared
+    definition by definition rather than as a whole.
+    """
+    unreachable: list[str] = []
+    for name, block in sorted(BLOCKS.items()):
+        missing = [
+            definition.key
+            for definition in block
+            if id(definition) not in REACHED_DEF_IDS
+        ]
+        if missing:
+            unreachable.append(f"{name}: {sorted(missing)}")
+    assert not unreachable, "Entity definitions no dispatcher ever returns:\n" + (
+        "\n".join(unreachable)
+    )
+
+
+@pytest.mark.parametrize(
+    "constant",
+    sorted(
+        name
+        for name, value in DEVICE_TYPES.items()
+        if value != UNCLASSIFIED_DEVICE_TYPE
+    ),
+)
+def test_every_device_type_has_sensors(constant: str) -> None:
+    """Every classified device type produces at least one sensor."""
+    device_type = DEVICE_TYPES[constant]
+    defs = _get_sensor_defs(device_type)
+    assert defs, (
+        f"{constant} ({device_type!r}) yields no sensor definitions. A device "
+        "type with no sensor produces a device entry with nothing in it - "
+        "either wire it into _get_sensor_defs or remove the type."
+    )


### PR DESCRIPTION
## Summary

- New `tests/test_entity_definitions.py` (17 tests): every `*_SENSORS` / `*_SWITCHES` / `*_NUMBERS` / `*_SELECTS` / `*_BUTTONS` / `*_BINARY_SENSORS` block in `const.py` must be returned by at least one dispatcher for at least one device type, serial class and mode; every device type must yield at least one sensor; and block names must follow the single-family-token convention the discovery depends on.
- README gains "When the Connection Drops": keepalive intervals, the reconnect schedule, the three stages after data stops with per-device thresholds, what clears them, and the two diagnostic sensors to look at. No figure, no comparison.

No change under `custom_components/`, so no version bump.

## Evidence

- Red probes before green: a deliberately orphaned block (`PROBEORPHAN_SENSORS`) failed two tests naming it; a two-token name (`PROBE_ORPHAN_SENSORS`) failed the convention test; the WAVE 3 branch removed from `_get_sensor_defs` failed three tests naming `WAVE3_SENSORS` and `DEVICE_TYPE_WAVE3`. Restored, 17 passed.
- Full suite in the main checkout: 3752 passed, 1 skipped.
- Every README sentence traces to a code line (`const.py`, `coordinator/availability.py`, `coordinator/keepalive.py`, `ecoflow/cloud_mqtt.py`).
