### PR TITLE
test: hold strings.json and en.json to the same text across the whole document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `strings.json` now carries the same entity names and states as the rendered `translations/en.json`. The two files are one language, and the test that held them together only compared the setup steps, so the entity section had drifted by 114 keys: 108 entity names and enum states existed only in the rendered file, and the three connectivity sensors still read `Not Detected` / `OK` in `strings.json` while the integration reports `Disconnected` / `Connected`. Nothing changes in Home Assistant, which reads only the rendered file. The test now compares the whole document, so the two cannot drift again.
 - A diagnostics download that is masked a second time keeps its masked frames intact. A serial the masking has already replaced can, under a payload the device XOR-masks, read on the wire as a run of one letter that happens to look like a serial again; the masking rewrote that run and left a stray letter where the mask byte had been. Found while building a test fixture from the masking's own output: two of nine frames came back changed. The masking now restores such a run only when everything under it is already the mask byte, so a payload whose header claims a mask it does not carry is still masked as before. Measured over every recording on file: nothing else moves.
 
 ## [1.21.0] - 2026-09-11

--- a/custom_components/ecoflow_energy/strings.json
+++ b/custom_components/ecoflow_energy/strings.json
@@ -161,6 +161,33 @@
   },
   "entity": {
     "sensor": {
+      "cms_batt_soc": {
+        "name": "SoC"
+      },
+      "pow_in_sum_w": {
+        "name": "Input Total"
+      },
+      "pow_out_sum_w": {
+        "name": "Output Total"
+      },
+      "pv1_in_w": {
+        "name": "Solar Input 1"
+      },
+      "pv2_in_w": {
+        "name": "Solar Input 2"
+      },
+      "dc_12v_out_w": {
+        "name": "12V Output"
+      },
+      "ac1_out_w": {
+        "name": "AC Output 1"
+      },
+      "ac2_out_w": {
+        "name": "AC Output 2"
+      },
+      "typec3_w": {
+        "name": "Type-C 3"
+      },
       "solar_w": {
         "name": "Solar Power"
       },
@@ -217,6 +244,12 @@
       },
       "batt_design_cap_mah": {
         "name": "Design Capacity"
+      },
+      "batt_charge_capacity_ah": {
+        "name": "Battery Charge Capacity"
+      },
+      "batt_discharge_capacity_ah": {
+        "name": "Battery Discharge Capacity"
       },
       "grid_import_power_w": {
         "name": "Grid Import Power"
@@ -445,6 +478,33 @@
           "discharging": "Discharging",
           "charging": "Charging"
         }
+      },
+      "soc_precise_pct": {
+        "name": "Battery SOC (Precise)"
+      },
+      "unit_batt_w": {
+        "name": "Unit Battery Power"
+      },
+      "unit_soc_pct": {
+        "name": "Unit Battery SOC"
+      },
+      "ac_voltage_v": {
+        "name": "AC Voltage"
+      },
+      "ac_frequency_hz": {
+        "name": "AC Frequency"
+      },
+      "backup_reserve_pct": {
+        "name": "Backup Reserve"
+      },
+      "max_charge_soc_pct": {
+        "name": "Max Charge SoC"
+      },
+      "min_discharge_soc_pct": {
+        "name": "Min Discharge SoC"
+      },
+      "ac_charge_power_limit_w": {
+        "name": "AC Charge Power Limit"
       },
       "soc": {
         "name": "SoC"
@@ -1181,22 +1241,22 @@
       "wifi_status": {
         "name": "WiFi Status",
         "state": {
-          "not_detected": "Not Detected",
-          "ok": "OK"
+          "disconnected": "Disconnected",
+          "connected": "Connected"
         }
       },
       "ethernet_status": {
         "name": "Ethernet Status",
         "state": {
-          "not_detected": "Not Detected",
-          "ok": "OK"
+          "disconnected": "Disconnected",
+          "connected": "Connected"
         }
       },
       "cellular_status": {
         "name": "4G Status",
         "state": {
-          "not_detected": "Not Detected",
-          "ok": "OK"
+          "disconnected": "Disconnected",
+          "connected": "Connected"
         }
       },
       "ems_led_brightness": {
@@ -1231,6 +1291,9 @@
       },
       "bp_max_discharge_power_w": {
         "name": "Battery Discharge Power (Max)"
+      },
+      "anderson_out_w": {
+        "name": "Anderson output"
       },
       "pv_total_w": {
         "name": "PV Total Power"
@@ -1427,11 +1490,84 @@
           "faulted": "Fault"
         }
       },
-      "unit_batt_w": {
-        "name": "Unit Battery Power"
+      "ev_voltage_l1_v": {
+        "name": "Wallbox Voltage L1"
       },
-      "unit_soc_pct": {
-        "name": "Unit Battery SOC"
+      "ev_voltage_l2_v": {
+        "name": "Wallbox Voltage L2"
+      },
+      "ev_voltage_l3_v": {
+        "name": "Wallbox Voltage L3"
+      },
+      "ev_current_l1_a": {
+        "name": "Wallbox Current L1"
+      },
+      "ev_current_l2_a": {
+        "name": "Wallbox Current L2"
+      },
+      "ev_current_l3_a": {
+        "name": "Wallbox Current L3"
+      },
+      "ev_max_current_a": {
+        "name": "Wallbox Maximum Current"
+      },
+      "ev_charge_current_a": {
+        "name": "Wallbox Charging Current"
+      },
+      "ev_phase_mode": {
+        "name": "Wallbox Phase Mode",
+        "state": {
+          "single_phase": "Single Phase",
+          "three_phase": "Three Phase"
+        }
+      },
+      "ev_session_status": {
+        "name": "Wallbox Session Status",
+        "state": {
+          "idle": "Idle",
+          "charging": "Charging",
+          "finished": "Finished"
+        }
+      },
+      "ev_session_start_ts": {
+        "name": "Wallbox Session Start"
+      },
+      "ev_session_start_energy_wh": {
+        "name": "Wallbox Session Start Meter"
+      },
+      "ev_total_energy_wh": {
+        "name": "Wallbox Total Energy"
+      },
+      "inv_output_w": {
+        "name": "Inverter Output Power"
+      },
+      "inv_output_energy_kwh": {
+        "name": "Inverter Output Energy"
+      },
+      "plug_total_w": {
+        "name": "Smart Plug Load Power"
+      },
+      "permanent_watts_w": {
+        "name": "Custom Load Power"
+      },
+      "lower_limit_pct": {
+        "name": "Discharge Limit"
+      },
+      "upper_limit_pct": {
+        "name": "Charge Limit"
+      },
+      "rated_power_w": {
+        "name": "Rated Power"
+      },
+      "pv1_voltage_v": {
+        "name": "PV 1 Voltage"
+      },
+      "supply_priority": {
+        "name": "Power Supply Priority",
+        "state": {
+          "power_supply": "Prioritize Power Supply",
+          "battery_storage": "Prioritize Battery Storage"
+        }
       },
       "grid_l1_w": {
         "name": "Phase A Power"
@@ -1480,6 +1616,52 @@
       },
       "grid_power_factor": {
         "name": "Power Factor"
+      },
+      "schedule_1_window": {
+        "name": "Schedule 1 Window"
+      },
+      "schedule_2_window": {
+        "name": "Schedule 2 Window"
+      },
+      "schedule_3_window": {
+        "name": "Schedule 3 Window"
+      },
+      "schedule_4_window": {
+        "name": "Schedule 4 Window"
+      },
+      "schedule_5_window": {
+        "name": "Schedule 5 Window"
+      },
+      "schedule_6_window": {
+        "name": "Schedule 6 Window"
+      },
+      "schedule_7_window": {
+        "name": "Schedule 7 Window"
+      },
+      "schedule_8_window": {
+        "name": "Schedule 8 Window"
+      },
+      "tilt_angle_deg": {
+        "name": "Tilt Angle"
+      },
+      "target_angle_deg": {
+        "name": "Target Angle"
+      },
+      "optimal_angle_deg": {
+        "name": "Optimal Angle"
+      },
+      "light_level": {
+        "name": "Light Level"
+      },
+      "battery_pct": {
+        "name": "Battery"
+      },
+      "tracking_mode": {
+        "name": "Mode",
+        "state": {
+          "manual": "Manual",
+          "auto": "Automatic"
+        }
       },
       "temp_ambient_c": {
         "name": "Ambient Temperature"
@@ -1573,11 +1755,38 @@
       "ems_sg_ready_enabled": {
         "name": "SG Ready Enabled"
       },
+      "port_priority_active": {
+        "name": "Port priority active"
+      },
       "backup_reserve_enabled": {
         "name": "Backup Reserve"
       },
       "backup_socket_enabled": {
         "name": "Backup Socket"
+      },
+      "schedule_1_running": {
+        "name": "Schedule 1 Running"
+      },
+      "schedule_2_running": {
+        "name": "Schedule 2 Running"
+      },
+      "schedule_3_running": {
+        "name": "Schedule 3 Running"
+      },
+      "schedule_4_running": {
+        "name": "Schedule 4 Running"
+      },
+      "schedule_5_running": {
+        "name": "Schedule 5 Running"
+      },
+      "schedule_6_running": {
+        "name": "Schedule 6 Running"
+      },
+      "schedule_7_running": {
+        "name": "Schedule 7 Running"
+      },
+      "schedule_8_running": {
+        "name": "Schedule 8 Running"
       },
       "grid_l1_connected": {
         "name": "Phase A Connected"
@@ -1602,6 +1811,9 @@
       },
       "bms_communication_error": {
         "name": "Battery Communication Error"
+      },
+      "ev_cable_lock_enabled": {
+        "name": "Wallbox Cable Lock"
       }
     },
     "switch": {
@@ -1629,6 +1841,30 @@
       "plug_switch": {
         "name": "Plug"
       },
+      "ac_out_switch": {
+        "name": "AC output"
+      },
+      "ac2_out_switch": {
+        "name": "AC output 2"
+      },
+      "dc_12v_out_switch": {
+        "name": "12V output"
+      },
+      "energy_backup_switch": {
+        "name": "Backup reserve"
+      },
+      "bypass_out_disable_switch": {
+        "name": "Bypass output disabled"
+      },
+      "port_priority_ac1_switch": {
+        "name": "AC 1 non-essential"
+      },
+      "port_priority_ac2_switch": {
+        "name": "AC 2 non-essential"
+      },
+      "port_priority_dc_switch": {
+        "name": "DC non-essential"
+      },
       "backup_socket_switch": {
         "name": "Backup Socket"
       },
@@ -1637,6 +1873,30 @@
       },
       "ac_outlet_2_switch": {
         "name": "AC Outlet 2"
+      },
+      "schedule_1_enabled": {
+        "name": "Schedule 1 Enabled"
+      },
+      "schedule_2_enabled": {
+        "name": "Schedule 2 Enabled"
+      },
+      "schedule_3_enabled": {
+        "name": "Schedule 3 Enabled"
+      },
+      "schedule_4_enabled": {
+        "name": "Schedule 4 Enabled"
+      },
+      "schedule_5_enabled": {
+        "name": "Schedule 5 Enabled"
+      },
+      "schedule_6_enabled": {
+        "name": "Schedule 6 Enabled"
+      },
+      "schedule_7_enabled": {
+        "name": "Schedule 7 Enabled"
+      },
+      "schedule_8_enabled": {
+        "name": "Schedule 8 Enabled"
       },
       "power": {
         "name": "Power"
@@ -1691,8 +1951,20 @@
       "max_watts": {
         "name": "Max Power Limit"
       },
+      "min_discharge_soc": {
+        "name": "Min Discharge SoC"
+      },
       "ac_charge_power_limit": {
         "name": "AC Charge Power"
+      },
+      "port_priority_ac1_soc": {
+        "name": "AC 1 cutoff level"
+      },
+      "port_priority_ac2_soc": {
+        "name": "AC 2 cutoff level"
+      },
+      "port_priority_dc_soc": {
+        "name": "DC cutoff level"
       },
       "max_charge_soc_pct": {
         "name": "Max Charge SoC"
@@ -1711,6 +1983,30 @@
       },
       "max_grid_input_power_w": {
         "name": "Max Grid Input Power"
+      },
+      "schedule_1_power_w": {
+        "name": "Schedule 1 Charge Power"
+      },
+      "schedule_2_power_w": {
+        "name": "Schedule 2 Charge Power"
+      },
+      "schedule_3_power_w": {
+        "name": "Schedule 3 Charge Power"
+      },
+      "schedule_4_power_w": {
+        "name": "Schedule 4 Charge Power"
+      },
+      "schedule_5_power_w": {
+        "name": "Schedule 5 Charge Power"
+      },
+      "schedule_6_power_w": {
+        "name": "Schedule 6 Charge Power"
+      },
+      "schedule_7_power_w": {
+        "name": "Schedule 7 Charge Power"
+      },
+      "schedule_8_power_w": {
+        "name": "Schedule 8 Charge Power"
       },
       "target_temp_c": {
         "name": "Target Temperature"

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -223,6 +223,18 @@ def _load_translations(path: Path) -> dict:
     return json.loads(path.read_text())
 
 
+def _flatten(tree: dict, prefix: str = "") -> dict[str, str]:
+    """Flatten a translation tree to `a.b.c -> text` for set arithmetic."""
+    flat: dict[str, str] = {}
+    for key, value in tree.items():
+        path = f"{prefix}{key}"
+        if isinstance(value, dict):
+            flat.update(_flatten(value, f"{path}."))
+        else:
+            flat[path] = value
+    return flat
+
+
 def _get_config_steps(translations: dict) -> dict:
     return translations.get("config", {}).get("step", {})
 
@@ -738,15 +750,33 @@ class TestDevicePickerExplanation:
         suite green. `strings.json` is the file a reviewer reads and
         `en.json` is the file Home Assistant renders, so any divergence
         between them is a mistake rather than a translation.
+
+        The whole document is compared, not only the flow steps. Until
+        2026-09-11 this test read the `config` and `options` steps alone,
+        and the `entity` section had drifted by 114 keys underneath it:
+        108 entity names and states that existed only in `en.json`, and
+        six states for the three connectivity sensors that `strings.json`
+        still spelled `not_detected` / `ok` while the definitions and the
+        rendered file said `disconnected` / `connected`.
         """
         strings = _load_translations(STRINGS_PATH)
         english = _load_translations(EN_PATH)
-        for section in ("config", "options"):
-            assert strings.get(section, {}).get("step") == english.get(section, {}).get(
-                "step"
-            ), (
-                f"strings.json and en.json disagree in the '{section}' steps; "
-                f"the rendered text is en.json, so the difference ships"
+        assert set(strings) == set(english), (
+            f"strings.json sections {sorted(strings)} and "
+            f"en.json sections {sorted(english)} differ"
+        )
+        for section in sorted(strings):
+            only_strings = (
+                _flatten(strings[section]).items() - _flatten(english[section]).items()
+            )
+            only_english = (
+                _flatten(english[section]).items() - _flatten(strings[section]).items()
+            )
+            assert not only_strings and not only_english, (
+                f"strings.json and en.json disagree in '{section}'; the rendered "
+                f"text is en.json, so the difference ships. "
+                f"Only in strings.json: {sorted(only_strings)[:5]}, "
+                f"only in en.json: {sorted(only_english)[:5]}"
             )
 
     def test_german_is_actually_translated(self) -> None:


### PR DESCRIPTION
## Summary

`strings.json` and `translations/en.json` are one language, and the test that held them together compared only the config and options steps. Underneath it the entity section had drifted by 114 keys: 108 entity names and enum states existed only in the rendered file, and the three connectivity sensors still read `Not Detected` / `OK` in `strings.json` where the definitions and the rendered file say `Disconnected` / `Connected`.

- `tests/test_translations.py`: the agreement test now flattens both documents and names the keys only one side carries.
- `strings.json`: brought level with `translations/en.json`. Home Assistant reads only the rendered file, so nothing changes at runtime.
- `CHANGELOG.md`: one entry under the open 1.22.0 block.

No generator for `en.json`. The two files are a copy plus a gate, which is cheaper than a build step and now cannot drift.

## Probes

- The widened test was red on the 114-key drift before the sync.
- One `en.json` entry given a different text under the same key: red. Restored: green.
- Full suite: 3752 passed, 1 skipped.
